### PR TITLE
perf(stream): drop the unread stdout copy in the CaptureOnly arm

### DIFF
--- a/src/core/stream.rs
+++ b/src/core/stream.rs
@@ -258,6 +258,7 @@ pub struct StreamResult {
     pub raw: String,
     pub raw_stdout: String,
     pub raw_stderr: String,
+    /// Empty under `FilterMode::CaptureOnly`, which runs no filter.
     pub filtered: String,
 }
 
@@ -510,7 +511,6 @@ pub fn run_streaming(
                             );
                         }
                     }
-                    filtered = raw_stdout.clone();
                 }
             }
         }
@@ -934,11 +934,25 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn test_run_streaming_capture_only_filtered_equals_raw() {
-        let mut cmd = Command::new("echo");
-        cmd.arg("check_equality");
+    fn test_run_streaming_capture_only_leaves_filtered_empty() {
+        // nosemgrep: interpreter-execution
+        let mut cmd = Command::new("sh");
+        // ~1 MiB of 80-char lines
+        cmd.args([
+            "-c",
+            "dd if=/dev/zero bs=1024 count=1024 2>/dev/null | tr '\\0' 'a' | fold -w 80",
+        ]);
         let result = run_streaming(&mut cmd, StdinMode::Null, FilterMode::CaptureOnly).unwrap();
-        assert_eq!(result.filtered.trim(), result.raw_stdout.trim());
+        assert!(
+            result.raw_stdout.len() > 1_000_000,
+            "stdout should still be captured, got {} bytes",
+            result.raw_stdout.len()
+        );
+        assert!(
+            result.filtered.is_empty(),
+            "CaptureOnly runs no filter, so stdout should not be copied into filtered; got {} bytes",
+            result.filtered.len()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `run_streaming`'s `CaptureOnly` arm cloned all of `raw_stdout` into `StreamResult.filtered`, up to the 10 MiB `RAW_CAP`, on every capture-mode command.
- Nothing reads `filtered` on that path: both `CaptureOnly` call sites (`run_captured_filter` in `runner.rs`, and `uv_cmd`) work off `raw`/`raw_stdout`/`raw_stderr`, and the three readers of `filtered` in `runner.rs`, `git.rs` and `search.rs` all sit on `FilterMode::Streaming` calls.
- The arm now leaves `filtered` empty.

## Test plan

- [ ] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [x] Manual testing: `rtk <command>` output inspected

`test_run_streaming_capture_only_filtered_equals_raw` asserted the copy existed. It is replaced by `test_run_streaming_capture_only_leaves_filtered_empty`, which spawns a child emitting ~1 MiB and checks that `raw_stdout` still carries it while `filtered` stays empty.

Fixes #3397
