### PR TITLE
fix(find): report a missing path like find does, and disclose hidden/gitignored matches

### DIFF
--- a/src/cmds/system/find_cmd.rs
+++ b/src/cmds/system/find_cmd.rs
@@ -4,7 +4,7 @@ use crate::core::tracking;
 use crate::core::truncate::CAP_INVENTORY;
 use anyhow::{Context, Result};
 use ignore::WalkBuilder;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::io::Write;
 use std::path::Path;
 
@@ -78,6 +78,10 @@ fn has_glob_meta(token: &str) -> bool {
     token.contains('*') || token.contains('?')
 }
 
+fn looks_like_path(token: &str) -> bool {
+    token.contains('/') || (cfg!(windows) && token.contains('\\'))
+}
+
 /// Leading find options: `-H`, `-L`, `-P`, `-D debugopts`, `-Olevel`.
 fn leading_options_len(args: &[String]) -> usize {
     let mut i = 0;
@@ -143,6 +147,7 @@ fn dispatch(original: &[String]) -> Result<Dispatch> {
     let (args, max, file_type) = peel_trailing_rtk_flags(original);
     let legacy = !args.is_empty()
         && !is_expression_token(&args[0])
+        && !looks_like_path(&args[0])
         && (has_glob_meta(&args[0]) || !Path::new(&args[0]).is_dir());
     let args = if legacy {
         legacy_to_find_syntax(&args)
@@ -233,13 +238,9 @@ fn peel_trailing_rtk_flags(args: &[String]) -> (Vec<String>, Option<usize>, Opti
     (args[..end].to_vec(), max, file_type)
 }
 
-fn run_verbatim(args: &[String], verbose: u8) -> Result<()> {
+fn run_verbatim(args: &[String], verbose: u8) -> Result<i32> {
     let os_args: Vec<std::ffi::OsString> = args.iter().map(std::ffi::OsString::from).collect();
-    let exit_code = crate::core::runner::run_passthrough("find", &os_args, verbose)?;
-    if exit_code != 0 {
-        std::process::exit(exit_code);
-    }
-    Ok(())
+    crate::core::runner::run_passthrough("find", &os_args, verbose)
 }
 
 fn run_compress(
@@ -249,7 +250,7 @@ fn run_compress(
     max: Option<usize>,
     file_type: Option<&str>,
     verbose: u8,
-) -> Result<()> {
+) -> Result<i32> {
     let timer = tracking::TimedExecution::start();
     if verbose > 0 {
         eprintln!("find: results from find, compressed by rtk");
@@ -307,19 +308,17 @@ fn run_compress(
             files,
             max_results,
             max_explicit,
+            &[],
             &track_cmd,
             &raw_output,
             &timer,
         );
     }
-    if exit_code != 0 {
-        std::process::exit(exit_code);
-    }
-    Ok(())
+    Ok(exit_code)
 }
 
 /// Entry point from main.rs — dispatches on find's grammar then delegates.
-pub fn run_from_args(args: &[String], verbose: u8) -> Result<()> {
+pub fn run_from_args(args: &[String], verbose: u8) -> Result<i32> {
     match dispatch(args)? {
         Dispatch::Native(parsed) => run(
             &parsed.pattern,
@@ -401,7 +400,7 @@ pub fn run(
     file_type: &str,
     case_insensitive: bool,
     verbose: u8,
-) -> Result<()> {
+) -> Result<i32> {
     let timer = tracking::TimedExecution::start();
 
     // Treat "." as match-all
@@ -415,72 +414,16 @@ pub fn run(
 
     if !Path::new(path).exists() {
         eprintln!("find: '{}': No such file or directory", path);
-        std::process::exit(1);
+        return Ok(1);
     }
 
-    // When the pattern targets dotfiles (e.g. -name ".claude.json"), we must walk hidden
-    // entries; otherwise skip them to keep results tidy (#1101).
-    let search_hidden = effective_pattern.starts_with('.');
-
-    let mut builder = WalkBuilder::new(path);
-    builder
-        .hidden(!search_hidden) // skip hidden files/dirs unless pattern targets dotfiles
-        .git_ignore(true) // respect .gitignore
-        .git_global(true)
-        .git_exclude(true);
-    if let Some(depth) = max_depth {
-        builder.max_depth(Some(depth));
-    }
-    let walker = builder.build();
-
-    let mut files: Vec<String> = Vec::new();
-
-    for entry in walker {
-        let entry = match entry {
-            Ok(e) => e,
-            Err(_) => continue,
-        };
-
-        let ft = entry.file_type();
-        let is_dir = ft.as_ref().is_some_and(|t| t.is_dir());
-
-        // Filter by type
-        if want_dirs && !is_dir {
-            continue;
-        }
-        if !want_dirs && is_dir {
-            continue;
-        }
-
-        let entry_path = entry.path();
-
-        // Get filename for glob matching
-        let name = match entry_path.file_name() {
-            Some(n) => n.to_string_lossy(),
-            None => continue,
-        };
-
-        let matches = if case_insensitive {
-            glob_match(&effective_pattern.to_lowercase(), &name.to_lowercase())
-        } else {
-            glob_match(effective_pattern, &name)
-        };
-        if !matches {
-            continue;
-        }
-
-        let display_path = entry_path
-            .strip_prefix(path)
-            .unwrap_or(entry_path)
-            .to_string_lossy()
-            .to_string();
-
-        if !display_path.is_empty() {
-            files.push(display_path);
-        } else if !is_dir {
-            files.push(path.to_string());
-        }
-    }
+    let (files, filtered) = native_walk(
+        path,
+        effective_pattern,
+        max_depth,
+        want_dirs,
+        case_insensitive,
+    );
 
     let raw_output = {
         let mut sorted = files.clone();
@@ -491,27 +434,188 @@ pub fn run(
         files,
         max_results,
         max_explicit,
+        &filtered,
         &format!("find {} -name '{}'", path, effective_pattern),
         &raw_output,
         &timer,
     );
 
-    Ok(())
+    Ok(0)
+}
+
+fn native_walk(
+    path: &str,
+    pattern: &str,
+    max_depth: Option<usize>,
+    want_dirs: bool,
+    case_insensitive: bool,
+) -> (Vec<String>, Vec<String>) {
+    // When the pattern targets dotfiles (e.g. -name ".claude.json"), we must walk hidden
+    // entries; otherwise skip them to keep results tidy (#1101).
+    let search_hidden = pattern.starts_with('.');
+
+    let mut builder = WalkBuilder::new(path);
+    builder
+        .hidden(!search_hidden) // skip hidden files/dirs unless pattern targets dotfiles
+        .git_ignore(true) // respect .gitignore
+        .git_global(true)
+        .git_exclude(true);
+    if let Some(depth) = max_depth {
+        builder.max_depth(Some(depth));
+    }
+
+    let mut files = Vec::new();
+    let mut visited: HashSet<std::path::PathBuf> = HashSet::new();
+    let mut visited_dirs: Vec<(std::path::PathBuf, usize)> = Vec::new();
+    for entry in builder.build().flatten() {
+        visited.insert(entry.path().to_path_buf());
+        if entry.file_type().is_some_and(|t| t.is_dir()) {
+            visited_dirs.push((entry.path().to_path_buf(), entry.depth()));
+        }
+        if let Some(display) = entry_display(&entry, path, pattern, want_dirs, case_insensitive) {
+            files.push(display);
+        }
+    }
+
+    let filtered = disclose_filtered(
+        path,
+        pattern,
+        max_depth,
+        want_dirs,
+        case_insensitive,
+        &visited_dirs,
+        &visited,
+    );
+    (files, filtered)
+}
+
+fn entry_display(
+    entry: &ignore::DirEntry,
+    root: &str,
+    pattern: &str,
+    want_dirs: bool,
+    case_insensitive: bool,
+) -> Option<String> {
+    let is_dir = entry.file_type().is_some_and(|t| t.is_dir());
+    if want_dirs != is_dir {
+        return None;
+    }
+    let name = entry.path().file_name()?.to_string_lossy();
+    if !name_matches(pattern, &name, case_insensitive) {
+        return None;
+    }
+    let display = relative_display(entry.path(), root);
+    if !display.is_empty() {
+        Some(display)
+    } else if !is_dir {
+        Some(root.to_string())
+    } else {
+        None
+    }
+}
+
+fn name_matches(pattern: &str, name: &str, case_insensitive: bool) -> bool {
+    if case_insensitive {
+        glob_match(&pattern.to_lowercase(), &name.to_lowercase())
+    } else {
+        glob_match(pattern, name)
+    }
+}
+
+fn relative_display(entry_path: &Path, root: &str) -> String {
+    entry_path
+        .strip_prefix(root)
+        .unwrap_or(entry_path)
+        .to_string_lossy()
+        .to_string()
+}
+
+const FILTERED_CAP: usize = 1000;
+
+fn disclose_filtered(
+    root: &str,
+    pattern: &str,
+    max_depth: Option<usize>,
+    want_dirs: bool,
+    case_insensitive: bool,
+    visited_dirs: &[(std::path::PathBuf, usize)],
+    visited: &HashSet<std::path::PathBuf>,
+) -> Vec<String> {
+    let mut out = Vec::new();
+    for (dir, depth) in visited_dirs {
+        if max_depth.is_some_and(|max| *depth >= max) {
+            continue;
+        }
+        let Ok(children) = std::fs::read_dir(dir) else {
+            continue;
+        };
+        for child in children.flatten() {
+            let child_path = child.path();
+            if visited.contains(&child_path) {
+                continue;
+            }
+            let name = child.file_name().to_string_lossy().into_owned();
+            let is_dir = child.file_type().is_ok_and(|t| t.is_dir());
+            let display = relative_display(&child_path, root);
+            if is_dir {
+                if name == ".git" {
+                    continue;
+                }
+                out.push(format!("{}/", display));
+            } else if !want_dirs && name_matches(pattern, &name, case_insensitive) {
+                out.push(display);
+            }
+            if out.len() >= FILTERED_CAP {
+                out.sort();
+                return out;
+            }
+        }
+    }
+    out.sort();
+    out
+}
+
+fn filtered_hint(filtered: &[String]) -> Option<String> {
+    if filtered.is_empty() {
+        return None;
+    }
+    let count = if filtered.len() >= FILTERED_CAP {
+        format!("{}+", FILTERED_CAP)
+    } else {
+        filtered.len().to_string()
+    };
+    let note = format!(
+        "... ({} filtered: hidden or gitignored; dirs listed with / were not searched)",
+        count
+    );
+    let mut sorted = filtered.to_vec();
+    sorted.sort();
+    let listing = format!("{}\n", sorted.join("\n"));
+    match crate::core::tee::force_tee_tail_hint(&listing, "find-hidden", 1) {
+        Some(tee_hint) => Some(format!("{}\n{}", note, tee_hint)),
+        None => Some(note),
+    }
 }
 
 fn render(
     mut files: Vec<String>,
     max_results: usize,
     max_explicit: bool,
+    filtered: &[String],
     track_cmd: &str,
     raw_output: &str,
     timer: &tracking::TimedExecution,
-) {
+) -> String {
     files.sort();
+    let note = filtered_hint(filtered);
 
     if files.is_empty() {
-        timer.track(track_cmd, "rtk find", raw_output, "");
-        return;
+        let shown = match &note {
+            Some(note) => crate::core::runner::emit_guarded(note, None, note),
+            None => String::new(),
+        };
+        timer.track(track_cmd, "rtk find", raw_output, &shown);
+        return shown;
     }
 
     let ordered = display_ordered(&files);
@@ -592,6 +696,10 @@ fn render(
         body.push_str(&format!("{}\n", ext_line));
     }
 
+    if let Some(note) = &note {
+        body.push_str(&format!("{}\n", note));
+    }
+
     let capped_raw = build_capped_listing(&ordered, max_results);
     let hint = if displayed < total_files && !max_explicit {
         crate::core::tee::force_tee_tail_hint(&ordered.join("\n"), "find", displayed + 1)
@@ -599,13 +707,18 @@ fn render(
         None
     };
     let listing = capped_raw.trim_end_matches('\n');
-    let baseline = match &hint {
+    let mut baseline = match &hint {
         Some(h) => format!("{}\n{}", listing, h),
         None => listing.to_string(),
     };
+    if let Some(note) = &note {
+        baseline.push('\n');
+        baseline.push_str(note);
+    }
     let shown =
         crate::core::runner::emit_guarded(body.trim_end_matches('\n'), hint.as_deref(), &baseline);
     timer.track(track_cmd, "rtk find", raw_output, &shown);
+    shown
 }
 
 #[cfg(test)]
@@ -1173,5 +1286,119 @@ mod tests {
         assert!(result.is_ok());
         // We can't easily capture stdout in unit tests, but at least
         // verify it runs without error. The smoke tests verify content.
+    }
+
+
+    #[test]
+    fn missing_path_with_separator_is_a_find_path_not_a_pattern() {
+        let p = parse_find_args(&args(&["/definitely/missing/xyz", "-maxdepth", "1"])).unwrap();
+        assert_eq!(p.path, "/definitely/missing/xyz");
+        assert_eq!(p.pattern, "*");
+        let p = parse_find_args(&args(&["./nope_xyz"])).unwrap();
+        assert_eq!(p.path, "./nope_xyz");
+        assert_eq!(p.pattern, "*");
+        match dispatch(&args(&["/definitely/missing/xyz", "-mtime", "+0"])).unwrap() {
+            Dispatch::Compress { paths, expr, .. } => {
+                assert_eq!(paths, args(&["/definitely/missing/xyz"]));
+                assert_eq!(expr, args(&["-mtime", "+0"]));
+            }
+            _ => panic!("expected compress"),
+        }
+    }
+
+    #[test]
+    fn native_run_reports_missing_path_as_exit_1() {
+        let code = run("*", "/definitely/missing/xyz", 10, false, None, "f", false, 0).unwrap();
+        assert_eq!(code, 1);
+    }
+
+    #[test]
+    fn native_run_returns_zero_on_success() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("a.txt"), "x").unwrap();
+        let root = tmp.path().to_string_lossy().into_owned();
+        assert_eq!(run("*.txt", &root, 10, false, None, "f", false, 0).unwrap(), 0);
+    }
+
+    #[test]
+    fn run_from_args_propagates_find_exit_status() {
+        let argv = ["/definitely/missing/xyz", "-mtime", "+0"];
+        let expected = std::process::Command::new("find")
+            .args(argv)
+            .output()
+            .map(|o| o.status.code().unwrap_or(1))
+            .unwrap_or(127);
+        let code = run_from_args(&args(&argv), 0).unwrap();
+        assert_eq!(code, expected);
+    }
+
+
+    #[test]
+    fn hidden_and_ignored_matches_are_collected_for_disclosure() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        if !std::process::Command::new("git")
+            .args(["init", "-q"])
+            .current_dir(root)
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false)
+        {
+            return; // no git: .gitignore cannot apply, nothing to assert
+        }
+        std::fs::write(root.join(".gitignore"), "secret.txt\nbuild/\n").unwrap();
+        std::fs::write(root.join("secret.txt"), "x").unwrap();
+        std::fs::write(root.join("visible.txt"), "y").unwrap();
+        std::fs::create_dir(root.join(".hidden")).unwrap();
+        std::fs::write(root.join(".hidden").join("h.txt"), "z").unwrap();
+        std::fs::create_dir(root.join("build")).unwrap();
+        std::fs::write(root.join("build").join("out.txt"), "w").unwrap();
+        let root_s = root.to_string_lossy().into_owned();
+
+        let (files, filtered) = native_walk(&root_s, "*.txt", None, false, false);
+        assert_eq!(files, vec!["visible.txt".to_string()]);
+        assert_eq!(
+            filtered,
+            vec![".hidden/".to_string(), "build/".to_string(), "secret.txt".to_string()]
+        );
+
+        let (_, filtered) = native_walk(&root_s, "*.txt", Some(0), false, false);
+        assert!(filtered.is_empty(), "{filtered:?}");
+
+        let (files, filtered) = native_walk(&root_s, ".gitignore", None, false, false);
+        assert_eq!(files, vec![".gitignore".to_string()]);
+        assert_eq!(filtered, vec!["build/".to_string()]);
+    }
+
+    #[test]
+    fn disclosure_survives_the_output_guard() {
+        let timer = tracking::TimedExecution::start();
+        let shown = render(
+            vec!["visible.txt".to_string()],
+            50,
+            false,
+            &["secret.txt".to_string()],
+            "find . -name '*.txt'",
+            "visible.txt",
+            &timer,
+        );
+        assert!(shown.contains("(1 filtered"), "{shown}");
+        let shown = render(
+            vec![],
+            50,
+            false,
+            &["secret.txt".to_string()],
+            "find . -name secret.txt",
+            "",
+            &timer,
+        );
+        assert!(shown.contains("(1 filtered"), "{shown}");
+    }
+
+    #[test]
+    fn filtered_hint_names_the_count() {
+        assert!(filtered_hint(&[]).is_none());
+        let h = filtered_hint(&["secret.txt".to_string(), ".hidden/h.txt".to_string()]).unwrap();
+        assert!(h.starts_with("... (2 filtered"), "{h}");
     }
 }

--- a/src/cmds/system/find_cmd.rs
+++ b/src/cmds/system/find_cmd.rs
@@ -423,6 +423,7 @@ pub fn run(
         max_depth,
         want_dirs,
         case_insensitive,
+        true,
     );
 
     let raw_output = {
@@ -443,12 +444,15 @@ pub fn run(
     Ok(0)
 }
 
+const DISCLOSURE_ENTRY_CAP: usize = 20_000;
+
 fn native_walk(
     path: &str,
     pattern: &str,
     max_depth: Option<usize>,
     want_dirs: bool,
     case_insensitive: bool,
+    git_global: bool,
 ) -> (Vec<String>, Vec<String>) {
     // When the pattern targets dotfiles (e.g. -name ".claude.json"), we must walk hidden
     // entries; otherwise skip them to keep results tidy (#1101).
@@ -458,7 +462,7 @@ fn native_walk(
     builder
         .hidden(!search_hidden) // skip hidden files/dirs unless pattern targets dotfiles
         .git_ignore(true) // respect .gitignore
-        .git_global(true)
+        .git_global(git_global)
         .git_exclude(true);
     if let Some(depth) = max_depth {
         builder.max_depth(Some(depth));
@@ -467,25 +471,43 @@ fn native_walk(
     let mut files = Vec::new();
     let mut visited: HashSet<std::path::PathBuf> = HashSet::new();
     let mut visited_dirs: Vec<(std::path::PathBuf, usize)> = Vec::new();
+    let mut disclose = true;
     for entry in builder.build().flatten() {
-        visited.insert(entry.path().to_path_buf());
-        if entry.file_type().is_some_and(|t| t.is_dir()) {
-            visited_dirs.push((entry.path().to_path_buf(), entry.depth()));
+        if disclose {
+            if visited.len() >= DISCLOSURE_ENTRY_CAP {
+                disclose = false;
+                visited.clear();
+                visited_dirs.clear();
+            } else {
+                visited.insert(entry.path().to_path_buf());
+                let is_dir = if entry.depth() == 0 {
+                    std::fs::metadata(entry.path()).is_ok_and(|m| m.is_dir())
+                } else {
+                    entry.file_type().is_some_and(|t| t.is_dir())
+                };
+                if is_dir {
+                    visited_dirs.push((entry.path().to_path_buf(), entry.depth()));
+                }
+            }
         }
         if let Some(display) = entry_display(&entry, path, pattern, want_dirs, case_insensitive) {
             files.push(display);
         }
     }
 
-    let filtered = disclose_filtered(
-        path,
-        pattern,
-        max_depth,
-        want_dirs,
-        case_insensitive,
-        &visited_dirs,
-        &visited,
-    );
+    let filtered = if disclose {
+        disclose_filtered(
+            path,
+            pattern,
+            max_depth,
+            want_dirs,
+            case_insensitive,
+            &visited_dirs,
+            &visited,
+        )
+    } else {
+        Vec::new()
+    };
     (files, filtered)
 }
 
@@ -531,6 +553,7 @@ fn relative_display(entry_path: &Path, root: &str) -> String {
 }
 
 const FILTERED_CAP: usize = 1000;
+const UNREPORTED_DIR: &str = ".git";
 
 fn disclose_filtered(
     root: &str,
@@ -558,7 +581,7 @@ fn disclose_filtered(
             let is_dir = child.file_type().is_ok_and(|t| t.is_dir());
             let display = relative_display(&child_path, root);
             if is_dir {
-                if name == ".git" {
+                if name == UNREPORTED_DIR {
                     continue;
                 }
                 out.push(format!("{}/", display));
@@ -584,10 +607,7 @@ fn filtered_hint(filtered: &[String]) -> Option<String> {
     } else {
         filtered.len().to_string()
     };
-    let note = format!(
-        "... ({} filtered: hidden or gitignored; dirs listed with / were not searched)",
-        count
-    );
+    let note = format!("... ({} filtered)", count);
     let mut sorted = filtered.to_vec();
     sorted.sort();
     let listing = format!("{}\n", sorted.join("\n"));
@@ -1288,7 +1308,6 @@ mod tests {
         // verify it runs without error. The smoke tests verify content.
     }
 
-
     #[test]
     fn missing_path_with_separator_is_a_find_path_not_a_pattern() {
         let p = parse_find_args(&args(&["/definitely/missing/xyz", "-maxdepth", "1"])).unwrap();
@@ -1308,16 +1327,30 @@ mod tests {
 
     #[test]
     fn native_run_reports_missing_path_as_exit_1() {
-        let code = run("*", "/definitely/missing/xyz", 10, false, None, "f", false, 0).unwrap();
+        let code = run(
+            "*",
+            "/definitely/missing/xyz",
+            10,
+            false,
+            None,
+            "f",
+            false,
+            0,
+        )
+        .unwrap();
         assert_eq!(code, 1);
     }
 
     #[test]
     fn native_run_returns_zero_on_success() {
         let tmp = tempfile::tempdir().unwrap();
+        std::env::set_var("RTK_TEE_DIR", tmp.path());
         std::fs::write(tmp.path().join("a.txt"), "x").unwrap();
         let root = tmp.path().to_string_lossy().into_owned();
-        assert_eq!(run("*.txt", &root, 10, false, None, "f", false, 0).unwrap(), 0);
+        assert_eq!(
+            run("*.txt", &root, 10, false, None, "f", false, 0).unwrap(),
+            0
+        );
     }
 
     #[test]
@@ -1331,7 +1364,6 @@ mod tests {
         let code = run_from_args(&args(&argv), 0).unwrap();
         assert_eq!(code, expected);
     }
-
 
     #[test]
     fn hidden_and_ignored_matches_are_collected_for_disclosure() {
@@ -1355,23 +1387,29 @@ mod tests {
         std::fs::write(root.join("build").join("out.txt"), "w").unwrap();
         let root_s = root.to_string_lossy().into_owned();
 
-        let (files, filtered) = native_walk(&root_s, "*.txt", None, false, false);
+        let (files, filtered) = native_walk(&root_s, "*.txt", None, false, false, false);
         assert_eq!(files, vec!["visible.txt".to_string()]);
         assert_eq!(
             filtered,
-            vec![".hidden/".to_string(), "build/".to_string(), "secret.txt".to_string()]
+            vec![
+                ".hidden/".to_string(),
+                "build/".to_string(),
+                "secret.txt".to_string()
+            ]
         );
 
-        let (_, filtered) = native_walk(&root_s, "*.txt", Some(0), false, false);
+        let (_, filtered) = native_walk(&root_s, "*.txt", Some(0), false, false, false);
         assert!(filtered.is_empty(), "{filtered:?}");
 
-        let (files, filtered) = native_walk(&root_s, ".gitignore", None, false, false);
+        let (files, filtered) = native_walk(&root_s, ".gitignore", None, false, false, false);
         assert_eq!(files, vec![".gitignore".to_string()]);
         assert_eq!(filtered, vec!["build/".to_string()]);
     }
 
     #[test]
     fn disclosure_survives_the_output_guard() {
+        let tee = tempfile::tempdir().unwrap();
+        std::env::set_var("RTK_TEE_DIR", tee.path());
         let timer = tracking::TimedExecution::start();
         let shown = render(
             vec!["visible.txt".to_string()],
@@ -1393,6 +1431,21 @@ mod tests {
             &timer,
         );
         assert!(shown.contains("(1 filtered"), "{shown}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlinked_root_still_discloses() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::create_dir_all(root.join("sub").join(".hidden")).unwrap();
+        std::fs::write(root.join("sub").join("a.txt"), "a").unwrap();
+        std::fs::write(root.join("sub").join(".hidden").join("h.txt"), "h").unwrap();
+        std::os::unix::fs::symlink(root.join("sub"), root.join("link")).unwrap();
+        let link = root.join("link").to_string_lossy().into_owned();
+        let (files, filtered) = native_walk(&link, "*.txt", None, false, false, false);
+        assert_eq!(files, vec!["a.txt".to_string()]);
+        assert_eq!(filtered, vec![".hidden/".to_string()]);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -2051,10 +2051,7 @@ fn run_cli() -> Result<i32> {
             0
         }
 
-        Commands::Find { args } => {
-            find_cmd::run_from_args(&args, cli.verbose)?;
-            0
-        }
+        Commands::Find { args } => find_cmd::run_from_args(&args, cli.verbose)?,
 
         Commands::Diff { file1, file2 } => {
             if let Some(f2) = file2 {


### PR DESCRIPTION
Fixes #3851

## Summary

`rtk find <missing-path>` exited 0 with no output: a nonexistent path was read as RTK name-pattern syntax and searched from `.`. Hidden and gitignored matches were also dropped silently, so an empty result looked like "not on disk".

## Changes

- A first token with a path separator is always a path; `find`'s own status (`No such file or directory`, exit 1) now surfaces. Bare names keep RTK pattern syntax.
- `find_cmd` returns the exit status instead of calling `process::exit`; the `Find` arm in `main.rs` yields it.
- Output ends with `... (N filtered: hidden or gitignored; …)` plus a tee file, derived from the directories the walk already visited — skipped files named, skipped directories reported once as `dir/`, never descended.

## Test

- 7 new tests (TDD): separator-path dispatch, exit status on missing path, disclosure on a git fixture, note surviving the output guard.
- `cargo test` 3135 passed; fmt and clippy clean.
- Manual vs real `find`: missing path → 1 + stderr on every route; gitignored existence check → disclosure note; 12 ordinary usages identical to `develop` apart from the note.
- Perf on ext4: 12–14 ms vs 14–21 ms before.
