### PR TITLE
feat(ast-grep): add ast-grep filter (rtk ast-grep)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ RTK intercepts shell commands and compresses their output before your agent read
 | `ls` / `tree` | Tree format with file counts instead of one line per entry |
 | `cat` / `read` | Smart file reading: signatures and structure over full bodies |
 | `grep` / `rg` | Truncates long lines, groups matches by file |
+| `ast-grep` | Groups structural matches by file, caps overflow |
 | `git status` | Compact stat format, grouped by state |
 | `git diff` | Reduced context, headers stripped |
 | `git log` | Hash, author and subject only |

--- a/docs/guide/resources/what-rtk-covers.md
+++ b/docs/guide/resources/what-rtk-covers.md
@@ -116,6 +116,7 @@ Every percentage below measures **bash output bytes removed** — the only thing
 | `ls` | 80% | Tree format with file counts |
 | `find` | 75% | Tree format |
 | `grep` | 70% | Truncated lines, grouped by file |
+| `ast-grep` | 85% | Grouped by file, capped overflow; `--json` passes through |
 | `diff` | 65% | Context reduced |
 | `wc` | 60% | Compact counts |
 | `cat` / `head` / `tail <file>` | 60-80% | Smart file reading via `rtk read` |

--- a/docs/usage/FEATURES.md
+++ b/docs/usage/FEATURES.md
@@ -238,6 +238,21 @@ src/ls.rs:25:fn run_tree(...)                src/ls.rs
 
 ---
 
+### `rtk ast-grep` -- Recherche structurelle (AST)
+
+**Objectif :** Remplace `ast-grep` avec une sortie groupee par fichier, plafonnee.
+
+**Syntaxe :**
+```bash
+rtk ast-grep run -p '<pattern>' [chemin] [options]
+```
+
+Regroupe les correspondances par fichier, plafonnees a 5 par fichier et 50 au total ; le surplus est remplace par une note de comptage ("N more matches in X" / "N more file(s) not shown"). Sur une recherche reelle dans ce depot, ~85% de reduction.
+
+`--json` n'est pas filtre -- une demande explicite de sortie structuree passe telle quelle, sans compression.
+
+---
+
 ### `rtk diff` -- Diff condense
 
 **Objectif :** Diff ultra-condense entre deux fichiers (uniquement les lignes modifiees).
@@ -1268,6 +1283,7 @@ rtk verify
 | `cargo test/build/clippy/check` | `rtk cargo ...` |
 | `cat/head/tail <fichier>` | `rtk read <fichier>` |
 | `rg/grep <pattern>` | `rtk grep <pattern>` |
+| `ast-grep run -p <pattern>` | `rtk ast-grep run -p <pattern>` |
 | `ls` | `rtk ls` |
 | `tree` | `rtk tree` |
 | `wc` | `rtk wc` |
@@ -1422,7 +1438,7 @@ Octets de sortie bash supprimes (voir [A propos de la reduction de sortie bash](
 
 | Categorie | Commandes | Reduction sortie bash |
 |-----------|-----------|-------------------|
-| **Fichiers** | ls, tree, read, find, grep, diff | 60-80% |
+| **Fichiers** | ls, tree, read, find, grep, ast-grep, diff | 60-85% |
 | **Git** | status, log, diff, show, add, commit, push, pull | 75-92% |
 | **GitHub** | pr, issue, run, api | 79-87% |
 | **Tests** | cargo test, vitest, playwright, pytest, go test | 90-99% |

--- a/src/cmds/system/ast_grep_cmd.rs
+++ b/src/cmds/system/ast_grep_cmd.rs
@@ -1,0 +1,163 @@
+//! Filters `ast-grep run` plain-mode output by grouping matches by file and
+//! capping how many are shown. `--json` is left near-passthrough (explicit
+//! structured-output request — see Correctness vs Token Savings).
+
+use crate::core::stream::exec_capture;
+use crate::core::tracking;
+use crate::core::utils::resolved_command;
+use anyhow::{Context, Result};
+use std::collections::HashMap;
+use std::sync::LazyLock;
+
+/// Matches the `path:line:` prefix ast-grep emits for every match/context line.
+static MATCH_LINE_RE: LazyLock<regex::Regex> =
+    LazyLock::new(|| regex::Regex::new(r"^(?P<file>[^:]+):(?P<line>\d+):(?P<content>.*)$").unwrap());
+
+const DEFAULT_MAX_TOTAL: usize = 50;
+const DEFAULT_MAX_PER_FILE: usize = 5;
+
+/// Groups raw `ast-grep run` plain output by file, keeping at most
+/// `max_per_file` lines per file and `max_total` lines overall. Files beyond
+/// the cap collapse to a one-line count so nothing silently disappears.
+fn filter_ast_grep(raw: &str, max_per_file: usize, max_total: usize) -> String {
+    let mut by_file: HashMap<&str, Vec<(usize, &str)>> = HashMap::new();
+    let mut order: Vec<&str> = Vec::new();
+
+    for line in raw.lines() {
+        let Some(caps) = MATCH_LINE_RE.captures(line) else {
+            continue;
+        };
+        let file = caps.name("file").unwrap().as_str();
+        let line_num: usize = caps.name("line").unwrap().as_str().parse().unwrap_or(0);
+        let content = caps.name("content").unwrap().as_str();
+        if !by_file.contains_key(file) {
+            order.push(file);
+        }
+        by_file.entry(file).or_default().push((line_num, content));
+    }
+
+    if order.is_empty() {
+        return raw.to_string();
+    }
+
+    let mut out = String::new();
+    let mut shown_total = 0;
+    let mut skipped_files = 0;
+
+    for file in &order {
+        let entries = &by_file[file];
+        if shown_total >= max_total {
+            skipped_files += 1;
+            continue;
+        }
+        for (line_num, content) in entries.iter().take(max_per_file) {
+            if shown_total >= max_total {
+                break;
+            }
+            out.push_str(file);
+            out.push(':');
+            out.push_str(&line_num.to_string());
+            out.push(':');
+            out.push_str(content);
+            out.push('\n');
+            shown_total += 1;
+        }
+        if entries.len() > max_per_file {
+            out.push_str(&format!(
+                "  … {} more matches in {}\n",
+                entries.len() - max_per_file,
+                file
+            ));
+        }
+    }
+
+    if skipped_files > 0 {
+        out.push_str(&format!(
+            "… {} more file(s) with matches not shown (use --json or narrow the pattern)\n",
+            skipped_files
+        ));
+    }
+
+    out
+}
+
+pub fn run(args: &[String]) -> Result<i32> {
+    let timer = tracking::TimedExecution::start();
+    let real_cmd = format!("ast-grep {}", args.join(" "));
+
+    let is_json = args.iter().any(|a| a == "--json" || a.starts_with("--json="));
+
+    let mut cmd = resolved_command("ast-grep");
+    cmd.args(args);
+    let result = exec_capture(&mut cmd).context("Failed to execute ast-grep")?;
+
+    let filtered = if is_json {
+        result.stdout.clone()
+    } else {
+        filter_ast_grep(&result.stdout, DEFAULT_MAX_PER_FILE, DEFAULT_MAX_TOTAL)
+    };
+
+    let shown = crate::core::guard::never_worse(&result.stdout, &filtered);
+    timer.track(&real_cmd, "rtk ast-grep", &result.stdout, shown);
+    print!("{}", shown);
+
+    if !result.stderr.is_empty() {
+        eprint!("{}", result.stderr);
+    }
+
+    Ok(result.exit_code)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn count_tokens(s: &str) -> usize {
+        s.split_whitespace().count()
+    }
+
+    #[test]
+    fn test_groups_and_caps_by_file() {
+        let input = "\
+src/a.rs:1:fn foo() {}
+src/a.rs:2:fn bar() {}
+src/a.rs:3:fn baz() {}
+src/b.rs:10:fn qux() {}
+";
+        let out = filter_ast_grep(input, 2, 50);
+        assert!(out.contains("src/a.rs:1:"));
+        assert!(out.contains("src/a.rs:2:"));
+        assert!(!out.contains("src/a.rs:3:"));
+        assert!(out.contains("1 more matches in src/a.rs"));
+        assert!(out.contains("src/b.rs:10:"));
+    }
+
+    #[test]
+    fn test_empty_input() {
+        assert_eq!(filter_ast_grep("", 5, 50), "");
+    }
+
+    #[test]
+    fn test_unparseable_input_falls_back_unchanged() {
+        let input = "no colons here\njust plain text\n";
+        assert_eq!(filter_ast_grep(input, 5, 50), input);
+    }
+
+    #[test]
+    fn test_real_fixture_savings() {
+        let input = include_str!("../../../tests/fixtures/ast_grep_lazylock_raw.txt");
+        let output = filter_ast_grep(input, DEFAULT_MAX_PER_FILE, DEFAULT_MAX_TOTAL);
+
+        let input_tokens = count_tokens(input);
+        let output_tokens = count_tokens(&output);
+        let savings = 100.0 - (output_tokens as f64 / input_tokens as f64 * 100.0);
+
+        assert!(
+            savings >= 60.0,
+            "ast-grep filter: expected >=60% savings, got {:.1}% ({} -> {} tokens)",
+            savings,
+            input_tokens,
+            output_tokens
+        );
+    }
+}

--- a/src/cmds/system/ast_grep_cmd.rs
+++ b/src/cmds/system/ast_grep_cmd.rs
@@ -91,13 +91,15 @@ pub fn run(args: &[String]) -> Result<i32> {
     cmd.args(args);
     let result = exec_capture(&mut cmd).context("Failed to execute ast-grep")?;
 
-    let filtered = if is_json {
-        result.stdout.clone()
+    let filtered_owned;
+    let filtered: &str = if is_json {
+        &result.stdout
     } else {
-        filter_ast_grep(&result.stdout, DEFAULT_MAX_PER_FILE, DEFAULT_MAX_TOTAL)
+        filtered_owned = filter_ast_grep(&result.stdout, DEFAULT_MAX_PER_FILE, DEFAULT_MAX_TOTAL);
+        &filtered_owned
     };
 
-    let shown = crate::core::guard::never_worse(&result.stdout, &filtered);
+    let shown = crate::core::guard::never_worse(&result.stdout, filtered);
     timer.track(&real_cmd, "rtk ast-grep", &result.stdout, shown);
     print!("{}", shown);
 

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -128,6 +128,18 @@ pub const RULES: &[RtkRule] = &[
         ..RtkRule::DEFAULT
     },
     RtkRule {
+        pattern: r"^ast-grep\s+",
+        rtk_cmd: "rtk ast-grep",
+        // Unlike grep/rg, `rtk ast-grep`'s run() execs with stdin null (no
+        // piped-stdin support yet), so it must not be rewritten as a
+        // pipeline's final stage — that would silently drop the pipe input.
+        pipeline_final_safe: false,
+        rewrite_prefixes: &["ast-grep"],
+        category: "Files",
+        savings_pct: 60.0,
+        ..RtkRule::DEFAULT
+    },
+    RtkRule {
         pattern: r"^ls(\s|$)",
         rtk_cmd: "rtk ls",
         rewrite_prefixes: &["ls"],

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,8 +24,8 @@ use cmds::ruby::{rake_cmd, rspec_cmd, rubocop_cmd};
 use cmds::rust::{cargo_cmd, runner};
 use cmds::scala::sbt_cmd;
 use cmds::system::{
-    ctest_cmd, deps, env_cmd, find_cmd, format_cmd, json_cmd, local_llm, log_cmd, ls, pipe_cmd,
-    read, search, summary, tree, wc_cmd,
+    ast_grep_cmd, ctest_cmd, deps, env_cmd, find_cmd, format_cmd, json_cmd, local_llm, log_cmd, ls,
+    pipe_cmd, read, search, summary, tree, wc_cmd,
 };
 
 use anyhow::{Context, Result};
@@ -349,6 +349,13 @@ enum Commands {
     /// Compact ripgrep - runs rg natively, same output filter as grep
     Rg {
         /// Pattern, path, and any rg flags (e.g. -v, -i, -t rust, --glob)
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        extra_args: Vec<String>,
+    },
+
+    /// Compact ast-grep - runs ast-grep natively, groups matches by file
+    AstGrep {
+        /// ast-grep subcommand, pattern, path, and any flags (e.g. run -p '$$$', --json)
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         extra_args: Vec<String>,
     },
@@ -2164,6 +2171,7 @@ fn run_cli() -> Result<i32> {
             &extra_args,
             cli.verbose,
         )?,
+        Commands::AstGrep { extra_args } => ast_grep_cmd::run(&extra_args)?,
         Commands::Rg { extra_args } => {
             search::run(search::Engine::Rg, 80, 200, false, &extra_args, cli.verbose)?
         }
@@ -2983,6 +2991,7 @@ fn is_operational_command(cmd: &Commands) -> bool {
             | Commands::Summary { .. }
             | Commands::Grep { .. }
             | Commands::Rg { .. }
+            | Commands::AstGrep { .. }
             | Commands::Wget { .. }
             | Commands::Vitest { .. }
             | Commands::Ctest { .. }
@@ -3368,6 +3377,7 @@ mod tests {
             "tree",
             "read",
             "rg",
+            "ast-grep",
             "git",
             "gh",
             "glab",

--- a/tests/fixtures/ast_grep_lazylock_raw.json
+++ b/tests/fixtures/ast_grep_lazylock_raw.json
@@ -1,0 +1,3674 @@
+[
+{
+  "text": "LazyLock::new(|| {\n    Regex::new(\n        r\"(?i)(unexpected argument|unknown (option|flag)|unrecognized (option|flag)|invalid (option|flag))\"\n    ).unwrap()\n})",
+  "range": {
+    "byteOffset": {
+      "start": 1272,
+      "end": 1432
+    },
+    "start": {
+      "line": 50,
+      "column": 42
+    },
+    "end": {
+      "line": 54,
+      "column": 2
+    }
+  },
+  "file": "src/learn/detector.rs",
+  "lines": "static UNKNOWN_FLAG_RE: LazyLock<Regex> = LazyLock::new(|| {\n    Regex::new(\n        r\"(?i)(unexpected argument|unknown (option|flag)|unrecognized (option|flag)|invalid (option|flag))\"\n    ).unwrap()\n});",
+  "charCount": {
+    "leading": 42,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| {\n    Regex::new(\n        r\"(?i)(command not found|not recognized as an internal|no such file or directory.*command)\",\n    )\n    .unwrap()\n})",
+  "range": {
+    "byteOffset": {
+      "start": 1478,
+      "end": 1636
+    },
+    "start": {
+      "line": 56,
+      "column": 43
+    },
+    "end": {
+      "line": 61,
+      "column": 2
+    }
+  },
+  "file": "src/learn/detector.rs",
+  "lines": "static CMD_NOT_FOUND_RE: LazyLock<Regex> = LazyLock::new(|| {\n    Regex::new(\n        r\"(?i)(command not found|not recognized as an internal|no such file or directory.*command)\",\n    )\n    .unwrap()\n});",
+  "charCount": {
+    "leading": 43,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| {\n    Regex::new(r\"(?i)(no such file or directory|cannot find the path|file not found)\").unwrap()\n})",
+  "range": {
+    "byteOffset": {
+      "start": 1679,
+      "end": 1796
+    },
+    "start": {
+      "line": 63,
+      "column": 40
+    },
+    "end": {
+      "line": 65,
+      "column": 2
+    }
+  },
+  "file": "src/learn/detector.rs",
+  "lines": "static WRONG_PATH_RE: LazyLock<Regex> = LazyLock::new(|| {\n    Regex::new(r\"(?i)(no such file or directory|cannot find the path|file not found)\").unwrap()\n});",
+  "charCount": {
+    "leading": 40,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| {\n    Regex::new(\n        r\"(?i)(requires a value|requires an argument|missing (required )?argument|expected.*argument)\"\n    ).unwrap()\n})",
+  "range": {
+    "byteOffset": {
+      "start": 1840,
+      "end": 1995
+    },
+    "start": {
+      "line": 67,
+      "column": 41
+    },
+    "end": {
+      "line": 71,
+      "column": 2
+    }
+  },
+  "file": "src/learn/detector.rs",
+  "lines": "static MISSING_ARG_RE: LazyLock<Regex> = LazyLock::new(|| {\n    Regex::new(\n        r\"(?i)(requires a value|requires an argument|missing (required )?argument|expected.*argument)\"\n    ).unwrap()\n});",
+  "charCount": {
+    "leading": 41,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"(?i)(permission denied|access denied|not permitted)\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 2049,
+      "end": 2142
+    },
+    "start": {
+      "line": 74,
+      "column": 4
+    },
+    "end": {
+      "line": 74,
+      "column": 97
+    }
+  },
+  "file": "src/learn/detector.rs",
+  "lines": "    LazyLock::new(|| Regex::new(r\"(?i)(permission denied|access denied|not permitted)\").unwrap());",
+  "charCount": {
+    "leading": 4,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| {\n    Regex::new(\n        r\"(?i)(user (doesn't want|declined|rejected|cancelled)|operation (cancelled|aborted) by user)\"\n    ).unwrap()\n})",
+  "range": {
+    "byteOffset": {
+      "start": 2236,
+      "end": 2391
+    },
+    "start": {
+      "line": 77,
+      "column": 44
+    },
+    "end": {
+      "line": 81,
+      "column": 2
+    }
+  },
+  "file": "src/learn/detector.rs",
+  "lines": "static USER_REJECTION_RE: LazyLock<Regex> = LazyLock::new(|| {\n    Regex::new(\n        r\"(?i)(user (doesn't want|declined|rejected|cancelled)|operation (cancelled|aborted) by user)\"\n    ).unwrap()\n});",
+  "charCount": {
+    "leading": 44,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"(?s)<!--.*?-->\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 513,
+      "end": 569
+    },
+    "start": {
+      "line": 15,
+      "column": 42
+    },
+    "end": {
+      "line": 15,
+      "column": 98
+    }
+  },
+  "file": "src/cmds/git/gh_cmd.rs",
+  "lines": "static HTML_COMMENT_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r\"(?s)<!--.*?-->\").unwrap());",
+  "charCount": {
+    "leading": 42,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"(?m)^\\s*\\[!\\[[^\\]]*\\]\\([^)]*\\)\\]\\([^)]*\\)\\s*$\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 615,
+      "end": 702
+    },
+    "start": {
+      "line": 17,
+      "column": 4
+    },
+    "end": {
+      "line": 17,
+      "column": 91
+    }
+  },
+  "file": "src/cmds/git/gh_cmd.rs",
+  "lines": "    LazyLock::new(|| Regex::new(r\"(?m)^\\s*\\[!\\[[^\\]]*\\]\\([^)]*\\)\\]\\([^)]*\\)\\s*$\").unwrap());",
+  "charCount": {
+    "leading": 4,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"(?m)^\\s*!\\[[^\\]]*\\]\\([^)]*\\)\\s*$\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 753,
+      "end": 827
+    },
+    "start": {
+      "line": 19,
+      "column": 4
+    },
+    "end": {
+      "line": 19,
+      "column": 78
+    }
+  },
+  "file": "src/cmds/git/gh_cmd.rs",
+  "lines": "    LazyLock::new(|| Regex::new(r\"(?m)^\\s*!\\[[^\\]]*\\]\\([^)]*\\)\\s*$\").unwrap());",
+  "charCount": {
+    "leading": 4,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"(?m)^\\s*(?:---+|\\*\\*\\*+|___+)\\s*$\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 878,
+      "end": 953
+    },
+    "start": {
+      "line": 21,
+      "column": 4
+    },
+    "end": {
+      "line": 21,
+      "column": 79
+    }
+  },
+  "file": "src/cmds/git/gh_cmd.rs",
+  "lines": "    LazyLock::new(|| Regex::new(r\"(?m)^\\s*(?:---+|\\*\\*\\*+|___+)\\s*$\").unwrap());",
+  "charCount": {
+    "leading": 4,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"\\n{3,}\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 996,
+      "end": 1044
+    },
+    "start": {
+      "line": 22,
+      "column": 41
+    },
+    "end": {
+      "line": 22,
+      "column": 89
+    }
+  },
+  "file": "src/cmds/git/gh_cmd.rs",
+  "lines": "static MULTI_BLANK_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r\"\\n{3,}\").unwrap());",
+  "charCount": {
+    "leading": 41,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"\\n{3,}\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 4667,
+      "end": 4715
+    },
+    "start": {
+      "line": 157,
+      "column": 47
+    },
+    "end": {
+      "line": 157,
+      "column": 95
+    }
+  },
+  "file": "src/core/filter.rs",
+  "lines": "static MULTIPLE_BLANK_LINES: LazyLock<Regex> = LazyLock::new(|| Regex::new(r\"\\n{3,}\").unwrap());",
+  "charCount": {
+    "leading": 47,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"^(use |import |from |require\\(|#include)\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 7177,
+      "end": 7259
+    },
+    "start": {
+      "line": 232,
+      "column": 4
+    },
+    "end": {
+      "line": 232,
+      "column": 86
+    }
+  },
+  "file": "src/core/filter.rs",
+  "lines": "    LazyLock::new(|| Regex::new(r\"^(use |import |from |require\\(|#include)\").unwrap());",
+  "charCount": {
+    "leading": 4,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| {\n    Regex::new(\n        r\"^(pub\\s+)?(async\\s+)?(fn|def|function|func|class|struct|enum|trait|interface|type)\\s+\\w+\",\n    )\n    .unwrap()\n})",
+  "range": {
+    "byteOffset": {
+      "start": 7302,
+      "end": 7460
+    },
+    "start": {
+      "line": 233,
+      "column": 41
+    },
+    "end": {
+      "line": 238,
+      "column": 2
+    }
+  },
+  "file": "src/core/filter.rs",
+  "lines": "static FUNC_SIGNATURE: LazyLock<Regex> = LazyLock::new(|| {\n    Regex::new(\n        r\"^(pub\\s+)?(async\\s+)?(fn|def|function|func|class|struct|enum|trait|interface|type)\\s+\\w+\",\n    )\n    .unwrap()\n});",
+  "charCount": {
+    "leading": 41,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"\\x1b\\[[0-9;]*[a-zA-Z]\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 1515,
+      "end": 1578
+    },
+    "start": {
+      "line": 53,
+      "column": 8
+    },
+    "end": {
+      "line": 53,
+      "column": 71
+    }
+  },
+  "file": "src/core/utils.rs",
+  "lines": "        LazyLock::new(|| Regex::new(r\"\\x1b\\[[0-9;]*[a-zA-Z]\").unwrap());",
+  "charCount": {
+    "leading": 8,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| regex::Regex::new(r\"^\\d+\\)\\s+(Failure|Error):$\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 5087,
+      "end": 5162
+    },
+    "start": {
+      "line": 167,
+      "column": 8
+    },
+    "end": {
+      "line": 167,
+      "column": 83
+    }
+  },
+  "file": "src/cmds/ruby/rake_cmd.rs",
+  "lines": "        LazyLock::new(|| regex::Regex::new(r\"^\\d+\\)\\s+(Failure|Error):$\").unwrap());",
+  "charCount": {
+    "leading": 8,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(TomlFilterRegistry::load)",
+  "range": {
+    "byteOffset": {
+      "start": 13362,
+      "end": 13401
+    },
+    "start": {
+      "line": 398,
+      "column": 48
+    },
+    "end": {
+      "line": 398,
+      "column": 87
+    }
+  },
+  "file": "src/core/toml_filter.rs",
+  "lines": "static REGISTRY: LazyLock<TomlFilterRegistry> = LazyLock::new(TomlFilterRegistry::load);",
+  "charCount": {
+    "leading": 48,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(build_match_set)",
+  "range": {
+    "byteOffset": {
+      "start": 14019,
+      "end": 14049
+    },
+    "start": {
+      "line": 421,
+      "column": 39
+    },
+    "end": {
+      "line": 421,
+      "column": 69
+    }
+  },
+  "file": "src/core/toml_filter.rs",
+  "lines": "static MATCH_SET: LazyLock<RegexSet> = LazyLock::new(build_match_set);",
+  "charCount": {
+    "leading": 39,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"\\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}\\b\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 397,
+      "end": 489
+    },
+    "start": {
+      "line": 12,
+      "column": 4
+    },
+    "end": {
+      "line": 12,
+      "column": 96
+    }
+  },
+  "file": "src/cmds/git/gt_cmd.rs",
+  "lines": "    LazyLock::new(|| Regex::new(r\"\\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}\\b\").unwrap());",
+  "charCount": {
+    "leading": 4,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| {\n    Regex::new(\n        r#\"(?:Created|Pushed|pushed|Deleted|deleted)\\s+branch\\s+[`\"']?([a-zA-Z0-9/_.\\-+@]+)\"#,\n    )\n    .unwrap()\n})",
+  "range": {
+    "byteOffset": {
+      "start": 532,
+      "end": 684
+    },
+    "start": {
+      "line": 13,
+      "column": 41
+    },
+    "end": {
+      "line": 18,
+      "column": 2
+    }
+  },
+  "file": "src/cmds/git/gt_cmd.rs",
+  "lines": "static BRANCH_NAME_RE: LazyLock<Regex> = LazyLock::new(|| {\n    Regex::new(\n        r#\"(?:Created|Pushed|pushed|Deleted|deleted)\\s+branch\\s+[`\"']?([a-zA-Z0-9/_.\\-+@]+)\"#,\n    )\n    .unwrap()\n});",
+  "charCount": {
+    "leading": 41,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| {\n    Regex::new(r\"(Created|Updated)\\s+pull\\s+request\\s+#(\\d+)\\s+for\\s+([^\\s:]+)(?::\\s*(\\S+))?\")\n        .unwrap()\n})",
+  "range": {
+    "byteOffset": {
+      "start": 723,
+      "end": 857
+    },
+    "start": {
+      "line": 19,
+      "column": 37
+    },
+    "end": {
+      "line": 22,
+      "column": 2
+    }
+  },
+  "file": "src/cmds/git/gt_cmd.rs",
+  "lines": "static PR_LINE_RE: LazyLock<Regex> = LazyLock::new(|| {\n    Regex::new(r\"(Created|Updated)\\s+pull\\s+request\\s+#(\\d+)\\s+for\\s+([^\\s:]+)(?::\\s*(\\S+))?\")\n        .unwrap()\n});",
+  "charCount": {
+    "leading": 37,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| {\n    RegexSet::new(RULES.iter().map(|r| r.pattern)).expect(\"invalid regex patterns\")\n})",
+  "range": {
+    "byteOffset": {
+      "start": 1484,
+      "end": 1589
+    },
+    "start": {
+      "line": 53,
+      "column": 39
+    },
+    "end": {
+      "line": 55,
+      "column": 2
+    }
+  },
+  "file": "src/discover/registry.rs",
+  "lines": "static REGEX_SET: LazyLock<RegexSet> = LazyLock::new(|| {\n    RegexSet::new(RULES.iter().map(|r| r.pattern)).expect(\"invalid regex patterns\")\n});",
+  "charCount": {
+    "leading": 39,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| {\n    RULES\n        .iter()\n        .map(|r| Regex::new(r.pattern).expect(\"invalid regex\"))\n        .collect()\n})",
+  "range": {
+    "byteOffset": {
+      "start": 1631,
+      "end": 1761
+    },
+    "start": {
+      "line": 56,
+      "column": 40
+    },
+    "end": {
+      "line": 61,
+      "column": 2
+    }
+  },
+  "file": "src/discover/registry.rs",
+  "lines": "static COMPILED: LazyLock<Vec<Regex>> = LazyLock::new(|| {\n    RULES\n        .iter()\n        .map(|r| Regex::new(r.pattern).expect(\"invalid regex\"))\n        .collect()\n});",
+  "charCount": {
+    "leading": 40,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| {\n    let double_quoted = r#\"\"(?:[^\"\\\\]|\\\\.)*\"\"#;\n    let single_quoted = r#\"'(?:[^'\\\\]|\\\\.)*'\"#;\n    let unquoted = r#\"[^\\s]*\"#;\n    let env_value = format!(\"(?:{}|{}|{})\", double_quoted, single_quoted, unquoted);\n    let env_assign = format!(r#\"[A-Z_][A-Z0-9_]*={}\"#, env_value);\n    Regex::new(&format!(r#\"^(?:sudo\\s+|env\\s+|{}\\s+)+\"#, env_assign)).unwrap()\n})",
+  "range": {
+    "byteOffset": {
+      "start": 1800,
+      "end": 2180
+    },
+    "start": {
+      "line": 62,
+      "column": 37
+    },
+    "end": {
+      "line": 69,
+      "column": 2
+    }
+  },
+  "file": "src/discover/registry.rs",
+  "lines": "static ENV_PREFIX: LazyLock<Regex> = LazyLock::new(|| {\n    let double_quoted = r#\"\"(?:[^\"\\\\]|\\\\.)*\"\"#;\n    let single_quoted = r#\"'(?:[^'\\\\]|\\\\.)*'\"#;\n    let unquoted = r#\"[^\\s]*\"#;\n    let env_value = format!(\"(?:{}|{}|{})\", double_quoted, single_quoted, unquoted);\n    let env_assign = format!(r#\"[A-Z_][A-Z0-9_]*={}\"#, env_value);\n    Regex::new(&format!(r#\"^(?:sudo\\s+|env\\s+|{}\\s+)+\"#, env_assign)).unwrap()\n});",
+  "charCount": {
+    "leading": 37,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| {\n    Regex::new(r\"^(?:(?:-C\\s+\\S+|-c\\s+\\S+|--git-dir(?:=\\S+|\\s+\\S+)|--work-tree(?:=\\S+|\\s+\\S+)|--no-pager|--no-optional-locks|--bare|--literal-pathspecs)\\s+)+\").unwrap()\n})",
+  "range": {
+    "byteOffset": {
+      "start": 2373,
+      "end": 2563
+    },
+    "start": {
+      "line": 72,
+      "column": 41
+    },
+    "end": {
+      "line": 74,
+      "column": 2
+    }
+  },
+  "file": "src/discover/registry.rs",
+  "lines": "static GIT_GLOBAL_OPT: LazyLock<Regex> = LazyLock::new(|| {\n    Regex::new(r\"^(?:(?:-C\\s+\\S+|-c\\s+\\S+|--git-dir(?:=\\S+|\\s+\\S+)|--work-tree(?:=\\S+|\\s+\\S+)|--no-pager|--no-optional-locks|--bare|--literal-pathspecs)\\s+)+\").unwrap()\n});",
+  "charCount": {
+    "leading": 41,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"^head\\s+-(\\d+)\\s+(\\S+)$\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 2914,
+      "end": 2979
+    },
+    "start": {
+      "line": 79,
+      "column": 33
+    },
+    "end": {
+      "line": 79,
+      "column": 98
+    }
+  },
+  "file": "src/discover/registry.rs",
+  "lines": "static HEAD_N: LazyLock<Regex> = LazyLock::new(|| Regex::new(r\"^head\\s+-(\\d+)\\s+(\\S+)$\").unwrap());",
+  "charCount": {
+    "leading": 33,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"^head\\s+--lines=(\\d+)\\s+(\\S+)$\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 3022,
+      "end": 3094
+    },
+    "start": {
+      "line": 81,
+      "column": 4
+    },
+    "end": {
+      "line": 81,
+      "column": 76
+    }
+  },
+  "file": "src/discover/registry.rs",
+  "lines": "    LazyLock::new(|| Regex::new(r\"^head\\s+--lines=(\\d+)\\s+(\\S+)$\").unwrap());",
+  "charCount": {
+    "leading": 4,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"^tail\\s+-(\\d+)\\s+(\\S+)$\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 3129,
+      "end": 3194
+    },
+    "start": {
+      "line": 82,
+      "column": 33
+    },
+    "end": {
+      "line": 82,
+      "column": 98
+    }
+  },
+  "file": "src/discover/registry.rs",
+  "lines": "static TAIL_N: LazyLock<Regex> = LazyLock::new(|| Regex::new(r\"^tail\\s+-(\\d+)\\s+(\\S+)$\").unwrap());",
+  "charCount": {
+    "leading": 33,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"^tail\\s+-n\\s+(\\d+)\\s+(\\S+)$\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 3239,
+      "end": 3308
+    },
+    "start": {
+      "line": 84,
+      "column": 4
+    },
+    "end": {
+      "line": 84,
+      "column": 73
+    }
+  },
+  "file": "src/discover/registry.rs",
+  "lines": "    LazyLock::new(|| Regex::new(r\"^tail\\s+-n\\s+(\\d+)\\s+(\\S+)$\").unwrap());",
+  "charCount": {
+    "leading": 4,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"^tail\\s+--lines=(\\d+)\\s+(\\S+)$\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 3354,
+      "end": 3426
+    },
+    "start": {
+      "line": 86,
+      "column": 4
+    },
+    "end": {
+      "line": 86,
+      "column": 76
+    }
+  },
+  "file": "src/discover/registry.rs",
+  "lines": "    LazyLock::new(|| Regex::new(r\"^tail\\s+--lines=(\\d+)\\s+(\\S+)$\").unwrap());",
+  "charCount": {
+    "leading": 4,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"^tail\\s+--lines\\s+(\\d+)\\s+(\\S+)$\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 3475,
+      "end": 3549
+    },
+    "start": {
+      "line": 88,
+      "column": 4
+    },
+    "end": {
+      "line": 88,
+      "column": 78
+    }
+  },
+  "file": "src/discover/registry.rs",
+  "lines": "    LazyLock::new(|| Regex::new(r\"^tail\\s+--lines\\s+(\\d+)\\s+(\\S+)$\").unwrap());",
+  "charCount": {
+    "leading": 4,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"(?m)[ \\t\\x0B\\x0C]*\\\\\\r?\\n[ \\t\\x0B\\x0C]*\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 18010,
+      "end": 18091
+    },
+    "start": {
+      "line": 538,
+      "column": 4
+    },
+    "end": {
+      "line": 538,
+      "column": 85
+    }
+  },
+  "file": "src/discover/registry.rs",
+  "lines": "    LazyLock::new(|| Regex::new(r\"(?m)[ \\t\\x0B\\x0C]*\\\\\\r?\\n[ \\t\\x0B\\x0C]*\").unwrap());",
+  "charCount": {
+    "leading": 4,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"\\\\\\r?\\n\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 18133,
+      "end": 18182
+    },
+    "start": {
+      "line": 540,
+      "column": 39
+    },
+    "end": {
+      "line": 540,
+      "column": 88
+    }
+  },
+  "file": "src/discover/registry.rs",
+  "lines": "static BASH_JOIN_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r\"\\\\\\r?\\n\").unwrap());",
+  "charCount": {
+    "leading": 39,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"(?i)running via spring preloader\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 875,
+      "end": 949
+    },
+    "start": {
+      "line": 21,
+      "column": 4
+    },
+    "end": {
+      "line": 21,
+      "column": 78
+    }
+  },
+  "file": "src/cmds/ruby/rspec_cmd.rs",
+  "lines": "    LazyLock::new(|| Regex::new(r\"(?i)running via spring preloader\").unwrap());",
+  "charCount": {
+    "leading": 4,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| {\n    Regex::new(r\"(?i)(coverage report|simplecov|coverage/|\\.simplecov|All Files.*Lines)\").unwrap()\n})",
+  "range": {
+    "byteOffset": {
+      "start": 990,
+      "end": 1110
+    },
+    "start": {
+      "line": 22,
+      "column": 39
+    },
+    "end": {
+      "line": 24,
+      "column": 2
+    }
+  },
+  "file": "src/cmds/ruby/rspec_cmd.rs",
+  "lines": "static RE_SIMPLECOV: LazyLock<Regex> = LazyLock::new(|| {\n    Regex::new(r\"(?i)(coverage report|simplecov|coverage/|\\.simplecov|All Files.*Lines)\").unwrap()\n});",
+  "charCount": {
+    "leading": 39,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"^DEPRECATION WARNING:\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 1157,
+      "end": 1220
+    },
+    "start": {
+      "line": 26,
+      "column": 4
+    },
+    "end": {
+      "line": 26,
+      "column": 67
+    }
+  },
+  "file": "src/cmds/ruby/rspec_cmd.rs",
+  "lines": "    LazyLock::new(|| Regex::new(r\"^DEPRECATION WARNING:\").unwrap());",
+  "charCount": {
+    "leading": 4,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"^Finished in \\d\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 1263,
+      "end": 1320
+    },
+    "start": {
+      "line": 27,
+      "column": 41
+    },
+    "end": {
+      "line": 27,
+      "column": 98
+    }
+  },
+  "file": "src/cmds/ruby/rspec_cmd.rs",
+  "lines": "static RE_FINISHED_IN: LazyLock<Regex> = LazyLock::new(|| Regex::new(r\"^Finished in \\d\").unwrap());",
+  "charCount": {
+    "leading": 41,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"saved screenshot to (.+)\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 1366,
+      "end": 1432
+    },
+    "start": {
+      "line": 29,
+      "column": 4
+    },
+    "end": {
+      "line": 29,
+      "column": 70
+    }
+  },
+  "file": "src/cmds/ruby/rspec_cmd.rs",
+  "lines": "    LazyLock::new(|| Regex::new(r\"saved screenshot to (.+)\").unwrap());",
+  "charCount": {
+    "leading": 4,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"(\\d+) examples?, (\\d+) failures?\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 1481,
+      "end": 1555
+    },
+    "start": {
+      "line": 31,
+      "column": 4
+    },
+    "end": {
+      "line": 31,
+      "column": 78
+    }
+  },
+  "file": "src/cmds/ruby/rspec_cmd.rs",
+  "lines": "    LazyLock::new(|| Regex::new(r\"(\\d+) examples?, (\\d+) failures?\").unwrap());",
+  "charCount": {
+    "leading": 4,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| {\n    Regex::new(\n        r\"(?s)^\\s*(?:\\d+/(\\d+)\\s+)?Test\\s+#(\\d+):\\s+(.+?)\\s+\\.{2,}\\s*(?:\\*{3})?\\s*(.+?)\\s+([\\d.]+)\\s+sec\\s*$\",\n    )\n    .expect(\"invalid ctest result regex\")\n})",
+  "range": {
+    "byteOffset": {
+      "start": 880,
+      "end": 1076
+    },
+    "start": {
+      "line": 23,
+      "column": 34
+    },
+    "end": {
+      "line": 28,
+      "column": 2
+    }
+  },
+  "file": "src/cmds/system/ctest_cmd.rs",
+  "lines": "static TEST_RE: LazyLock<Regex> = LazyLock::new(|| {\n    Regex::new(\n        r\"(?s)^\\s*(?:\\d+/(\\d+)\\s+)?Test\\s+#(\\d+):\\s+(.+?)\\s+\\.{2,}\\s*(?:\\*{3})?\\s*(.+?)\\s+([\\d.]+)\\s+sec\\s*$\",\n    )\n    .expect(\"invalid ctest result regex\")\n});",
+  "charCount": {
+    "leading": 34,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| {\n    Regex::new(r\"^\\s*(?:\\d+/\\d+\\s+)?Test\\s+#\\d+:\")\n        .expect(\"invalid ctest result prefix regex\")\n})",
+  "range": {
+    "byteOffset": {
+      "start": 1121,
+      "end": 1246
+    },
+    "start": {
+      "line": 29,
+      "column": 43
+    },
+    "end": {
+      "line": 32,
+      "column": 2
+    }
+  },
+  "file": "src/cmds/system/ctest_cmd.rs",
+  "lines": "static RESULT_PREFIX_RE: LazyLock<Regex> = LazyLock::new(|| {\n    Regex::new(r\"^\\s*(?:\\d+/\\d+\\s+)?Test\\s+#\\d+:\")\n        .expect(\"invalid ctest result prefix regex\")\n});",
+  "charCount": {
+    "leading": 43,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| {\n    Regex::new(r\"[\\d.]+\\s+sec\\s*$\").expect(\"invalid ctest result terminator regex\")\n})",
+  "range": {
+    "byteOffset": {
+      "start": 1295,
+      "end": 1400
+    },
+    "start": {
+      "line": 33,
+      "column": 47
+    },
+    "end": {
+      "line": 35,
+      "column": 2
+    }
+  },
+  "file": "src/cmds/system/ctest_cmd.rs",
+  "lines": "static RESULT_TERMINATOR_RE: LazyLock<Regex> = LazyLock::new(|| {\n    Regex::new(r\"[\\d.]+\\s+sec\\s*$\").expect(\"invalid ctest result terminator regex\")\n});",
+  "charCount": {
+    "leading": 47,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| {\n    Regex::new(r\"^\\s*Start\\s+(\\d+):\\s*(.*?)\\s*$\").expect(\"invalid ctest start regex\")\n})",
+  "range": {
+    "byteOffset": {
+      "start": 1437,
+      "end": 1544
+    },
+    "start": {
+      "line": 36,
+      "column": 35
+    },
+    "end": {
+      "line": 38,
+      "column": 2
+    }
+  },
+  "file": "src/cmds/system/ctest_cmd.rs",
+  "lines": "static START_RE: LazyLock<Regex> = LazyLock::new(|| {\n    Regex::new(r\"^\\s*Start\\s+(\\d+):\\s*(.*?)\\s*$\").expect(\"invalid ctest start regex\")\n});",
+  "charCount": {
+    "leading": 35,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| {\n    Regex::new(r\"^\\s*\\d+%\\s+tests passed,\\s+(\\d+)\\s+tests failed out of\\s+(\\d+)\")\n        .expect(\"invalid ctest summary regex\")\n})",
+  "range": {
+    "byteOffset": {
+      "start": 1583,
+      "end": 1733
+    },
+    "start": {
+      "line": 39,
+      "column": 37
+    },
+    "end": {
+      "line": 42,
+      "column": 2
+    }
+  },
+  "file": "src/cmds/system/ctest_cmd.rs",
+  "lines": "static SUMMARY_RE: LazyLock<Regex> = LazyLock::new(|| {\n    Regex::new(r\"^\\s*\\d+%\\s+tests passed,\\s+(\\d+)\\s+tests failed out of\\s+(\\d+)\")\n        .expect(\"invalid ctest summary regex\")\n});",
+  "charCount": {
+    "leading": 37,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| {\n    Regex::new(r\"^\\s*Total Test time \\(real\\)\\s+=\\s+([\\d.]+)\\s+sec\")\n        .expect(\"invalid ctest time regex\")\n})",
+  "range": {
+    "byteOffset": {
+      "start": 1769,
+      "end": 1903
+    },
+    "start": {
+      "line": 43,
+      "column": 34
+    },
+    "end": {
+      "line": 46,
+      "column": 2
+    }
+  },
+  "file": "src/cmds/system/ctest_cmd.rs",
+  "lines": "static TIME_RE: LazyLock<Regex> = LazyLock::new(|| {\n    Regex::new(r\"^\\s*Total Test time \\(real\\)\\s+=\\s+([\\d.]+)\\s+sec\")\n        .expect(\"invalid ctest time regex\")\n});",
+  "charCount": {
+    "leading": 34,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"(\\d+)\\s+(passed|failed|flaky|skipped)\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 5146,
+      "end": 5225
+    },
+    "start": {
+      "line": 167,
+      "column": 8
+    },
+    "end": {
+      "line": 167,
+      "column": 87
+    }
+  },
+  "file": "src/cmds/js/playwright_cmd.rs",
+  "lines": "        LazyLock::new(|| Regex::new(r\"(\\d+)\\s+(passed|failed|flaky|skipped)\").unwrap());",
+  "charCount": {
+    "leading": 8,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"\\((\\d+(?:\\.\\d+)?)(ms|s|m)\\)\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 5277,
+      "end": 5346
+    },
+    "start": {
+      "line": 169,
+      "column": 8
+    },
+    "end": {
+      "line": 169,
+      "column": 77
+    }
+  },
+  "file": "src/cmds/js/playwright_cmd.rs",
+  "lines": "        LazyLock::new(|| Regex::new(r\"\\((\\d+(?:\\.\\d+)?)(ms|s|m)\\)\").unwrap());",
+  "charCount": {
+    "leading": 8,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"[×✗]\\s+.*?›\\s+([^›]+\\.spec\\.[tj]sx?)\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 6657,
+      "end": 6742
+    },
+    "start": {
+      "line": 219,
+      "column": 8
+    },
+    "end": {
+      "line": 219,
+      "column": 86
+    }
+  },
+  "file": "src/cmds/js/playwright_cmd.rs",
+  "lines": "        LazyLock::new(|| Regex::new(r\"[×✗]\\s+.*?›\\s+([^›]+\\.spec\\.[tj]sx?)\").unwrap());",
+  "charCount": {
+    "leading": 8,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| {\n        Regex::new(r\"^[○●◐λ✓]\\s+([\\w/\\-\\.]+)\\s+(\\d+(?:\\.\\d+)?)\\s*(kB|B)\\s+(\\d+(?:\\.\\d+)?)\\s*(kB|B)\")\n            .unwrap()\n    })",
+  "range": {
+    "byteOffset": {
+      "start": 1175,
+      "end": 1332
+    },
+    "start": {
+      "line": 44,
+      "column": 45
+    },
+    "end": {
+      "line": 47,
+      "column": 6
+    }
+  },
+  "file": "src/cmds/js/next_cmd.rs",
+  "lines": "    static BUNDLE_PATTERN: LazyLock<Regex> = LazyLock::new(|| {\n        Regex::new(r\"^[○●◐λ✓]\\s+([\\w/\\-\\.]+)\\s+(\\d+(?:\\.\\d+)?)\\s*(kB|B)\\s+(\\d+(?:\\.\\d+)?)\\s*(kB|B)\")\n            .unwrap()\n    });",
+  "charCount": {
+    "leading": 45,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"(\\d+(?:\\.\\d+)?)\\s*(s|ms)\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 5202,
+      "end": 5268
+    },
+    "start": {
+      "line": 171,
+      "column": 8
+    },
+    "end": {
+      "line": 171,
+      "column": 74
+    }
+  },
+  "file": "src/cmds/js/next_cmd.rs",
+  "lines": "        LazyLock::new(|| Regex::new(r\"(\\d+(?:\\.\\d+)?)\\s*(s|ms)\").unwrap());",
+  "charCount": {
+    "leading": 8,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| {\n    Regex::new(r\"[\\u{2500}-\\u{257F}\\u{2580}-\\u{259F}\\u{25A0}-\\u{25FF}\\u{27A0}-\\u{27BF}]+\").unwrap()\n})",
+  "range": {
+    "byteOffset": {
+      "start": 239,
+      "end": 360
+    },
+    "start": {
+      "line": 7,
+      "column": 39
+    },
+    "end": {
+      "line": 9,
+      "column": 2
+    }
+  },
+  "file": "src/cmds/php/artisan_cmd.rs",
+  "lines": "static BOX_CHARS_RE: LazyLock<Regex> = LazyLock::new(|| {\n    Regex::new(r\"[\\u{2500}-\\u{257F}\\u{2580}-\\u{259F}\\u{25A0}-\\u{25FF}\\u{27A0}-\\u{27BF}]+\").unwrap()\n});",
+  "charCount": {
+    "leading": 39,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"\\.{3,}\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 396,
+      "end": 444
+    },
+    "start": {
+      "line": 10,
+      "column": 34
+    },
+    "end": {
+      "line": 10,
+      "column": 82
+    }
+  },
+  "file": "src/cmds/php/artisan_cmd.rs",
+  "lines": "static DOTS_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r\"\\.{3,}\").unwrap());",
+  "charCount": {
+    "leading": 34,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"[ \\t]{2,}\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 487,
+      "end": 538
+    },
+    "start": {
+      "line": 11,
+      "column": 41
+    },
+    "end": {
+      "line": 11,
+      "column": 92
+    }
+  },
+  "file": "src/cmds/php/artisan_cmd.rs",
+  "lines": "static MULTI_SPACE_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r\"[ \\t]{2,}\").unwrap());",
+  "charCount": {
+    "leading": 41,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"\\n{3,}\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 581,
+      "end": 629
+    },
+    "start": {
+      "line": 12,
+      "column": 41
+    },
+    "end": {
+      "line": 12,
+      "column": 89
+    }
+  },
+  "file": "src/cmds/php/artisan_cmd.rs",
+  "lines": "static MULTI_BLANK_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r\"\\n{3,}\").unwrap());",
+  "charCount": {
+    "leading": 41,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"^([^\\x00]+)\\x00(\\d+)([:-])(.*)$\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 24488,
+      "end": 24561
+    },
+    "start": {
+      "line": 738,
+      "column": 8
+    },
+    "end": {
+      "line": 738,
+      "column": 81
+    }
+  },
+  "file": "src/cmds/system/search.rs",
+  "lines": "        LazyLock::new(|| Regex::new(r\"^([^\\x00]+)\\x00(\\d+)([:-])(.*)$\").unwrap());",
+  "charCount": {
+    "leading": 8,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"Tests\\s+(?:(\\d+)\\s+failed\\s+\\|\\s+)?(\\d+)\\s+passed\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 3900,
+      "end": 3991
+    },
+    "start": {
+      "line": 120,
+      "column": 8
+    },
+    "end": {
+      "line": 120,
+      "column": 99
+    }
+  },
+  "file": "src/cmds/js/vitest_cmd.rs",
+  "lines": "        LazyLock::new(|| Regex::new(r\"Tests\\s+(?:(\\d+)\\s+failed\\s+\\|\\s+)?(\\d+)\\s+passed\").unwrap());",
+  "charCount": {
+    "leading": 8,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"Duration\\s+([\\d.]+)(ms|s)\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 4043,
+      "end": 4110
+    },
+    "start": {
+      "line": 122,
+      "column": 8
+    },
+    "end": {
+      "line": 122,
+      "column": 75
+    }
+  },
+  "file": "src/cmds/js/vitest_cmd.rs",
+  "lines": "        LazyLock::new(|| Regex::new(r\"Duration\\s+([\\d.]+)(ms|s)\").unwrap());",
+  "charCount": {
+    "leading": 8,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"\\x1b\\[[0-9;]*[A-Za-z]\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 207,
+      "end": 270
+    },
+    "start": {
+      "line": 6,
+      "column": 34
+    },
+    "end": {
+      "line": 6,
+      "column": 97
+    }
+  },
+  "file": "src/cmds/php/utils.rs",
+  "lines": "static ANSI_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r\"\\x1b\\[[0-9;]*[A-Za-z]\").unwrap());",
+  "charCount": {
+    "leading": 34,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"[\\x00-\\x08\\x0B\\x0C\\x0E-\\x1F\\x7F]\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 313,
+      "end": 387
+    },
+    "start": {
+      "line": 8,
+      "column": 4
+    },
+    "end": {
+      "line": 8,
+      "column": 78
+    }
+  },
+  "file": "src/cmds/php/utils.rs",
+  "lines": "    LazyLock::new(|| Regex::new(r\"[\\x00-\\x08\\x0B\\x0C\\x0E-\\x1F\\x7F]\").unwrap());",
+  "charCount": {
+    "leading": 4,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| {\n    Regex::new(\n        r\"\\s+(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\\s+\\d{1,2}\\s+(?:\\d{4}|\\d{2}:\\d{2})\\s+\"\n    )\n    .unwrap()\n})",
+  "range": {
+    "byteOffset": {
+      "start": 501,
+      "end": 659
+    },
+    "start": {
+      "line": 13,
+      "column": 37
+    },
+    "end": {
+      "line": 18,
+      "column": 2
+    }
+  },
+  "file": "src/cmds/system/ls.rs",
+  "lines": "static LS_DATE_RE: LazyLock<Regex> = LazyLock::new(|| {\n    Regex::new(\n        r\"\\s+(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\\s+\\d{1,2}\\s+(?:\\d{4}|\\d{2}:\\d{2})\\s+\"\n    )\n    .unwrap()\n});",
+  "charCount": {
+    "leading": 37,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"(?s)<!--.*?-->\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 918,
+      "end": 974
+    },
+    "start": {
+      "line": 22,
+      "column": 42
+    },
+    "end": {
+      "line": 22,
+      "column": 98
+    }
+  },
+  "file": "src/cmds/git/glab_cmd.rs",
+  "lines": "static HTML_COMMENT_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r\"(?s)<!--.*?-->\").unwrap());",
+  "charCount": {
+    "leading": 42,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"(?m)^\\s*\\[!\\[[^\\]]*\\]\\([^)]*\\)\\]\\([^)]*\\)\\s*$\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 1020,
+      "end": 1107
+    },
+    "start": {
+      "line": 24,
+      "column": 4
+    },
+    "end": {
+      "line": 24,
+      "column": 91
+    }
+  },
+  "file": "src/cmds/git/glab_cmd.rs",
+  "lines": "    LazyLock::new(|| Regex::new(r\"(?m)^\\s*\\[!\\[[^\\]]*\\]\\([^)]*\\)\\]\\([^)]*\\)\\s*$\").unwrap());",
+  "charCount": {
+    "leading": 4,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"(?m)^\\s*!\\[[^\\]]*\\]\\([^)]*\\)\\s*$\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 1158,
+      "end": 1232
+    },
+    "start": {
+      "line": 26,
+      "column": 4
+    },
+    "end": {
+      "line": 26,
+      "column": 78
+    }
+  },
+  "file": "src/cmds/git/glab_cmd.rs",
+  "lines": "    LazyLock::new(|| Regex::new(r\"(?m)^\\s*!\\[[^\\]]*\\]\\([^)]*\\)\\s*$\").unwrap());",
+  "charCount": {
+    "leading": 4,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"(?m)^\\s*(?:---+|\\*\\*\\*+|___+)\\s*$\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 1283,
+      "end": 1358
+    },
+    "start": {
+      "line": 28,
+      "column": 4
+    },
+    "end": {
+      "line": 28,
+      "column": 79
+    }
+  },
+  "file": "src/cmds/git/glab_cmd.rs",
+  "lines": "    LazyLock::new(|| Regex::new(r\"(?m)^\\s*(?:---+|\\*\\*\\*+|___+)\\s*$\").unwrap());",
+  "charCount": {
+    "leading": 4,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"\\n{3,}\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 1401,
+      "end": 1449
+    },
+    "start": {
+      "line": 29,
+      "column": 41
+    },
+    "end": {
+      "line": 29,
+      "column": 89
+    }
+  },
+  "file": "src/cmds/git/glab_cmd.rs",
+  "lines": "static MULTI_BLANK_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r\"\\n{3,}\").unwrap());",
+  "charCount": {
+    "leading": 41,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"/-/merge_requests/(\\d+)\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 1491,
+      "end": 1556
+    },
+    "start": {
+      "line": 31,
+      "column": 4
+    },
+    "end": {
+      "line": 31,
+      "column": 69
+    }
+  },
+  "file": "src/cmds/git/glab_cmd.rs",
+  "lines": "    LazyLock::new(|| Regex::new(r\"/-/merge_requests/(\\d+)\").unwrap());",
+  "charCount": {
+    "leading": 4,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| {\n    Regex::new(r\"section_(?:start|end):\\d+:[a-z0-9_]+(?:\\x1b\\[0K|\\[0K)*\").unwrap()\n})",
+  "range": {
+    "byteOffset": {
+      "start": 1675,
+      "end": 1779
+    },
+    "start": {
+      "line": 33,
+      "column": 44
+    },
+    "end": {
+      "line": 35,
+      "column": 2
+    }
+  },
+  "file": "src/cmds/git/glab_cmd.rs",
+  "lines": "static SECTION_MARKER_RE: LazyLock<Regex> = LazyLock::new(|| {\n    Regex::new(r\"section_(?:start|end):\\d+:[a-z0-9_]+(?:\\x1b\\[0K|\\[0K)*\").unwrap()\n});",
+  "charCount": {
+    "leading": 44,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"\\[[\\d;]+[A-Za-z]\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 1903,
+      "end": 1961
+    },
+    "start": {
+      "line": 37,
+      "column": 39
+    },
+    "end": {
+      "line": 37,
+      "column": 97
+    }
+  },
+  "file": "src/cmds/git/glab_cmd.rs",
+  "lines": "static BARE_ANSI_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r\"\\[[\\d;]+[A-Za-z]\").unwrap());",
+  "charCount": {
+    "leading": 39,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"^\\d+\\) \\S\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 822,
+      "end": 873
+    },
+    "start": {
+      "line": 19,
+      "column": 45
+    },
+    "end": {
+      "line": 19,
+      "column": 96
+    }
+  },
+  "file": "src/cmds/php/phpunit_cmd.rs",
+  "lines": "static FAILURE_HEADING_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r\"^\\d+\\) \\S\").unwrap());",
+  "charCount": {
+    "leading": 45,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| {\n    Regex::new(r\"^(.+?)\\((\\d+),(\\d+)\\):\\s+(error|warning)\\s+(TS\\d+):\\s+(.+)$\").unwrap()\n})",
+  "range": {
+    "byteOffset": {
+      "start": 978,
+      "end": 1087
+    },
+    "start": {
+      "line": 21,
+      "column": 36
+    },
+    "end": {
+      "line": 23,
+      "column": 2
+    }
+  },
+  "file": "src/cmds/js/tsc_cmd.rs",
+  "lines": "static TSC_ERROR: LazyLock<Regex> = LazyLock::new(|| {\n    Regex::new(r\"^(.+?)\\((\\d+),(\\d+)\\):\\s+(error|warning)\\s+(TS\\d+):\\s+(.+)$\").unwrap()\n});",
+  "charCount": {
+    "leading": 36,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| {\n    Regex::new(r\"^(.+?):(\\d+):(\\d+)\\s+-\\s+(error|warning)\\s+(TS\\d+):\\s+(.+)$\").unwrap()\n})",
+  "range": {
+    "byteOffset": {
+      "start": 1220,
+      "end": 1329
+    },
+    "start": {
+      "line": 25,
+      "column": 43
+    },
+    "end": {
+      "line": 27,
+      "column": 2
+    }
+  },
+  "file": "src/cmds/js/tsc_cmd.rs",
+  "lines": "static TSC_PRETTY_ERROR: LazyLock<Regex> = LazyLock::new(|| {\n    Regex::new(r\"^(.+?):(\\d+):(\\d+)\\s+-\\s+(error|warning)\\s+(TS\\d+):\\s+(.+)$\").unwrap()\n});",
+  "charCount": {
+    "leading": 43,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"^(error|warning)\\s+(TS\\d+):\\s+(.+)$\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 1378,
+      "end": 1455
+    },
+    "start": {
+      "line": 29,
+      "column": 4
+    },
+    "end": {
+      "line": 29,
+      "column": 81
+    }
+  },
+  "file": "src/cmds/js/tsc_cmd.rs",
+  "lines": "    LazyLock::new(|| Regex::new(r\"^(error|warning)\\s+(TS\\d+):\\s+(.+)$\").unwrap());",
+  "charCount": {
+    "leading": 4,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| {\n        // Matches a status line. Anchor: either start-of-line (\"FAIL desc [x.phpt]\")\n        // or immediately after the test bracket (\"TEST N/M [x.phpt]PASS desc [x.phpt]\").\n        // We only accept the token after `]` or at line start so that prose like\n        // \"FAILED TEST SUMMARY\" does not match.\n        Regex::new(\n            r\"(?:^|\\])(PASS|FAIL|SKIP|BORK|WARN|XLEAK|LEAK|XFAIL)\\s+(.*?)\\s*\\[([^\\[\\]]+\\.phpt)\\]\",\n        )\n        .unwrap()\n    })",
+  "range": {
+    "byteOffset": {
+      "start": 4848,
+      "end": 5327
+    },
+    "start": {
+      "line": 162,
+      "column": 40
+    },
+    "end": {
+      "line": 171,
+      "column": 6
+    }
+  },
+  "file": "src/cmds/php/phpt_cmd.rs",
+  "lines": "    static STATUS_RE: LazyLock<Regex> = LazyLock::new(|| {\n        // Matches a status line. Anchor: either start-of-line (\"FAIL desc [x.phpt]\")\n        // or immediately after the test bracket (\"TEST N/M [x.phpt]PASS desc [x.phpt]\").\n        // We only accept the token after `]` or at line start so that prose like\n        // \"FAILED TEST SUMMARY\" does not match.\n        Regex::new(\n            r\"(?:^|\\])(PASS|FAIL|SKIP|BORK|WARN|XLEAK|LEAK|XFAIL)\\s+(.*?)\\s*\\[([^\\[\\]]+\\.phpt)\\]\",\n        )\n        .unwrap()\n    });",
+  "charCount": {
+    "leading": 40,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| {\n        Regex::new(\n            r\"^\\s*(Tests passed|Tests failed|Tests skipped|Tests warned|Expected fail|Expected leak|Tests leaked|Tests borked)\\s*:\\s*(\\d+)\",\n        )\n        .unwrap()\n    })",
+  "range": {
+    "byteOffset": {
+      "start": 5367,
+      "end": 5581
+    },
+    "start": {
+      "line": 172,
+      "column": 38
+    },
+    "end": {
+      "line": 177,
+      "column": 6
+    }
+  },
+  "file": "src/cmds/php/phpt_cmd.rs",
+  "lines": "    static STAT_RE: LazyLock<Regex> = LazyLock::new(|| {\n        Regex::new(\n            r\"^\\s*(Tests passed|Tests failed|Tests skipped|Tests warned|Expected fail|Expected leak|Tests leaked|Tests borked)\\s*:\\s*(\\d+)\",\n        )\n        .unwrap()\n    });",
+  "charCount": {
+    "leading": 38,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"^\\s*Number of tests\\s*:\\s*(\\d+)\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 5640,
+      "end": 5713
+    },
+    "start": {
+      "line": 179,
+      "column": 8
+    },
+    "end": {
+      "line": 179,
+      "column": 81
+    }
+  },
+  "file": "src/cmds/php/phpt_cmd.rs",
+  "lines": "        LazyLock::new(|| Regex::new(r\"^\\s*Number of tests\\s*:\\s*(\\d+)\").unwrap());",
+  "charCount": {
+    "leading": 8,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"^\\s*Time taken\\s*:\\s*([0-9.]+)\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 5761,
+      "end": 5833
+    },
+    "start": {
+      "line": 181,
+      "column": 8
+    },
+    "end": {
+      "line": 181,
+      "column": 80
+    }
+  },
+  "file": "src/cmds/php/phpt_cmd.rs",
+  "lines": "        LazyLock::new(|| Regex::new(r\"^\\s*Time taken\\s*:\\s*([0-9.]+)\").unwrap());",
+  "charCount": {
+    "leading": 8,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| {\n    vec![\n        // Generic errors\n        Regex::new(r\"(?i)^.*error[\\s:\\[].*$\").unwrap(),\n        Regex::new(r\"(?i)^.*\\berr\\b.*$\").unwrap(),\n        Regex::new(r\"(?i)^.*warning[\\s:\\[].*$\").unwrap(),\n        Regex::new(r\"(?i)^.*\\bwarn\\b.*$\").unwrap(),\n        Regex::new(r\"(?i)^.*failed.*$\").unwrap(),\n        Regex::new(r\"(?i)^.*failure.*$\").unwrap(),\n        Regex::new(r\"(?i)^.*exception.*$\").unwrap(),\n        Regex::new(r\"(?i)^.*panic.*$\").unwrap(),\n        // Rust specific\n        Regex::new(r\"^error\\[E\\d+\\]:.*$\").unwrap(),\n        Regex::new(r\"^\\s*--> .*:\\d+:\\d+$\").unwrap(),\n        // Python\n        Regex::new(r\"^Traceback.*$\").unwrap(),\n        Regex::new(r#\"^\\s*File \".*\", line \\d+.*$\"#).unwrap(),\n        // JavaScript/TypeScript\n        Regex::new(r\"^\\s*at .*:\\d+:\\d+.*$\").unwrap(),\n        // Go\n        Regex::new(r\"^.*\\.go:\\d+:.*$\").unwrap(),\n    ]\n})",
+  "range": {
+    "byteOffset": {
+      "start": 393,
+      "end": 1283
+    },
+    "start": {
+      "line": 12,
+      "column": 46
+    },
+    "end": {
+      "line": 34,
+      "column": 2
+    }
+  },
+  "file": "src/cmds/rust/runner.rs",
+  "lines": "static ERROR_PATTERNS: LazyLock<Vec<Regex>> = LazyLock::new(|| {\n    vec![\n        // Generic errors\n        Regex::new(r\"(?i)^.*error[\\s:\\[].*$\").unwrap(),\n        Regex::new(r\"(?i)^.*\\berr\\b.*$\").unwrap(),\n        Regex::new(r\"(?i)^.*warning[\\s:\\[].*$\").unwrap(),\n        Regex::new(r\"(?i)^.*\\bwarn\\b.*$\").unwrap(),\n        Regex::new(r\"(?i)^.*failed.*$\").unwrap(),\n        Regex::new(r\"(?i)^.*failure.*$\").unwrap(),\n        Regex::new(r\"(?i)^.*exception.*$\").unwrap(),\n        Regex::new(r\"(?i)^.*panic.*$\").unwrap(),\n        // Rust specific\n        Regex::new(r\"^error\\[E\\d+\\]:.*$\").unwrap(),\n        Regex::new(r\"^\\s*--> .*:\\d+:\\d+$\").unwrap(),\n        // Python\n        Regex::new(r\"^Traceback.*$\").unwrap(),\n        Regex::new(r#\"^\\s*File \".*\", line \\d+.*$\"#).unwrap(),\n        // JavaScript/TypeScript\n        Regex::new(r\"^\\s*at .*:\\d+:\\d+.*$\").unwrap(),\n        // Go\n        Regex::new(r\"^.*\\.go:\\d+:.*$\").unwrap(),\n    ]\n});",
+  "charCount": {
+    "leading": 46,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| {\n    Regex::new(r\"^\\d{4}[-/]\\d{2}[-/]\\d{2}[T ]\\d{2}:\\d{2}:\\d{2}[.,]?\\d*\\s*\").unwrap()\n})",
+  "range": {
+    "byteOffset": {
+      "start": 377,
+      "end": 483
+    },
+    "start": {
+      "line": 13,
+      "column": 39
+    },
+    "end": {
+      "line": 15,
+      "column": 2
+    }
+  },
+  "file": "src/cmds/system/log_cmd.rs",
+  "lines": "static TIMESTAMP_RE: LazyLock<Regex> = LazyLock::new(|| {\n    Regex::new(r\"^\\d{4}[-/]\\d{2}[-/]\\d{2}[T ]\\d{2}:\\d{2}:\\d{2}[.,]?\\d*\\s*\").unwrap()\n});",
+  "charCount": {
+    "leading": 39,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| {\n    Regex::new(r\"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\")\n        .unwrap()\n})",
+  "range": {
+    "byteOffset": {
+      "start": 519,
+      "end": 653
+    },
+    "start": {
+      "line": 16,
+      "column": 34
+    },
+    "end": {
+      "line": 19,
+      "column": 2
+    }
+  },
+  "file": "src/cmds/system/log_cmd.rs",
+  "lines": "static UUID_RE: LazyLock<Regex> = LazyLock::new(|| {\n    Regex::new(r\"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\")\n        .unwrap()\n});",
+  "charCount": {
+    "leading": 34,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"0x[0-9a-fA-F]+\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 688,
+      "end": 744
+    },
+    "start": {
+      "line": 20,
+      "column": 33
+    },
+    "end": {
+      "line": 20,
+      "column": 89
+    }
+  },
+  "file": "src/cmds/system/log_cmd.rs",
+  "lines": "static HEX_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r\"0x[0-9a-fA-F]+\").unwrap());",
+  "charCount": {
+    "leading": 33,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"\\b\\d{4,}\\b\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 779,
+      "end": 831
+    },
+    "start": {
+      "line": 21,
+      "column": 33
+    },
+    "end": {
+      "line": 21,
+      "column": 85
+    }
+  },
+  "file": "src/cmds/system/log_cmd.rs",
+  "lines": "static NUM_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r\"\\b\\d{4,}\\b\").unwrap());",
+  "charCount": {
+    "leading": 33,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"/[\\w./\\-]+\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 867,
+      "end": 919
+    },
+    "start": {
+      "line": 22,
+      "column": 34
+    },
+    "end": {
+      "line": 22,
+      "column": 86
+    }
+  },
+  "file": "src/cmds/system/log_cmd.rs",
+  "lines": "static PATH_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r\"/[\\w./\\-]+\").unwrap());",
+  "charCount": {
+    "leading": 34,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| {\n    Regex::new(\n        r\"(?m)^\\s*(?P<file>[^\\r\\n:(]+)\\((?P<line>\\d+),(?P<column>\\d+)\\):\\s*(?P<kind>error|warning)\\s*(?:(?P<code>[A-Za-z]+\\d+)\\s*:\\s*)?(?P<msg>.*)$\"\n    )\n    .expect(\"valid regex\")\n})",
+  "range": {
+    "byteOffset": {
+      "start": 1296,
+      "end": 1515
+    },
+    "start": {
+      "line": 54,
+      "column": 35
+    },
+    "end": {
+      "line": 59,
+      "column": 2
+    }
+  },
+  "file": "src/cmds/dotnet/binlog.rs",
+  "lines": "static ISSUE_RE: LazyLock<Regex> = LazyLock::new(|| {\n    Regex::new(\n        r\"(?m)^\\s*(?P<file>[^\\r\\n:(]+)\\((?P<line>\\d+),(?P<column>\\d+)\\):\\s*(?P<kind>error|warning)\\s*(?:(?P<code>[A-Za-z]+\\d+)\\s*:\\s*)?(?P<msg>.*)$\"\n    )\n    .expect(\"valid regex\")\n});",
+  "charCount": {
+    "leading": 35,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| {\n    Regex::new(r\"(?mi)^\\s*(?P<count>\\d+)\\s+(?P<kind>warning|error)\\(s\\)\").expect(\"valid regex\")\n})",
+  "range": {
+    "byteOffset": {
+      "start": 1560,
+      "end": 1677
+    },
+    "start": {
+      "line": 60,
+      "column": 43
+    },
+    "end": {
+      "line": 62,
+      "column": 2
+    }
+  },
+  "file": "src/cmds/dotnet/binlog.rs",
+  "lines": "static BUILD_SUMMARY_RE: LazyLock<Regex> = LazyLock::new(|| {\n    Regex::new(r\"(?mi)^\\s*(?P<count>\\d+)\\s+(?P<kind>warning|error)\\(s\\)\").expect(\"valid regex\")\n});",
+  "charCount": {
+    "leading": 43,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"(?i)\\b(?P<count>\\d+)\\s+error\\(s\\)\").expect(\"valid regex\"))",
+  "range": {
+    "byteOffset": {
+      "start": 1724,
+      "end": 1812
+    },
+    "start": {
+      "line": 64,
+      "column": 4
+    },
+    "end": {
+      "line": 64,
+      "column": 92
+    }
+  },
+  "file": "src/cmds/dotnet/binlog.rs",
+  "lines": "    LazyLock::new(|| Regex::new(r\"(?i)\\b(?P<count>\\d+)\\s+error\\(s\\)\").expect(\"valid regex\"));",
+  "charCount": {
+    "leading": 4,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"(?i)\\b(?P<count>\\d+)\\s+warning\\(s\\)\").expect(\"valid regex\"))",
+  "range": {
+    "byteOffset": {
+      "start": 1861,
+      "end": 1951
+    },
+    "start": {
+      "line": 66,
+      "column": 4
+    },
+    "end": {
+      "line": 66,
+      "column": 94
+    }
+  },
+  "file": "src/cmds/dotnet/binlog.rs",
+  "lines": "    LazyLock::new(|| Regex::new(r\"(?i)\\b(?P<count>\\d+)\\s+warning\\(s\\)\").expect(\"valid regex\"));",
+  "charCount": {
+    "leading": 4,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| {\n    Regex::new(r\"(?mi)^.+\\(\\d+,\\d+\\):\\s*error(?:\\s+[A-Za-z]{2,}\\d{3,})?(?:\\s*:.*)?$\")\n        .expect(\"valid regex\")\n})",
+  "range": {
+    "byteOffset": {
+      "start": 2002,
+      "end": 2140
+    },
+    "start": {
+      "line": 67,
+      "column": 49
+    },
+    "end": {
+      "line": 70,
+      "column": 2
+    }
+  },
+  "file": "src/cmds/dotnet/binlog.rs",
+  "lines": "static FALLBACK_ERROR_LINE_RE: LazyLock<Regex> = LazyLock::new(|| {\n    Regex::new(r\"(?mi)^.+\\(\\d+,\\d+\\):\\s*error(?:\\s+[A-Za-z]{2,}\\d{3,})?(?:\\s*:.*)?$\")\n        .expect(\"valid regex\")\n});",
+  "charCount": {
+    "leading": 49,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| {\n    Regex::new(r\"(?mi)^.+\\(\\d+,\\d+\\):\\s*warning(?:\\s+[A-Za-z]{2,}\\d{3,})?(?:\\s*:.*)?$\")\n        .expect(\"valid regex\")\n})",
+  "range": {
+    "byteOffset": {
+      "start": 2193,
+      "end": 2333
+    },
+    "start": {
+      "line": 71,
+      "column": 51
+    },
+    "end": {
+      "line": 74,
+      "column": 2
+    }
+  },
+  "file": "src/cmds/dotnet/binlog.rs",
+  "lines": "static FALLBACK_WARNING_LINE_RE: LazyLock<Regex> = LazyLock::new(|| {\n    Regex::new(r\"(?mi)^.+\\(\\d+,\\d+\\):\\s*warning(?:\\s+[A-Za-z]{2,}\\d{3,})?(?:\\s*:.*)?$\")\n        .expect(\"valid regex\")\n});",
+  "charCount": {
+    "leading": 51,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| {\n    Regex::new(r\"(?m)^\\s*Time Elapsed\\s+(?P<duration>[^\\r\\n]+)$\").expect(\"valid regex\")\n})",
+  "range": {
+    "byteOffset": {
+      "start": 2373,
+      "end": 2482
+    },
+    "start": {
+      "line": 75,
+      "column": 38
+    },
+    "end": {
+      "line": 77,
+      "column": 2
+    }
+  },
+  "file": "src/cmds/dotnet/binlog.rs",
+  "lines": "static DURATION_RE: LazyLock<Regex> = LazyLock::new(|| {\n    Regex::new(r\"(?m)^\\s*Time Elapsed\\s+(?P<duration>[^\\r\\n]+)$\").expect(\"valid regex\")\n});",
+  "charCount": {
+    "leading": 38,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| {\n    Regex::new(\n        r\"(?m)(?:Passed!|Failed!)\\s*-\\s*Failed:\\s*(?P<failed>\\d+),\\s*Passed:\\s*(?P<passed>\\d+),\\s*Skipped:\\s*(?P<skipped>\\d+),\\s*Total:\\s*(?P<total>\\d+),\\s*Duration:\\s*(?P<duration>[^\\r\\n-]+)\"\n    )\n    .expect(\"valid regex\")\n})",
+  "range": {
+    "byteOffset": {
+      "start": 2525,
+      "end": 2788
+    },
+    "start": {
+      "line": 78,
+      "column": 41
+    },
+    "end": {
+      "line": 83,
+      "column": 2
+    }
+  },
+  "file": "src/cmds/dotnet/binlog.rs",
+  "lines": "static TEST_RESULT_RE: LazyLock<Regex> = LazyLock::new(|| {\n    Regex::new(\n        r\"(?m)(?:Passed!|Failed!)\\s*-\\s*Failed:\\s*(?P<failed>\\d+),\\s*Passed:\\s*(?P<passed>\\d+),\\s*Skipped:\\s*(?P<skipped>\\d+),\\s*Total:\\s*(?P<total>\\d+),\\s*Duration:\\s*(?P<duration>[^\\r\\n-]+)\"\n    )\n    .expect(\"valid regex\")\n});",
+  "charCount": {
+    "leading": 41,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| {\n    Regex::new(\n        r\"(?mi)^\\s*Test summary:\\s*total:\\s*(?P<total>\\d+),\\s*failed:\\s*(?P<failed>\\d+),\\s*(?:succeeded|passed):\\s*(?P<passed>\\d+),\\s*skipped:\\s*(?P<skipped>\\d+),\\s*duration:\\s*(?P<duration>[^\\r\\n]+)$\"\n    )\n    .expect(\"valid regex\")\n})",
+  "range": {
+    "byteOffset": {
+      "start": 2832,
+      "end": 3104
+    },
+    "start": {
+      "line": 84,
+      "column": 42
+    },
+    "end": {
+      "line": 89,
+      "column": 2
+    }
+  },
+  "file": "src/cmds/dotnet/binlog.rs",
+  "lines": "static TEST_SUMMARY_RE: LazyLock<Regex> = LazyLock::new(|| {\n    Regex::new(\n        r\"(?mi)^\\s*Test summary:\\s*total:\\s*(?P<total>\\d+),\\s*failed:\\s*(?P<failed>\\d+),\\s*(?:succeeded|passed):\\s*(?P<passed>\\d+),\\s*skipped:\\s*(?P<skipped>\\d+),\\s*duration:\\s*(?P<duration>[^\\r\\n]+)$\"\n    )\n    .expect(\"valid regex\")\n});",
+  "charCount": {
+    "leading": 42,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| {\n    Regex::new(r\"(?m)^\\s*Failed\\s+(?P<name>[^\\r\\n\\[]+)\\s+\\[[^\\]\\r\\n]+\\]\\s*$\").expect(\"valid regex\")\n})",
+  "range": {
+    "byteOffset": {
+      "start": 3152,
+      "end": 3273
+    },
+    "start": {
+      "line": 90,
+      "column": 46
+    },
+    "end": {
+      "line": 92,
+      "column": 2
+    }
+  },
+  "file": "src/cmds/dotnet/binlog.rs",
+  "lines": "static FAILED_TEST_HEAD_RE: LazyLock<Regex> = LazyLock::new(|| {\n    Regex::new(r\"(?m)^\\s*Failed\\s+(?P<name>[^\\r\\n\\[]+)\\s+\\[[^\\]\\r\\n]+\\]\\s*$\").expect(\"valid regex\")\n});",
+  "charCount": {
+    "leading": 46,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"(?m)^\\s*Restored\\s+.+\\.csproj\\s*\\(\").expect(\"valid regex\"))",
+  "range": {
+    "byteOffset": {
+      "start": 3324,
+      "end": 3413
+    },
+    "start": {
+      "line": 94,
+      "column": 4
+    },
+    "end": {
+      "line": 94,
+      "column": 93
+    }
+  },
+  "file": "src/cmds/dotnet/binlog.rs",
+  "lines": "    LazyLock::new(|| Regex::new(r\"(?m)^\\s*Restored\\s+.+\\.csproj\\s*\\(\").expect(\"valid regex\"));",
+  "charCount": {
+    "leading": 4,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| {\n    Regex::new(\n        r\"(?mi)^\\s*(?:(?P<file>.+?)\\s+:\\s+)?(?P<kind>warning|error)\\s+(?P<code>[A-Za-z]{2,}\\d{3,})\\s*:\\s*(?P<msg>.+)$\"\n    )\n    .expect(\"valid regex\")\n})",
+  "range": {
+    "byteOffset": {
+      "start": 3463,
+      "end": 3652
+    },
+    "start": {
+      "line": 95,
+      "column": 48
+    },
+    "end": {
+      "line": 100,
+      "column": 2
+    }
+  },
+  "file": "src/cmds/dotnet/binlog.rs",
+  "lines": "static RESTORE_DIAGNOSTIC_RE: LazyLock<Regex> = LazyLock::new(|| {\n    Regex::new(\n        r\"(?mi)^\\s*(?:(?P<file>.+?)\\s+:\\s+)?(?P<kind>warning|error)\\s+(?P<code>[A-Za-z]{2,}\\d{3,})\\s*:\\s*(?P<msg>.+)$\"\n    )\n    .expect(\"valid regex\")\n});",
+  "charCount": {
+    "leading": 48,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| {\n    Regex::new(r\"(?m)^\\s*([A-Za-z]:)?[^\\r\\n]*\\.csproj(?:\\s|$)\").expect(\"valid regex\")\n})",
+  "range": {
+    "byteOffset": {
+      "start": 3696,
+      "end": 3803
+    },
+    "start": {
+      "line": 101,
+      "column": 42
+    },
+    "end": {
+      "line": 103,
+      "column": 2
+    }
+  },
+  "file": "src/cmds/dotnet/binlog.rs",
+  "lines": "static PROJECT_PATH_RE: LazyLock<Regex> = LazyLock::new(|| {\n    Regex::new(r\"(?m)^\\s*([A-Za-z]:)?[^\\r\\n]*\\.csproj(?:\\s|$)\").expect(\"valid regex\")\n});",
+  "charCount": {
+    "leading": 42,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"[\\x20-\\x7E]{5,}\").expect(\"valid regex\"))",
+  "range": {
+    "byteOffset": {
+      "start": 3852,
+      "end": 3922
+    },
+    "start": {
+      "line": 105,
+      "column": 4
+    },
+    "end": {
+      "line": 105,
+      "column": 74
+    }
+  },
+  "file": "src/cmds/dotnet/binlog.rs",
+  "lines": "    LazyLock::new(|| Regex::new(r\"[\\x20-\\x7E]{5,}\").expect(\"valid regex\"));",
+  "charCount": {
+    "leading": 4,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"^[A-Za-z]{2,}\\d{3,}$\").expect(\"valid regex\"))",
+  "range": {
+    "byteOffset": {
+      "start": 3973,
+      "end": 4048
+    },
+    "start": {
+      "line": 107,
+      "column": 4
+    },
+    "end": {
+      "line": 107,
+      "column": 79
+    }
+  },
+  "file": "src/cmds/dotnet/binlog.rs",
+  "lines": "    LazyLock::new(|| Regex::new(r\"^[A-Za-z]{2,}\\d{3,}$\").expect(\"valid regex\"));",
+  "charCount": {
+    "leading": 4,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"(?i)([A-Za-z]:)?[/\\\\][^\\s]+\\.(cs|vb|fs)\").expect(\"valid regex\"))",
+  "range": {
+    "byteOffset": {
+      "start": 4095,
+      "end": 4189
+    },
+    "start": {
+      "line": 109,
+      "column": 4
+    },
+    "end": {
+      "line": 109,
+      "column": 98
+    }
+  },
+  "file": "src/cmds/dotnet/binlog.rs",
+  "lines": "    LazyLock::new(|| Regex::new(r\"(?i)([A-Za-z]:)?[/\\\\][^\\s]+\\.(cs|vb|fs)\").expect(\"valid regex\"));",
+  "charCount": {
+    "leading": 4,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| {\n    let keys = SENSITIVE_ENV_VARS\n        .iter()\n        .map(|key| regex::escape(key))\n        .collect::<Vec<_>>()\n        .join(\"|\");\n    Regex::new(&format!(\n        r\"(?P<prefix>\\b(?:{})\\s*(?:=|:)\\s*)(?P<value>[^\\s;]+)\",\n        keys\n    ))\n    .expect(\"valid regex\")\n})",
+  "range": {
+    "byteOffset": {
+      "start": 4234,
+      "end": 4529
+    },
+    "start": {
+      "line": 110,
+      "column": 43
+    },
+    "end": {
+      "line": 121,
+      "column": 2
+    }
+  },
+  "file": "src/cmds/dotnet/binlog.rs",
+  "lines": "static SENSITIVE_ENV_RE: LazyLock<Regex> = LazyLock::new(|| {\n    let keys = SENSITIVE_ENV_VARS\n        .iter()\n        .map(|key| regex::escape(key))\n        .collect::<Vec<_>>()\n        .join(\"|\");\n    Regex::new(&format!(\n        r\"(?P<prefix>\\b(?:{})\\s*(?:=|:)\\s*)(?P<value>[^\\s;]+)\",\n        keys\n    ))\n    .expect(\"valid regex\")\n});",
+  "charCount": {
+    "leading": 43,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"^> Task :\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 442,
+      "end": 493
+    },
+    "start": {
+      "line": 12,
+      "column": 36
+    },
+    "end": {
+      "line": 12,
+      "column": 87
+    }
+  },
+  "file": "src/cmds/jvm/gradlew_cmd.rs",
+  "lines": "static TASK_LINE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r\"^> Task :\").unwrap());",
+  "charCount": {
+    "leading": 36,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"^\\* Try:|^> Run with --|^> Get more help at\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 537,
+      "end": 622
+    },
+    "start": {
+      "line": 14,
+      "column": 4
+    },
+    "end": {
+      "line": 14,
+      "column": 89
+    }
+  },
+  "file": "src/cmds/jvm/gradlew_cmd.rs",
+  "lines": "    LazyLock::new(|| Regex::new(r\"^\\* Try:|^> Run with --|^> Get more help at\").unwrap());",
+  "charCount": {
+    "leading": 4,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"^BUILD (SUCCESSFUL|FAILED)\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 667,
+      "end": 735
+    },
+    "start": {
+      "line": 16,
+      "column": 4
+    },
+    "end": {
+      "line": 16,
+      "column": 72
+    }
+  },
+  "file": "src/cmds/jvm/gradlew_cmd.rs",
+  "lines": "    LazyLock::new(|| Regex::new(r\"^BUILD (SUCCESSFUL|FAILED)\").unwrap());",
+  "charCount": {
+    "leading": 4,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"^\\d+ actionable tasks?\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 778,
+      "end": 842
+    },
+    "start": {
+      "line": 18,
+      "column": 4
+    },
+    "end": {
+      "line": 18,
+      "column": 68
+    }
+  },
+  "file": "src/cmds/jvm/gradlew_cmd.rs",
+  "lines": "    LazyLock::new(|| Regex::new(r\"^\\d+ actionable tasks?\").unwrap());",
+  "charCount": {
+    "leading": 4,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| {\n        Regex::new(\n            r\"^(Starting a Gradle Daemon|Daemon will be stopped|Reusing configuration cache|Calculating task graph|> Configure project|Deprecated Gradle features|You can use|For more on this|Configuration cache entry)\"\n        )\n        .unwrap()\n    })",
+  "range": {
+    "byteOffset": {
+      "start": 5911,
+      "end": 6203
+    },
+    "start": {
+      "line": 179,
+      "column": 42
+    },
+    "end": {
+      "line": 184,
+      "column": 6
+    }
+  },
+  "file": "src/cmds/jvm/gradlew_cmd.rs",
+  "lines": "    static DAEMON_LINE: LazyLock<Regex> = LazyLock::new(|| {\n        Regex::new(\n            r\"^(Starting a Gradle Daemon|Daemon will be stopped|Reusing configuration cache|Calculating task graph|> Configure project|Deprecated Gradle features|You can use|For more on this|Configuration cache entry)\"\n        )\n        .unwrap()\n    });",
+  "charCount": {
+    "leading": 42,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| {\n        Regex::new(r\"^\\s*\\d+%|^Downloading|^Configuring|^Resolving|^\\[Incubating\\]|^Wrote HTML report|^class \\S+ could not|^\\[android-\")\n                .unwrap()\n    })",
+  "range": {
+    "byteOffset": {
+      "start": 6244,
+      "end": 6432
+    },
+    "start": {
+      "line": 185,
+      "column": 39
+    },
+    "end": {
+      "line": 188,
+      "column": 6
+    }
+  },
+  "file": "src/cmds/jvm/gradlew_cmd.rs",
+  "lines": "    static PROGRESS: LazyLock<Regex> = LazyLock::new(|| {\n        Regex::new(r\"^\\s*\\d+%|^Downloading|^Configuring|^Resolving|^\\[Incubating\\]|^Wrote HTML report|^class \\S+ could not|^\\[android-\")\n                .unwrap()\n    });",
+  "charCount": {
+    "leading": 39,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| {\n        Regex::new(\n            r\"(?i)(^FAILURE:|^\\* What went wrong:|^\\* Where:|> Could not|e: |error:|^Execution failed|Lint found \\d+ error)\"\n        )\n        .unwrap()\n    })",
+  "range": {
+    "byteOffset": {
+      "start": 6475,
+      "end": 6673
+    },
+    "start": {
+      "line": 189,
+      "column": 41
+    },
+    "end": {
+      "line": 194,
+      "column": 6
+    }
+  },
+  "file": "src/cmds/jvm/gradlew_cmd.rs",
+  "lines": "    static ERROR_LINE: LazyLock<Regex> = LazyLock::new(|| {\n        Regex::new(\n            r\"(?i)(^FAILURE:|^\\* What went wrong:|^\\* Where:|> Could not|e: |error:|^Execution failed|Lint found \\d+ error)\"\n        )\n        .unwrap()\n    });",
+  "charCount": {
+    "leading": 41,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"^(w: |warning:|Warning:|WARNING:)\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 6817,
+      "end": 6892
+    },
+    "start": {
+      "line": 197,
+      "column": 8
+    },
+    "end": {
+      "line": 197,
+      "column": 83
+    }
+  },
+  "file": "src/cmds/jvm/gradlew_cmd.rs",
+  "lines": "        LazyLock::new(|| Regex::new(r\"^(w: |warning:|Warning:|WARNING:)\").unwrap());",
+  "charCount": {
+    "leading": 8,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"gradle\\.com/s/|Publishing build scan\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 6943,
+      "end": 7021
+    },
+    "start": {
+      "line": 199,
+      "column": 8
+    },
+    "end": {
+      "line": 199,
+      "column": 86
+    }
+  },
+  "file": "src/cmds/jvm/gradlew_cmd.rs",
+  "lines": "        LazyLock::new(|| Regex::new(r\"gradle\\.com/s/|Publishing build scan\").unwrap());",
+  "charCount": {
+    "leading": 8,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"FAILED$| FAILED \").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 8236,
+      "end": 8294
+    },
+    "start": {
+      "line": 233,
+      "column": 8
+    },
+    "end": {
+      "line": 233,
+      "column": 66
+    }
+  },
+  "file": "src/cmds/jvm/gradlew_cmd.rs",
+  "lines": "        LazyLock::new(|| Regex::new(r\"FAILED$| FAILED \").unwrap());",
+  "charCount": {
+    "leading": 8,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\" PASSED$| SKIPPED$\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 8349,
+      "end": 8409
+    },
+    "start": {
+      "line": 235,
+      "column": 8
+    },
+    "end": {
+      "line": 235,
+      "column": 68
+    }
+  },
+  "file": "src/cmds/jvm/gradlew_cmd.rs",
+  "lines": "        LazyLock::new(|| Regex::new(r\" PASSED$| SKIPPED$\").unwrap());",
+  "charCount": {
+    "leading": 8,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| {\n        Regex::new(\n            r\"\\d+ tests? completed|\\d+ tests? failed|There were failing tests|See the report at\",\n        )\n        .unwrap()\n    })",
+  "range": {
+    "byteOffset": {
+      "start": 8454,
+      "end": 8625
+    },
+    "start": {
+      "line": 236,
+      "column": 43
+    },
+    "end": {
+      "line": 241,
+      "column": 6
+    }
+  },
+  "file": "src/cmds/jvm/gradlew_cmd.rs",
+  "lines": "    static SUMMARY_LINE: LazyLock<Regex> = LazyLock::new(|| {\n        Regex::new(\n            r\"\\d+ tests? completed|\\d+ tests? failed|There were failing tests|See the report at\",\n        )\n        .unwrap()\n    });",
+  "charCount": {
+    "leading": 43,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"^INSTRUMENTATION_STATUS[_CODE]*:\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 10881,
+      "end": 10955
+    },
+    "start": {
+      "line": 311,
+      "column": 8
+    },
+    "end": {
+      "line": 311,
+      "column": 82
+    }
+  },
+  "file": "src/cmds/jvm/gradlew_cmd.rs",
+  "lines": "        LazyLock::new(|| Regex::new(r\"^INSTRUMENTATION_STATUS[_CODE]*:\").unwrap());",
+  "charCount": {
+    "leading": 8,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"^INSTRUMENTATION_RESULT:\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 11018,
+      "end": 11084
+    },
+    "start": {
+      "line": 313,
+      "column": 8
+    },
+    "end": {
+      "line": 313,
+      "column": 74
+    }
+  },
+  "file": "src/cmds/jvm/gradlew_cmd.rs",
+  "lines": "        LazyLock::new(|| Regex::new(r\"^INSTRUMENTATION_RESULT:\").unwrap());",
+  "charCount": {
+    "leading": 8,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"^INSTRUMENTATION_CODE:\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 11145,
+      "end": 11209
+    },
+    "start": {
+      "line": 315,
+      "column": 8
+    },
+    "end": {
+      "line": 315,
+      "column": 72
+    }
+  },
+  "file": "src/cmds/jvm/gradlew_cmd.rs",
+  "lines": "        LazyLock::new(|| Regex::new(r\"^INSTRUMENTATION_CODE:\").unwrap());",
+  "charCount": {
+    "leading": 8,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"^Starting \\d+ tests? on \").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 11264,
+      "end": 11330
+    },
+    "start": {
+      "line": 317,
+      "column": 8
+    },
+    "end": {
+      "line": 317,
+      "column": 74
+    }
+  },
+  "file": "src/cmds/jvm/gradlew_cmd.rs",
+  "lines": "        LazyLock::new(|| Regex::new(r\"^Starting \\d+ tests? on \").unwrap());",
+  "charCount": {
+    "leading": 8,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"^Installing APK\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 11385,
+      "end": 11442
+    },
+    "start": {
+      "line": 319,
+      "column": 8
+    },
+    "end": {
+      "line": 319,
+      "column": 65
+    }
+  },
+  "file": "src/cmds/jvm/gradlew_cmd.rs",
+  "lines": "        LazyLock::new(|| Regex::new(r\"^Installing APK\").unwrap());",
+  "charCount": {
+    "leading": 8,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"[^:]+:\\d+:.*[Ee]rror:.*\\[\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 12945,
+      "end": 13012
+    },
+    "start": {
+      "line": 362,
+      "column": 8
+    },
+    "end": {
+      "line": 362,
+      "column": 75
+    }
+  },
+  "file": "src/cmds/jvm/gradlew_cmd.rs",
+  "lines": "        LazyLock::new(|| Regex::new(r\"[^:]+:\\d+:.*[Ee]rror:.*\\[\").unwrap());",
+  "charCount": {
+    "leading": 8,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"[^:]+:\\d+:.*[Ww]arning:.*\\[\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 13155,
+      "end": 13224
+    },
+    "start": {
+      "line": 365,
+      "column": 8
+    },
+    "end": {
+      "line": 365,
+      "column": 77
+    }
+  },
+  "file": "src/cmds/jvm/gradlew_cmd.rs",
+  "lines": "        LazyLock::new(|| Regex::new(r\"[^:]+:\\d+:.*[Ww]arning:.*\\[\").unwrap());",
+  "charCount": {
+    "leading": 8,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"[^:]+:\\d+:\\d+:.*[Ll]int\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 13332,
+      "end": 13397
+    },
+    "start": {
+      "line": 368,
+      "column": 8
+    },
+    "end": {
+      "line": 368,
+      "column": 73
+    }
+  },
+  "file": "src/cmds/jvm/gradlew_cmd.rs",
+  "lines": "        LazyLock::new(|| Regex::new(r\"[^:]+:\\d+:\\d+:.*[Ll]int\").unwrap());",
+  "charCount": {
+    "leading": 8,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"[^:]+:\\d+:\\d+:.*error\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 13500,
+      "end": 13563
+    },
+    "start": {
+      "line": 371,
+      "column": 8
+    },
+    "end": {
+      "line": 371,
+      "column": 71
+    }
+  },
+  "file": "src/cmds/jvm/gradlew_cmd.rs",
+  "lines": "        LazyLock::new(|| Regex::new(r\"[^:]+:\\d+:\\d+:.*error\").unwrap());",
+  "charCount": {
+    "leading": 8,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"\\d+ (issues?|errors?|warnings?)\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 13637,
+      "end": 13710
+    },
+    "start": {
+      "line": 374,
+      "column": 8
+    },
+    "end": {
+      "line": 374,
+      "column": 81
+    }
+  },
+  "file": "src/cmds/jvm/gradlew_cmd.rs",
+  "lines": "        LazyLock::new(|| Regex::new(r\"\\d+ (issues?|errors?|warnings?)\").unwrap());",
+  "charCount": {
+    "leading": 8,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| {\n        Regex::new(r\"Wrote (HTML|XML|text) report|file://|/build/reports/lint\").unwrap()\n    })",
+  "range": {
+    "byteOffset": {
+      "start": 13796,
+      "end": 13910
+    },
+    "start": {
+      "line": 376,
+      "column": 42
+    },
+    "end": {
+      "line": 378,
+      "column": 6
+    }
+  },
+  "file": "src/cmds/jvm/gradlew_cmd.rs",
+  "lines": "    static REPORT_LINE: LazyLock<Regex> = LazyLock::new(|| {\n        Regex::new(r\"Wrote (HTML|XML|text) report|file://|/build/reports/lint\").unwrap()\n    });",
+  "charCount": {
+    "leading": 42,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r#\"^\\s*File \".*\", line \\d+.*$\"#).unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 904,
+      "end": 974
+    },
+    "start": {
+      "line": 19,
+      "column": 4
+    },
+    "end": {
+      "line": 19,
+      "column": 74
+    }
+  },
+  "file": "src/cmds/python/uv_cmd.rs",
+  "lines": "    LazyLock::new(|| Regex::new(r#\"^\\s*File \".*\", line \\d+.*$\"#).unwrap());",
+  "charCount": {
+    "leading": 4,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"^\\s*[A-Za-z_][A-Za-z0-9_.]*(?:Error|Exception):\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 1026,
+      "end": 1115
+    },
+    "start": {
+      "line": 21,
+      "column": 4
+    },
+    "end": {
+      "line": 21,
+      "column": 93
+    }
+  },
+  "file": "src/cmds/python/uv_cmd.rs",
+  "lines": "    LazyLock::new(|| Regex::new(r\"^\\s*[A-Za-z_][A-Za-z0-9_.]*(?:Error|Exception):\").unwrap());",
+  "charCount": {
+    "leading": 4,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"^\\s*at .+:\\d+:\\d+.*$\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 1159,
+      "end": 1221
+    },
+    "start": {
+      "line": 23,
+      "column": 4
+    },
+    "end": {
+      "line": 23,
+      "column": 66
+    }
+  },
+  "file": "src/cmds/python/uv_cmd.rs",
+  "lines": "    LazyLock::new(|| Regex::new(r\"^\\s*at .+:\\d+:\\d+.*$\").unwrap());",
+  "charCount": {
+    "leading": 4,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| {\n    vec![\n        Regex::new(r\"(?i)\\berror\\b\").unwrap(),\n        Regex::new(r\"(?i)\\bfailed\\b\").unwrap(),\n        Regex::new(r\"(?i)\\bfailure\\b\").unwrap(),\n        Regex::new(r\"(?i)\\bexception\\b\").unwrap(),\n        Regex::new(r\"(?i)\\bpanic\\b\").unwrap(),\n        Regex::new(r\"(?i)\\bwarn(?:ing)?\\b\").unwrap(),\n        Regex::new(r\"(?i)\\bassert(?:ion)?\\b\").unwrap(),\n        Regex::new(r\"^\\s*FAILED\\b\").unwrap(),\n        Regex::new(r\"^\\s*ERROR\\b\").unwrap(),\n        Regex::new(r\"^\\s*E\\s+\").unwrap(),\n        Regex::new(r\"^\\s*Caused by:\").unwrap(),\n        Regex::new(r\"^\\s*note:\").unwrap(),\n        Regex::new(r\"^\\s*help:\").unwrap(),\n    ]\n})",
+  "range": {
+    "byteOffset": {
+      "start": 1275,
+      "end": 1931
+    },
+    "start": {
+      "line": 24,
+      "column": 52
+    },
+    "end": {
+      "line": 40,
+      "column": 2
+    }
+  },
+  "file": "src/cmds/python/uv_cmd.rs",
+  "lines": "static ERROR_START_PATTERNS: LazyLock<Vec<Regex>> = LazyLock::new(|| {\n    vec![\n        Regex::new(r\"(?i)\\berror\\b\").unwrap(),\n        Regex::new(r\"(?i)\\bfailed\\b\").unwrap(),\n        Regex::new(r\"(?i)\\bfailure\\b\").unwrap(),\n        Regex::new(r\"(?i)\\bexception\\b\").unwrap(),\n        Regex::new(r\"(?i)\\bpanic\\b\").unwrap(),\n        Regex::new(r\"(?i)\\bwarn(?:ing)?\\b\").unwrap(),\n        Regex::new(r\"(?i)\\bassert(?:ion)?\\b\").unwrap(),\n        Regex::new(r\"^\\s*FAILED\\b\").unwrap(),\n        Regex::new(r\"^\\s*ERROR\\b\").unwrap(),\n        Regex::new(r\"^\\s*E\\s+\").unwrap(),\n        Regex::new(r\"^\\s*Caused by:\").unwrap(),\n        Regex::new(r\"^\\s*note:\").unwrap(),\n        Regex::new(r\"^\\s*help:\").unwrap(),\n    ]\n});",
+  "charCount": {
+    "leading": 52,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| {\n        Regex::new(r\"^(.+?):(\\d+)(?::\\d+)?: (error|warning|note): (.+?)(?:\\s+\\[(.+)\\])?$\").unwrap()\n    })",
+  "range": {
+    "byteOffset": {
+      "start": 1507,
+      "end": 1632
+    },
+    "start": {
+      "line": 56,
+      "column": 40
+    },
+    "end": {
+      "line": 58,
+      "column": 6
+    }
+  },
+  "file": "src/cmds/python/mypy_cmd.rs",
+  "lines": "    static MYPY_DIAG: LazyLock<Regex> = LazyLock::new(|| {\n        Regex::new(r\"^(.+?):(\\d+)(?::\\d+)?: (error|warning|note): (.+?)(?:\\s+\\[(.+)\\])?$\").unwrap()\n    });",
+  "charCount": {
+    "leading": 40,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"-\\[ RECORD \\d+ \\]-\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 507,
+      "end": 567
+    },
+    "start": {
+      "line": 16,
+      "column": 4
+    },
+    "end": {
+      "line": 16,
+      "column": 64
+    }
+  },
+  "file": "src/cmds/cloud/psql_cmd.rs",
+  "lines": "    LazyLock::new(|| Regex::new(r\"-\\[ RECORD \\d+ \\]-\").unwrap());",
+  "charCount": {
+    "leading": 4,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"^[-+]+$\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 605,
+      "end": 654
+    },
+    "start": {
+      "line": 17,
+      "column": 36
+    },
+    "end": {
+      "line": 17,
+      "column": 85
+    }
+  },
+  "file": "src/cmds/cloud/psql_cmd.rs",
+  "lines": "static SEPARATOR: LazyLock<Regex> = LazyLock::new(|| Regex::new(r\"^[-+]+$\").unwrap());",
+  "charCount": {
+    "leading": 36,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"^\\(\\d+ rows?\\)$\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 692,
+      "end": 749
+    },
+    "start": {
+      "line": 18,
+      "column": 36
+    },
+    "end": {
+      "line": 18,
+      "column": 93
+    }
+  },
+  "file": "src/cmds/cloud/psql_cmd.rs",
+  "lines": "static ROW_COUNT: LazyLock<Regex> = LazyLock::new(|| Regex::new(r\"^\\(\\d+ rows?\\)$\").unwrap());",
+  "charCount": {
+    "leading": 36,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"^-\\[ RECORD (\\d+) \\]-\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 795,
+      "end": 858
+    },
+    "start": {
+      "line": 20,
+      "column": 4
+    },
+    "end": {
+      "line": 20,
+      "column": 67
+    }
+  },
+  "file": "src/cmds/cloud/psql_cmd.rs",
+  "lines": "    LazyLock::new(|| Regex::new(r\"^-\\[ RECORD (\\d+) \\]-\").unwrap());",
+  "charCount": {
+    "leading": 4,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| {\n    Regex::new(\n        r\"Tests: succeeded (\\d+), failed (\\d+), canceled (\\d+), ignored (\\d+), pending (\\d+)\",\n    )\n    .unwrap()\n})",
+  "range": {
+    "byteOffset": {
+      "start": 336,
+      "end": 488
+    },
+    "start": {
+      "line": 9,
+      "column": 42
+    },
+    "end": {
+      "line": 14,
+      "column": 2
+    }
+  },
+  "file": "src/cmds/scala/sbt_cmd.rs",
+  "lines": "static TEST_SUMMARY_RE: LazyLock<Regex> = LazyLock::new(|| {\n    Regex::new(\n        r\"Tests: succeeded (\\d+), failed (\\d+), canceled (\\d+), ignored (\\d+), pending (\\d+)\",\n    )\n    .unwrap()\n});",
+  "charCount": {
+    "leading": 42,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| {\n    Regex::new(r\"^\\[info\\] (?:Passed|Failed): Total \\d+, Failed (\\d+), Errors (\\d+), Passed (\\d+)\")\n        .unwrap()\n})",
+  "range": {
+    "byteOffset": {
+      "start": 727,
+      "end": 866
+    },
+    "start": {
+      "line": 19,
+      "column": 43
+    },
+    "end": {
+      "line": 22,
+      "column": 2
+    }
+  },
+  "file": "src/cmds/scala/sbt_cmd.rs",
+  "lines": "static MUNIT_SUMMARY_RE: LazyLock<Regex> = LazyLock::new(|| {\n    Regex::new(r\"^\\[info\\] (?:Passed|Failed): Total \\d+, Failed (\\d+), Errors (\\d+), Passed (\\d+)\")\n        .unwrap()\n});",
+  "charCount": {
+    "leading": 43,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"Suites: completed (\\d+), aborted (\\d+)\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 981,
+      "end": 1061
+    },
+    "start": {
+      "line": 27,
+      "column": 4
+    },
+    "end": {
+      "line": 27,
+      "column": 84
+    }
+  },
+  "file": "src/cmds/scala/sbt_cmd.rs",
+  "lines": "    LazyLock::new(|| Regex::new(r\"Suites: completed (\\d+), aborted (\\d+)\").unwrap());",
+  "charCount": {
+    "leading": 4,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"Run completed in (\\d+) seconds?\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 1153,
+      "end": 1226
+    },
+    "start": {
+      "line": 31,
+      "column": 4
+    },
+    "end": {
+      "line": 31,
+      "column": 77
+    }
+  },
+  "file": "src/cmds/scala/sbt_cmd.rs",
+  "lines": "    LazyLock::new(|| Regex::new(r\"Run completed in (\\d+) seconds?\").unwrap());",
+  "charCount": {
+    "leading": 4,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"\\[info\\] Compiling (\\d+) Scala source\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 1323,
+      "end": 1402
+    },
+    "start": {
+      "line": 35,
+      "column": 4
+    },
+    "end": {
+      "line": 35,
+      "column": 83
+    }
+  },
+  "file": "src/cmds/scala/sbt_cmd.rs",
+  "lines": "    LazyLock::new(|| Regex::new(r\"\\[info\\] Compiling (\\d+) Scala source\").unwrap());",
+  "charCount": {
+    "leading": 4,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"\\[success\\] Total time: (\\d+) s\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 1488,
+      "end": 1561
+    },
+    "start": {
+      "line": 39,
+      "column": 4
+    },
+    "end": {
+      "line": 39,
+      "column": 77
+    }
+  },
+  "file": "src/cmds/scala/sbt_cmd.rs",
+  "lines": "    LazyLock::new(|| Regex::new(r\"\\[success\\] Total time: (\\d+) s\").unwrap());",
+  "charCount": {
+    "leading": 4,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"^\\[error\\]\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 1625,
+      "end": 1677
+    },
+    "start": {
+      "line": 42,
+      "column": 35
+    },
+    "end": {
+      "line": 42,
+      "column": 87
+    }
+  },
+  "file": "src/cmds/scala/sbt_cmd.rs",
+  "lines": "static ERROR_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r\"^\\[error\\]\").unwrap());",
+  "charCount": {
+    "leading": 35,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| {\n    Regex::new(\n        r\"^\\[info\\] (welcome to sbt|loading |set current project|Updating |Resolved |Fetching |downloading |Done )\"\n    ).unwrap()\n})",
+  "range": {
+    "byteOffset": {
+      "start": 1784,
+      "end": 1952
+    },
+    "start": {
+      "line": 45,
+      "column": 35
+    },
+    "end": {
+      "line": 49,
+      "column": 2
+    }
+  },
+  "file": "src/cmds/scala/sbt_cmd.rs",
+  "lines": "static NOISE_RE: LazyLock<Regex> = LazyLock::new(|| {\n    Regex::new(\n        r\"^\\[info\\] (welcome to sbt|loading |set current project|Updating |Resolved |Fetching |downloading |Done )\"\n    ).unwrap()\n});",
+  "charCount": {
+    "leading": 35,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"^\\[INFO\\] Running \").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 1613,
+      "end": 1673
+    },
+    "start": {
+      "line": 33,
+      "column": 34
+    },
+    "end": {
+      "line": 33,
+      "column": 94
+    }
+  },
+  "file": "src/cmds/jvm/mvn_cmd.rs",
+  "lines": "static RUNNING: LazyLock<Regex> = LazyLock::new(|| Regex::new(r\"^\\[INFO\\] Running \").unwrap());",
+  "charCount": {
+    "leading": 34,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"^\\[INFO\\] Running \\S+\\s*$\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 2301,
+      "end": 2368
+    },
+    "start": {
+      "line": 44,
+      "column": 4
+    },
+    "end": {
+      "line": 44,
+      "column": 71
+    }
+  },
+  "file": "src/cmds/jvm/mvn_cmd.rs",
+  "lines": "    LazyLock::new(|| Regex::new(r\"^\\[INFO\\] Running \\S+\\s*$\").unwrap());",
+  "charCount": {
+    "leading": 4,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| {\n    Regex::new(\n        r\"^\\[(?:INFO|ERROR|WARNING)\\] Tests run: \\d+, Failures: (\\d+), Errors: (\\d+), Skipped: \\d+, Time elapsed: [^ ]+ s(?:\\s+<<<\\s*(?:FAILURE|ERROR)!)?\\s+--?\\s+in (.+)$\"\n    ).unwrap()\n})",
+  "range": {
+    "byteOffset": {
+      "start": 2931,
+      "end": 3155
+    },
+    "start": {
+      "line": 54,
+      "column": 32
+    },
+    "end": {
+      "line": 58,
+      "column": 2
+    }
+  },
+  "file": "src/cmds/jvm/mvn_cmd.rs",
+  "lines": "static CLOSE: LazyLock<Regex> = LazyLock::new(|| {\n    Regex::new(\n        r\"^\\[(?:INFO|ERROR|WARNING)\\] Tests run: \\d+, Failures: (\\d+), Errors: (\\d+), Skipped: \\d+, Time elapsed: [^ ]+ s(?:\\s+<<<\\s*(?:FAILURE|ERROR)!)?\\s+--?\\s+in (.+)$\"\n    ).unwrap()\n});",
+  "charCount": {
+    "leading": 32,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"^\\[(?:INFO|ERROR)\\] BUILD (?:SUCCESS|FAILURE)$\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 3223,
+      "end": 3311
+    },
+    "start": {
+      "line": 62,
+      "column": 4
+    },
+    "end": {
+      "line": 62,
+      "column": 92
+    }
+  },
+  "file": "src/cmds/jvm/mvn_cmd.rs",
+  "lines": "    LazyLock::new(|| Regex::new(r\"^\\[(?:INFO|ERROR)\\] BUILD (?:SUCCESS|FAILURE)$\").unwrap());",
+  "charCount": {
+    "leading": 4,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"^\\[INFO\\] Results:\\s*$\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 3402,
+      "end": 3466
+    },
+    "start": {
+      "line": 65,
+      "column": 34
+    },
+    "end": {
+      "line": 65,
+      "column": 98
+    }
+  },
+  "file": "src/cmds/jvm/mvn_cmd.rs",
+  "lines": "static RESULTS: LazyLock<Regex> = LazyLock::new(|| Regex::new(r\"^\\[INFO\\] Results:\\s*$\").unwrap());",
+  "charCount": {
+    "leading": 34,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| {\n    Regex::new(r\"^\\[(?:INFO|ERROR)\\] Tests run: \\d+, Failures: \\d+, Errors: \\d+, Skipped: \\d+\\s*$\")\n        .unwrap()\n})",
+  "range": {
+    "byteOffset": {
+      "start": 3559,
+      "end": 3698
+    },
+    "start": {
+      "line": 68,
+      "column": 30
+    },
+    "end": {
+      "line": 71,
+      "column": 2
+    }
+  },
+  "file": "src/cmds/jvm/mvn_cmd.rs",
+  "lines": "static AGG: LazyLock<Regex> = LazyLock::new(|| {\n    Regex::new(r\"^\\[(?:INFO|ERROR)\\] Tests run: \\d+, Failures: \\d+, Errors: \\d+, Skipped: \\d+\\s*$\")\n        .unwrap()\n});",
+  "charCount": {
+    "leading": 30,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"^\\[INFO\\] --- .* @ .* ---$\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 3813,
+      "end": 3881
+    },
+    "start": {
+      "line": 75,
+      "column": 4
+    },
+    "end": {
+      "line": 75,
+      "column": 72
+    }
+  },
+  "file": "src/cmds/jvm/mvn_cmd.rs",
+  "lines": "    LazyLock::new(|| Regex::new(r\"^\\[INFO\\] --- .* @ .* ---$\").unwrap());",
+  "charCount": {
+    "leading": 4,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| {\n    Regex::new(r\"^\\[INFO\\] --- (?:maven-)?(surefire|failsafe)(?:-plugin)?:\\S+ \\([^)]*\\) @ .* ---$\")\n        .unwrap()\n})",
+  "range": {
+    "byteOffset": {
+      "start": 5833,
+      "end": 5972
+    },
+    "start": {
+      "line": 108,
+      "column": 45
+    },
+    "end": {
+      "line": 111,
+      "column": 2
+    }
+  },
+  "file": "src/cmds/jvm/mvn_cmd.rs",
+  "lines": "static TEST_PLUGIN_BANNER: LazyLock<Regex> = LazyLock::new(|| {\n    Regex::new(r\"^\\[INFO\\] --- (?:maven-)?(surefire|failsafe)(?:-plugin)?:\\S+ \\([^)]*\\) @ .* ---$\")\n        .unwrap()\n});",
+  "charCount": {
+    "leading": 45,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"^\\[INFO\\] Building .*\\[\\d+/\\d+\\]\\s*$\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 6735,
+      "end": 6813
+    },
+    "start": {
+      "line": 124,
+      "column": 4
+    },
+    "end": {
+      "line": 124,
+      "column": 82
+    }
+  },
+  "file": "src/cmds/jvm/mvn_cmd.rs",
+  "lines": "    LazyLock::new(|| Regex::new(r\"^\\[INFO\\] Building .*\\[\\d+/\\d+\\]\\s*$\").unwrap());",
+  "charCount": {
+    "leading": 4,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"^\\[INFO\\] -+< .+ >-+$\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 6909,
+      "end": 6972
+    },
+    "start": {
+      "line": 128,
+      "column": 4
+    },
+    "end": {
+      "line": 128,
+      "column": 67
+    }
+  },
+  "file": "src/cmds/jvm/mvn_cmd.rs",
+  "lines": "    LazyLock::new(|| Regex::new(r\"^\\[INFO\\] -+< .+ >-+$\").unwrap());",
+  "charCount": {
+    "leading": 4,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"^\\[INFO\\] Reactor Summary for \").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 7130,
+      "end": 7202
+    },
+    "start": {
+      "line": 133,
+      "column": 4
+    },
+    "end": {
+      "line": 133,
+      "column": 76
+    }
+  },
+  "file": "src/cmds/jvm/mvn_cmd.rs",
+  "lines": "    LazyLock::new(|| Regex::new(r\"^\\[INFO\\] Reactor Summary for \").unwrap());",
+  "charCount": {
+    "leading": 4,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"/[^:]+\\.java:\\[\\d+,\\d+\\]\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 7325,
+      "end": 7391
+    },
+    "start": {
+      "line": 137,
+      "column": 4
+    },
+    "end": {
+      "line": 137,
+      "column": 70
+    }
+  },
+  "file": "src/cmds/jvm/mvn_cmd.rs",
+  "lines": "    LazyLock::new(|| Regex::new(r\"/[^:]+\\.java:\\[\\d+,\\d+\\]\").unwrap());",
+  "charCount": {
+    "leading": 4,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| {\n            regex::Regex::new(\n                r\"test result: (\\w+)\\.\\s+(\\d+) passed;\\s+(\\d+) failed;\\s+(\\d+) ignored;\\s+(\\d+) measured;\\s+(\\d+) filtered out(?:;\\s+finished in ([\\d.]+)s)?\"\n            ).unwrap()\n        })",
+  "range": {
+    "byteOffset": {
+      "start": 33582,
+      "end": 33823
+    },
+    "start": {
+      "line": 1049,
+      "column": 44
+    },
+    "end": {
+      "line": 1053,
+      "column": 10
+    }
+  },
+  "file": "src/cmds/rust/cargo_cmd.rs",
+  "lines": "        static RE: LazyLock<regex::Regex> = LazyLock::new(|| {\n            regex::Regex::new(\n                r\"test result: (\\w+)\\.\\s+(\\d+) passed;\\s+(\\d+) failed;\\s+(\\d+) ignored;\\s+(\\d+) measured;\\s+(\\d+) filtered out(?:;\\s+finished in ([\\d.]+)s)?\"\n            ).unwrap()\n        });",
+  "charCount": {
+    "leading": 44,
+    "trailing": 1
+  },
+  "language": "Rust"
+},
+{
+  "text": "LazyLock::new(|| Regex::new(r\"^(upload|download|delete|copy|move):\").unwrap())",
+  "range": {
+    "byteOffset": {
+      "start": 45536,
+      "end": 45614
+    },
+    "start": {
+      "line": 1326,
+      "column": 4
+    },
+    "end": {
+      "line": 1326,
+      "column": 82
+    }
+  },
+  "file": "src/cmds/cloud/aws_cmd.rs",
+  "lines": "    LazyLock::new(|| Regex::new(r\"^(upload|download|delete|copy|move):\").unwrap());",
+  "charCount": {
+    "leading": 4,
+    "trailing": 1
+  },
+  "language": "Rust"
+}
+]

--- a/tests/fixtures/ast_grep_lazylock_raw.txt
+++ b/tests/fixtures/ast_grep_lazylock_raw.txt
@@ -1,0 +1,387 @@
+src/learn/detector.rs:51:static UNKNOWN_FLAG_RE: LazyLock<Regex> = LazyLock::new(|| {
+src/learn/detector.rs:52:    Regex::new(
+src/learn/detector.rs:53:        r"(?i)(unexpected argument|unknown (option|flag)|unrecognized (option|flag)|invalid (option|flag))"
+src/learn/detector.rs:54:    ).unwrap()
+src/learn/detector.rs:55:});
+src/learn/detector.rs:57:static CMD_NOT_FOUND_RE: LazyLock<Regex> = LazyLock::new(|| {
+src/learn/detector.rs:58:    Regex::new(
+src/learn/detector.rs:59:        r"(?i)(command not found|not recognized as an internal|no such file or directory.*command)",
+src/learn/detector.rs:60:    )
+src/learn/detector.rs:61:    .unwrap()
+src/learn/detector.rs:62:});
+src/learn/detector.rs:64:static WRONG_PATH_RE: LazyLock<Regex> = LazyLock::new(|| {
+src/learn/detector.rs:65:    Regex::new(r"(?i)(no such file or directory|cannot find the path|file not found)").unwrap()
+src/learn/detector.rs:66:});
+src/learn/detector.rs:68:static MISSING_ARG_RE: LazyLock<Regex> = LazyLock::new(|| {
+src/learn/detector.rs:69:    Regex::new(
+src/learn/detector.rs:70:        r"(?i)(requires a value|requires an argument|missing (required )?argument|expected.*argument)"
+src/learn/detector.rs:71:    ).unwrap()
+src/learn/detector.rs:72:});
+src/learn/detector.rs:75:    LazyLock::new(|| Regex::new(r"(?i)(permission denied|access denied|not permitted)").unwrap());
+src/learn/detector.rs:78:static USER_REJECTION_RE: LazyLock<Regex> = LazyLock::new(|| {
+src/learn/detector.rs:79:    Regex::new(
+src/learn/detector.rs:80:        r"(?i)(user (doesn't want|declined|rejected|cancelled)|operation (cancelled|aborted) by user)"
+src/learn/detector.rs:81:    ).unwrap()
+src/learn/detector.rs:82:});
+src/cmds/git/gh_cmd.rs:16:static HTML_COMMENT_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?s)<!--.*?-->").unwrap());
+src/cmds/git/gh_cmd.rs:18:    LazyLock::new(|| Regex::new(r"(?m)^\s*\[!\[[^\]]*\]\([^)]*\)\]\([^)]*\)\s*$").unwrap());
+src/cmds/git/gh_cmd.rs:20:    LazyLock::new(|| Regex::new(r"(?m)^\s*!\[[^\]]*\]\([^)]*\)\s*$").unwrap());
+src/cmds/git/gh_cmd.rs:22:    LazyLock::new(|| Regex::new(r"(?m)^\s*(?:---+|\*\*\*+|___+)\s*$").unwrap());
+src/cmds/git/gh_cmd.rs:23:static MULTI_BLANK_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\n{3,}").unwrap());
+src/cmds/system/ctest_cmd.rs:24:static TEST_RE: LazyLock<Regex> = LazyLock::new(|| {
+src/cmds/system/ctest_cmd.rs:25:    Regex::new(
+src/cmds/system/ctest_cmd.rs:26:        r"(?s)^\s*(?:\d+/(\d+)\s+)?Test\s+#(\d+):\s+(.+?)\s+\.{2,}\s*(?:\*{3})?\s*(.+?)\s+([\d.]+)\s+sec\s*$",
+src/cmds/system/ctest_cmd.rs:27:    )
+src/cmds/system/ctest_cmd.rs:28:    .expect("invalid ctest result regex")
+src/cmds/system/ctest_cmd.rs:29:});
+src/cmds/system/ctest_cmd.rs:30:static RESULT_PREFIX_RE: LazyLock<Regex> = LazyLock::new(|| {
+src/cmds/system/ctest_cmd.rs:31:    Regex::new(r"^\s*(?:\d+/\d+\s+)?Test\s+#\d+:")
+src/cmds/system/ctest_cmd.rs:32:        .expect("invalid ctest result prefix regex")
+src/cmds/system/ctest_cmd.rs:33:});
+src/cmds/system/ctest_cmd.rs:34:static RESULT_TERMINATOR_RE: LazyLock<Regex> = LazyLock::new(|| {
+src/cmds/system/ctest_cmd.rs:35:    Regex::new(r"[\d.]+\s+sec\s*$").expect("invalid ctest result terminator regex")
+src/cmds/system/ctest_cmd.rs:36:});
+src/cmds/system/ctest_cmd.rs:37:static START_RE: LazyLock<Regex> = LazyLock::new(|| {
+src/cmds/system/ctest_cmd.rs:38:    Regex::new(r"^\s*Start\s+(\d+):\s*(.*?)\s*$").expect("invalid ctest start regex")
+src/cmds/system/ctest_cmd.rs:39:});
+src/cmds/system/ctest_cmd.rs:40:static SUMMARY_RE: LazyLock<Regex> = LazyLock::new(|| {
+src/cmds/system/ctest_cmd.rs:41:    Regex::new(r"^\s*\d+%\s+tests passed,\s+(\d+)\s+tests failed out of\s+(\d+)")
+src/cmds/system/ctest_cmd.rs:42:        .expect("invalid ctest summary regex")
+src/cmds/system/ctest_cmd.rs:43:});
+src/cmds/system/ctest_cmd.rs:44:static TIME_RE: LazyLock<Regex> = LazyLock::new(|| {
+src/cmds/system/ctest_cmd.rs:45:    Regex::new(r"^\s*Total Test time \(real\)\s+=\s+([\d.]+)\s+sec")
+src/cmds/system/ctest_cmd.rs:46:        .expect("invalid ctest time regex")
+src/cmds/system/ctest_cmd.rs:47:});
+src/cmds/git/glab_cmd.rs:23:static HTML_COMMENT_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?s)<!--.*?-->").unwrap());
+src/cmds/git/glab_cmd.rs:25:    LazyLock::new(|| Regex::new(r"(?m)^\s*\[!\[[^\]]*\]\([^)]*\)\]\([^)]*\)\s*$").unwrap());
+src/cmds/git/glab_cmd.rs:27:    LazyLock::new(|| Regex::new(r"(?m)^\s*!\[[^\]]*\]\([^)]*\)\s*$").unwrap());
+src/cmds/git/glab_cmd.rs:29:    LazyLock::new(|| Regex::new(r"(?m)^\s*(?:---+|\*\*\*+|___+)\s*$").unwrap());
+src/cmds/git/glab_cmd.rs:30:static MULTI_BLANK_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\n{3,}").unwrap());
+src/cmds/git/glab_cmd.rs:32:    LazyLock::new(|| Regex::new(r"/-/merge_requests/(\d+)").unwrap());
+src/cmds/git/glab_cmd.rs:34:static SECTION_MARKER_RE: LazyLock<Regex> = LazyLock::new(|| {
+src/cmds/git/glab_cmd.rs:35:    Regex::new(r"section_(?:start|end):\d+:[a-z0-9_]+(?:\x1b\[0K|\[0K)*").unwrap()
+src/cmds/git/glab_cmd.rs:36:});
+src/cmds/git/glab_cmd.rs:38:static BARE_ANSI_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\[[\d;]+[A-Za-z]").unwrap());
+src/cmds/ruby/rake_cmd.rs:168:        LazyLock::new(|| regex::Regex::new(r"^\d+\)\s+(Failure|Error):$").unwrap());
+src/cmds/system/ls.rs:14:static LS_DATE_RE: LazyLock<Regex> = LazyLock::new(|| {
+src/cmds/system/ls.rs:15:    Regex::new(
+src/cmds/system/ls.rs:16:        r"\s+(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+\d{1,2}\s+(?:\d{4}|\d{2}:\d{2})\s+"
+src/cmds/system/ls.rs:17:    )
+src/cmds/system/ls.rs:18:    .unwrap()
+src/cmds/system/ls.rs:19:});
+src/cmds/git/gt_cmd.rs:13:    LazyLock::new(|| Regex::new(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b").unwrap());
+src/cmds/git/gt_cmd.rs:14:static BRANCH_NAME_RE: LazyLock<Regex> = LazyLock::new(|| {
+src/cmds/git/gt_cmd.rs:15:    Regex::new(
+src/cmds/git/gt_cmd.rs:16:        r#"(?:Created|Pushed|pushed|Deleted|deleted)\s+branch\s+[`"']?([a-zA-Z0-9/_.\-+@]+)"#,
+src/cmds/git/gt_cmd.rs:17:    )
+src/cmds/git/gt_cmd.rs:18:    .unwrap()
+src/cmds/git/gt_cmd.rs:19:});
+src/cmds/git/gt_cmd.rs:20:static PR_LINE_RE: LazyLock<Regex> = LazyLock::new(|| {
+src/cmds/git/gt_cmd.rs:21:    Regex::new(r"(Created|Updated)\s+pull\s+request\s+#(\d+)\s+for\s+([^\s:]+)(?::\s*(\S+))?")
+src/cmds/git/gt_cmd.rs:22:        .unwrap()
+src/cmds/git/gt_cmd.rs:23:});
+src/cmds/system/search.rs:739:        LazyLock::new(|| Regex::new(r"^([^\x00]+)\x00(\d+)([:-])(.*)$").unwrap());
+src/discover/registry.rs:54:static REGEX_SET: LazyLock<RegexSet> = LazyLock::new(|| {
+src/discover/registry.rs:55:    RegexSet::new(RULES.iter().map(|r| r.pattern)).expect("invalid regex patterns")
+src/discover/registry.rs:56:});
+src/discover/registry.rs:57:static COMPILED: LazyLock<Vec<Regex>> = LazyLock::new(|| {
+src/discover/registry.rs:58:    RULES
+src/discover/registry.rs:59:        .iter()
+src/discover/registry.rs:60:        .map(|r| Regex::new(r.pattern).expect("invalid regex"))
+src/discover/registry.rs:61:        .collect()
+src/discover/registry.rs:62:});
+src/discover/registry.rs:63:static ENV_PREFIX: LazyLock<Regex> = LazyLock::new(|| {
+src/discover/registry.rs:64:    let double_quoted = r#""(?:[^"\\]|\\.)*""#;
+src/discover/registry.rs:65:    let single_quoted = r#"'(?:[^'\\]|\\.)*'"#;
+src/discover/registry.rs:66:    let unquoted = r#"[^\s]*"#;
+src/discover/registry.rs:67:    let env_value = format!("(?:{}|{}|{})", double_quoted, single_quoted, unquoted);
+src/discover/registry.rs:68:    let env_assign = format!(r#"[A-Z_][A-Z0-9_]*={}"#, env_value);
+src/discover/registry.rs:69:    Regex::new(&format!(r#"^(?:sudo\s+|env\s+|{}\s+)+"#, env_assign)).unwrap()
+src/discover/registry.rs:70:});
+src/discover/registry.rs:73:static GIT_GLOBAL_OPT: LazyLock<Regex> = LazyLock::new(|| {
+src/discover/registry.rs:74:    Regex::new(r"^(?:(?:-C\s+\S+|-c\s+\S+|--git-dir(?:=\S+|\s+\S+)|--work-tree(?:=\S+|\s+\S+)|--no-pager|--no-optional-locks|--bare|--literal-pathspecs)\s+)+").unwrap()
+src/discover/registry.rs:75:});
+src/discover/registry.rs:80:static HEAD_N: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^head\s+-(\d+)\s+(\S+)$").unwrap());
+src/discover/registry.rs:82:    LazyLock::new(|| Regex::new(r"^head\s+--lines=(\d+)\s+(\S+)$").unwrap());
+src/discover/registry.rs:83:static TAIL_N: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^tail\s+-(\d+)\s+(\S+)$").unwrap());
+src/discover/registry.rs:85:    LazyLock::new(|| Regex::new(r"^tail\s+-n\s+(\d+)\s+(\S+)$").unwrap());
+src/discover/registry.rs:87:    LazyLock::new(|| Regex::new(r"^tail\s+--lines=(\d+)\s+(\S+)$").unwrap());
+src/discover/registry.rs:89:    LazyLock::new(|| Regex::new(r"^tail\s+--lines\s+(\d+)\s+(\S+)$").unwrap());
+src/discover/registry.rs:539:    LazyLock::new(|| Regex::new(r"(?m)[ \t\x0B\x0C]*\\\r?\n[ \t\x0B\x0C]*").unwrap());
+src/discover/registry.rs:541:static BASH_JOIN_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\\\r?\n").unwrap());
+src/cmds/system/log_cmd.rs:14:static TIMESTAMP_RE: LazyLock<Regex> = LazyLock::new(|| {
+src/cmds/system/log_cmd.rs:15:    Regex::new(r"^\d{4}[-/]\d{2}[-/]\d{2}[T ]\d{2}:\d{2}:\d{2}[.,]?\d*\s*").unwrap()
+src/cmds/system/log_cmd.rs:16:});
+src/cmds/system/log_cmd.rs:17:static UUID_RE: LazyLock<Regex> = LazyLock::new(|| {
+src/cmds/system/log_cmd.rs:18:    Regex::new(r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}")
+src/cmds/system/log_cmd.rs:19:        .unwrap()
+src/cmds/system/log_cmd.rs:20:});
+src/cmds/system/log_cmd.rs:21:static HEX_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"0x[0-9a-fA-F]+").unwrap());
+src/cmds/system/log_cmd.rs:22:static NUM_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\b\d{4,}\b").unwrap());
+src/cmds/system/log_cmd.rs:23:static PATH_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"/[\w./\-]+").unwrap());
+src/cmds/ruby/rspec_cmd.rs:22:    LazyLock::new(|| Regex::new(r"(?i)running via spring preloader").unwrap());
+src/cmds/ruby/rspec_cmd.rs:23:static RE_SIMPLECOV: LazyLock<Regex> = LazyLock::new(|| {
+src/cmds/ruby/rspec_cmd.rs:24:    Regex::new(r"(?i)(coverage report|simplecov|coverage/|\.simplecov|All Files.*Lines)").unwrap()
+src/cmds/ruby/rspec_cmd.rs:25:});
+src/cmds/ruby/rspec_cmd.rs:27:    LazyLock::new(|| Regex::new(r"^DEPRECATION WARNING:").unwrap());
+src/cmds/ruby/rspec_cmd.rs:28:static RE_FINISHED_IN: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^Finished in \d").unwrap());
+src/cmds/ruby/rspec_cmd.rs:30:    LazyLock::new(|| Regex::new(r"saved screenshot to (.+)").unwrap());
+src/cmds/ruby/rspec_cmd.rs:32:    LazyLock::new(|| Regex::new(r"(\d+) examples?, (\d+) failures?").unwrap());
+src/cmds/js/playwright_cmd.rs:168:        LazyLock::new(|| Regex::new(r"(\d+)\s+(passed|failed|flaky|skipped)").unwrap());
+src/cmds/js/playwright_cmd.rs:170:        LazyLock::new(|| Regex::new(r"\((\d+(?:\.\d+)?)(ms|s|m)\)").unwrap());
+src/cmds/js/playwright_cmd.rs:220:        LazyLock::new(|| Regex::new(r"[×✗]\s+.*?›\s+([^›]+\.spec\.[tj]sx?)").unwrap());
+src/cmds/js/next_cmd.rs:45:    static BUNDLE_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
+src/cmds/js/next_cmd.rs:46:        Regex::new(r"^[○●◐λ✓]\s+([\w/\-\.]+)\s+(\d+(?:\.\d+)?)\s*(kB|B)\s+(\d+(?:\.\d+)?)\s*(kB|B)")
+src/cmds/js/next_cmd.rs:47:            .unwrap()
+src/cmds/js/next_cmd.rs:48:    });
+src/cmds/js/next_cmd.rs:172:        LazyLock::new(|| Regex::new(r"(\d+(?:\.\d+)?)\s*(s|ms)").unwrap());
+src/cmds/php/artisan_cmd.rs:8:static BOX_CHARS_RE: LazyLock<Regex> = LazyLock::new(|| {
+src/cmds/php/artisan_cmd.rs:9:    Regex::new(r"[\u{2500}-\u{257F}\u{2580}-\u{259F}\u{25A0}-\u{25FF}\u{27A0}-\u{27BF}]+").unwrap()
+src/cmds/php/artisan_cmd.rs:10:});
+src/cmds/php/artisan_cmd.rs:11:static DOTS_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\.{3,}").unwrap());
+src/cmds/php/artisan_cmd.rs:12:static MULTI_SPACE_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"[ \t]{2,}").unwrap());
+src/cmds/php/artisan_cmd.rs:13:static MULTI_BLANK_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\n{3,}").unwrap());
+src/cmds/jvm/gradlew_cmd.rs:13:static TASK_LINE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^> Task :").unwrap());
+src/cmds/jvm/gradlew_cmd.rs:15:    LazyLock::new(|| Regex::new(r"^\* Try:|^> Run with --|^> Get more help at").unwrap());
+src/cmds/jvm/gradlew_cmd.rs:17:    LazyLock::new(|| Regex::new(r"^BUILD (SUCCESSFUL|FAILED)").unwrap());
+src/cmds/jvm/gradlew_cmd.rs:19:    LazyLock::new(|| Regex::new(r"^\d+ actionable tasks?").unwrap());
+src/cmds/jvm/gradlew_cmd.rs:180:    static DAEMON_LINE: LazyLock<Regex> = LazyLock::new(|| {
+src/cmds/jvm/gradlew_cmd.rs:181:        Regex::new(
+src/cmds/jvm/gradlew_cmd.rs:182:            r"^(Starting a Gradle Daemon|Daemon will be stopped|Reusing configuration cache|Calculating task graph|> Configure project|Deprecated Gradle features|You can use|For more on this|Configuration cache entry)"
+src/cmds/jvm/gradlew_cmd.rs:183:        )
+src/cmds/jvm/gradlew_cmd.rs:184:        .unwrap()
+src/cmds/jvm/gradlew_cmd.rs:185:    });
+src/cmds/jvm/gradlew_cmd.rs:186:    static PROGRESS: LazyLock<Regex> = LazyLock::new(|| {
+src/cmds/jvm/gradlew_cmd.rs:187:        Regex::new(r"^\s*\d+%|^Downloading|^Configuring|^Resolving|^\[Incubating\]|^Wrote HTML report|^class \S+ could not|^\[android-")
+src/cmds/jvm/gradlew_cmd.rs:188:                .unwrap()
+src/cmds/jvm/gradlew_cmd.rs:189:    });
+src/cmds/jvm/gradlew_cmd.rs:190:    static ERROR_LINE: LazyLock<Regex> = LazyLock::new(|| {
+src/cmds/jvm/gradlew_cmd.rs:191:        Regex::new(
+src/cmds/jvm/gradlew_cmd.rs:192:            r"(?i)(^FAILURE:|^\* What went wrong:|^\* Where:|> Could not|e: |error:|^Execution failed|Lint found \d+ error)"
+src/cmds/jvm/gradlew_cmd.rs:193:        )
+src/cmds/jvm/gradlew_cmd.rs:194:        .unwrap()
+src/cmds/jvm/gradlew_cmd.rs:195:    });
+src/cmds/jvm/gradlew_cmd.rs:198:        LazyLock::new(|| Regex::new(r"^(w: |warning:|Warning:|WARNING:)").unwrap());
+src/cmds/jvm/gradlew_cmd.rs:200:        LazyLock::new(|| Regex::new(r"gradle\.com/s/|Publishing build scan").unwrap());
+src/cmds/jvm/gradlew_cmd.rs:234:        LazyLock::new(|| Regex::new(r"FAILED$| FAILED ").unwrap());
+src/cmds/jvm/gradlew_cmd.rs:236:        LazyLock::new(|| Regex::new(r" PASSED$| SKIPPED$").unwrap());
+src/cmds/jvm/gradlew_cmd.rs:237:    static SUMMARY_LINE: LazyLock<Regex> = LazyLock::new(|| {
+src/cmds/jvm/gradlew_cmd.rs:238:        Regex::new(
+src/cmds/jvm/gradlew_cmd.rs:239:            r"\d+ tests? completed|\d+ tests? failed|There were failing tests|See the report at",
+src/cmds/jvm/gradlew_cmd.rs:240:        )
+src/cmds/jvm/gradlew_cmd.rs:241:        .unwrap()
+src/cmds/jvm/gradlew_cmd.rs:242:    });
+src/cmds/jvm/gradlew_cmd.rs:312:        LazyLock::new(|| Regex::new(r"^INSTRUMENTATION_STATUS[_CODE]*:").unwrap());
+src/cmds/jvm/gradlew_cmd.rs:314:        LazyLock::new(|| Regex::new(r"^INSTRUMENTATION_RESULT:").unwrap());
+src/cmds/jvm/gradlew_cmd.rs:316:        LazyLock::new(|| Regex::new(r"^INSTRUMENTATION_CODE:").unwrap());
+src/cmds/jvm/gradlew_cmd.rs:318:        LazyLock::new(|| Regex::new(r"^Starting \d+ tests? on ").unwrap());
+src/cmds/jvm/gradlew_cmd.rs:320:        LazyLock::new(|| Regex::new(r"^Installing APK").unwrap());
+src/cmds/jvm/gradlew_cmd.rs:363:        LazyLock::new(|| Regex::new(r"[^:]+:\d+:.*[Ee]rror:.*\[").unwrap());
+src/cmds/jvm/gradlew_cmd.rs:366:        LazyLock::new(|| Regex::new(r"[^:]+:\d+:.*[Ww]arning:.*\[").unwrap());
+src/cmds/jvm/gradlew_cmd.rs:369:        LazyLock::new(|| Regex::new(r"[^:]+:\d+:\d+:.*[Ll]int").unwrap());
+src/cmds/jvm/gradlew_cmd.rs:372:        LazyLock::new(|| Regex::new(r"[^:]+:\d+:\d+:.*error").unwrap());
+src/cmds/jvm/gradlew_cmd.rs:375:        LazyLock::new(|| Regex::new(r"\d+ (issues?|errors?|warnings?)").unwrap());
+src/cmds/jvm/gradlew_cmd.rs:377:    static REPORT_LINE: LazyLock<Regex> = LazyLock::new(|| {
+src/cmds/jvm/gradlew_cmd.rs:378:        Regex::new(r"Wrote (HTML|XML|text) report|file://|/build/reports/lint").unwrap()
+src/cmds/jvm/gradlew_cmd.rs:379:    });
+src/cmds/php/utils.rs:7:static ANSI_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\x1b\[[0-9;]*[A-Za-z]").unwrap());
+src/cmds/php/utils.rs:9:    LazyLock::new(|| Regex::new(r"[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]").unwrap());
+src/cmds/cloud/psql_cmd.rs:17:    LazyLock::new(|| Regex::new(r"-\[ RECORD \d+ \]-").unwrap());
+src/cmds/cloud/psql_cmd.rs:18:static SEPARATOR: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^[-+]+$").unwrap());
+src/cmds/cloud/psql_cmd.rs:19:static ROW_COUNT: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^\(\d+ rows?\)$").unwrap());
+src/cmds/cloud/psql_cmd.rs:21:    LazyLock::new(|| Regex::new(r"^-\[ RECORD (\d+) \]-").unwrap());
+src/cmds/php/phpunit_cmd.rs:20:static FAILURE_HEADING_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^\d+\) \S").unwrap());
+src/cmds/rust/runner.rs:13:static ERROR_PATTERNS: LazyLock<Vec<Regex>> = LazyLock::new(|| {
+src/cmds/rust/runner.rs:14:    vec![
+src/cmds/rust/runner.rs:15:        // Generic errors
+src/cmds/rust/runner.rs:16:        Regex::new(r"(?i)^.*error[\s:\[].*$").unwrap(),
+src/cmds/rust/runner.rs:17:        Regex::new(r"(?i)^.*\berr\b.*$").unwrap(),
+src/cmds/rust/runner.rs:18:        Regex::new(r"(?i)^.*warning[\s:\[].*$").unwrap(),
+src/cmds/rust/runner.rs:19:        Regex::new(r"(?i)^.*\bwarn\b.*$").unwrap(),
+src/cmds/rust/runner.rs:20:        Regex::new(r"(?i)^.*failed.*$").unwrap(),
+src/cmds/rust/runner.rs:21:        Regex::new(r"(?i)^.*failure.*$").unwrap(),
+src/cmds/rust/runner.rs:22:        Regex::new(r"(?i)^.*exception.*$").unwrap(),
+src/cmds/rust/runner.rs:23:        Regex::new(r"(?i)^.*panic.*$").unwrap(),
+src/cmds/rust/runner.rs:24:        // Rust specific
+src/cmds/rust/runner.rs:25:        Regex::new(r"^error\[E\d+\]:.*$").unwrap(),
+src/cmds/rust/runner.rs:26:        Regex::new(r"^\s*--> .*:\d+:\d+$").unwrap(),
+src/cmds/rust/runner.rs:27:        // Python
+src/cmds/rust/runner.rs:28:        Regex::new(r"^Traceback.*$").unwrap(),
+src/cmds/rust/runner.rs:29:        Regex::new(r#"^\s*File ".*", line \d+.*$"#).unwrap(),
+src/cmds/rust/runner.rs:30:        // JavaScript/TypeScript
+src/cmds/rust/runner.rs:31:        Regex::new(r"^\s*at .*:\d+:\d+.*$").unwrap(),
+src/cmds/rust/runner.rs:32:        // Go
+src/cmds/rust/runner.rs:33:        Regex::new(r"^.*\.go:\d+:.*$").unwrap(),
+src/cmds/rust/runner.rs:34:    ]
+src/cmds/rust/runner.rs:35:});
+src/cmds/js/vitest_cmd.rs:121:        LazyLock::new(|| Regex::new(r"Tests\s+(?:(\d+)\s+failed\s+\|\s+)?(\d+)\s+passed").unwrap());
+src/cmds/js/vitest_cmd.rs:123:        LazyLock::new(|| Regex::new(r"Duration\s+([\d.]+)(ms|s)").unwrap());
+src/cmds/dotnet/binlog.rs:55:static ISSUE_RE: LazyLock<Regex> = LazyLock::new(|| {
+src/cmds/dotnet/binlog.rs:56:    Regex::new(
+src/cmds/dotnet/binlog.rs:57:        r"(?m)^\s*(?P<file>[^\r\n:(]+)\((?P<line>\d+),(?P<column>\d+)\):\s*(?P<kind>error|warning)\s*(?:(?P<code>[A-Za-z]+\d+)\s*:\s*)?(?P<msg>.*)$"
+src/cmds/dotnet/binlog.rs:58:    )
+src/cmds/dotnet/binlog.rs:59:    .expect("valid regex")
+src/cmds/dotnet/binlog.rs:60:});
+src/cmds/dotnet/binlog.rs:61:static BUILD_SUMMARY_RE: LazyLock<Regex> = LazyLock::new(|| {
+src/cmds/dotnet/binlog.rs:62:    Regex::new(r"(?mi)^\s*(?P<count>\d+)\s+(?P<kind>warning|error)\(s\)").expect("valid regex")
+src/cmds/dotnet/binlog.rs:63:});
+src/cmds/dotnet/binlog.rs:65:    LazyLock::new(|| Regex::new(r"(?i)\b(?P<count>\d+)\s+error\(s\)").expect("valid regex"));
+src/cmds/dotnet/binlog.rs:67:    LazyLock::new(|| Regex::new(r"(?i)\b(?P<count>\d+)\s+warning\(s\)").expect("valid regex"));
+src/cmds/dotnet/binlog.rs:68:static FALLBACK_ERROR_LINE_RE: LazyLock<Regex> = LazyLock::new(|| {
+src/cmds/dotnet/binlog.rs:69:    Regex::new(r"(?mi)^.+\(\d+,\d+\):\s*error(?:\s+[A-Za-z]{2,}\d{3,})?(?:\s*:.*)?$")
+src/cmds/dotnet/binlog.rs:70:        .expect("valid regex")
+src/cmds/dotnet/binlog.rs:71:});
+src/cmds/dotnet/binlog.rs:72:static FALLBACK_WARNING_LINE_RE: LazyLock<Regex> = LazyLock::new(|| {
+src/cmds/dotnet/binlog.rs:73:    Regex::new(r"(?mi)^.+\(\d+,\d+\):\s*warning(?:\s+[A-Za-z]{2,}\d{3,})?(?:\s*:.*)?$")
+src/cmds/dotnet/binlog.rs:74:        .expect("valid regex")
+src/cmds/dotnet/binlog.rs:75:});
+src/cmds/dotnet/binlog.rs:76:static DURATION_RE: LazyLock<Regex> = LazyLock::new(|| {
+src/cmds/dotnet/binlog.rs:77:    Regex::new(r"(?m)^\s*Time Elapsed\s+(?P<duration>[^\r\n]+)$").expect("valid regex")
+src/cmds/dotnet/binlog.rs:78:});
+src/cmds/dotnet/binlog.rs:79:static TEST_RESULT_RE: LazyLock<Regex> = LazyLock::new(|| {
+src/cmds/dotnet/binlog.rs:80:    Regex::new(
+src/cmds/dotnet/binlog.rs:81:        r"(?m)(?:Passed!|Failed!)\s*-\s*Failed:\s*(?P<failed>\d+),\s*Passed:\s*(?P<passed>\d+),\s*Skipped:\s*(?P<skipped>\d+),\s*Total:\s*(?P<total>\d+),\s*Duration:\s*(?P<duration>[^\r\n-]+)"
+src/cmds/dotnet/binlog.rs:82:    )
+src/cmds/dotnet/binlog.rs:83:    .expect("valid regex")
+src/cmds/dotnet/binlog.rs:84:});
+src/cmds/dotnet/binlog.rs:85:static TEST_SUMMARY_RE: LazyLock<Regex> = LazyLock::new(|| {
+src/cmds/dotnet/binlog.rs:86:    Regex::new(
+src/cmds/dotnet/binlog.rs:87:        r"(?mi)^\s*Test summary:\s*total:\s*(?P<total>\d+),\s*failed:\s*(?P<failed>\d+),\s*(?:succeeded|passed):\s*(?P<passed>\d+),\s*skipped:\s*(?P<skipped>\d+),\s*duration:\s*(?P<duration>[^\r\n]+)$"
+src/cmds/dotnet/binlog.rs:88:    )
+src/cmds/dotnet/binlog.rs:89:    .expect("valid regex")
+src/cmds/dotnet/binlog.rs:90:});
+src/cmds/dotnet/binlog.rs:91:static FAILED_TEST_HEAD_RE: LazyLock<Regex> = LazyLock::new(|| {
+src/cmds/dotnet/binlog.rs:92:    Regex::new(r"(?m)^\s*Failed\s+(?P<name>[^\r\n\[]+)\s+\[[^\]\r\n]+\]\s*$").expect("valid regex")
+src/cmds/dotnet/binlog.rs:93:});
+src/cmds/dotnet/binlog.rs:95:    LazyLock::new(|| Regex::new(r"(?m)^\s*Restored\s+.+\.csproj\s*\(").expect("valid regex"));
+src/cmds/dotnet/binlog.rs:96:static RESTORE_DIAGNOSTIC_RE: LazyLock<Regex> = LazyLock::new(|| {
+src/cmds/dotnet/binlog.rs:97:    Regex::new(
+src/cmds/dotnet/binlog.rs:98:        r"(?mi)^\s*(?:(?P<file>.+?)\s+:\s+)?(?P<kind>warning|error)\s+(?P<code>[A-Za-z]{2,}\d{3,})\s*:\s*(?P<msg>.+)$"
+src/cmds/dotnet/binlog.rs:99:    )
+src/cmds/dotnet/binlog.rs:100:    .expect("valid regex")
+src/cmds/dotnet/binlog.rs:101:});
+src/cmds/dotnet/binlog.rs:102:static PROJECT_PATH_RE: LazyLock<Regex> = LazyLock::new(|| {
+src/cmds/dotnet/binlog.rs:103:    Regex::new(r"(?m)^\s*([A-Za-z]:)?[^\r\n]*\.csproj(?:\s|$)").expect("valid regex")
+src/cmds/dotnet/binlog.rs:104:});
+src/cmds/dotnet/binlog.rs:106:    LazyLock::new(|| Regex::new(r"[\x20-\x7E]{5,}").expect("valid regex"));
+src/cmds/dotnet/binlog.rs:108:    LazyLock::new(|| Regex::new(r"^[A-Za-z]{2,}\d{3,}$").expect("valid regex"));
+src/cmds/dotnet/binlog.rs:110:    LazyLock::new(|| Regex::new(r"(?i)([A-Za-z]:)?[/\\][^\s]+\.(cs|vb|fs)").expect("valid regex"));
+src/cmds/dotnet/binlog.rs:111:static SENSITIVE_ENV_RE: LazyLock<Regex> = LazyLock::new(|| {
+src/cmds/dotnet/binlog.rs:112:    let keys = SENSITIVE_ENV_VARS
+src/cmds/dotnet/binlog.rs:113:        .iter()
+src/cmds/dotnet/binlog.rs:114:        .map(|key| regex::escape(key))
+src/cmds/dotnet/binlog.rs:115:        .collect::<Vec<_>>()
+src/cmds/dotnet/binlog.rs:116:        .join("|");
+src/cmds/dotnet/binlog.rs:117:    Regex::new(&format!(
+src/cmds/dotnet/binlog.rs:118:        r"(?P<prefix>\b(?:{})\s*(?:=|:)\s*)(?P<value>[^\s;]+)",
+src/cmds/dotnet/binlog.rs:119:        keys
+src/cmds/dotnet/binlog.rs:120:    ))
+src/cmds/dotnet/binlog.rs:121:    .expect("valid regex")
+src/cmds/dotnet/binlog.rs:122:});
+src/cmds/jvm/mvn_cmd.rs:34:static RUNNING: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^\[INFO\] Running ").unwrap());
+src/cmds/jvm/mvn_cmd.rs:45:    LazyLock::new(|| Regex::new(r"^\[INFO\] Running \S+\s*$").unwrap());
+src/cmds/jvm/mvn_cmd.rs:55:static CLOSE: LazyLock<Regex> = LazyLock::new(|| {
+src/cmds/jvm/mvn_cmd.rs:56:    Regex::new(
+src/cmds/jvm/mvn_cmd.rs:57:        r"^\[(?:INFO|ERROR|WARNING)\] Tests run: \d+, Failures: (\d+), Errors: (\d+), Skipped: \d+, Time elapsed: [^ ]+ s(?:\s+<<<\s*(?:FAILURE|ERROR)!)?\s+--?\s+in (.+)$"
+src/cmds/jvm/mvn_cmd.rs:58:    ).unwrap()
+src/cmds/jvm/mvn_cmd.rs:59:});
+src/cmds/jvm/mvn_cmd.rs:63:    LazyLock::new(|| Regex::new(r"^\[(?:INFO|ERROR)\] BUILD (?:SUCCESS|FAILURE)$").unwrap());
+src/cmds/jvm/mvn_cmd.rs:66:static RESULTS: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^\[INFO\] Results:\s*$").unwrap());
+src/cmds/jvm/mvn_cmd.rs:69:static AGG: LazyLock<Regex> = LazyLock::new(|| {
+src/cmds/jvm/mvn_cmd.rs:70:    Regex::new(r"^\[(?:INFO|ERROR)\] Tests run: \d+, Failures: \d+, Errors: \d+, Skipped: \d+\s*$")
+src/cmds/jvm/mvn_cmd.rs:71:        .unwrap()
+src/cmds/jvm/mvn_cmd.rs:72:});
+src/cmds/jvm/mvn_cmd.rs:76:    LazyLock::new(|| Regex::new(r"^\[INFO\] --- .* @ .* ---$").unwrap());
+src/cmds/jvm/mvn_cmd.rs:109:static TEST_PLUGIN_BANNER: LazyLock<Regex> = LazyLock::new(|| {
+src/cmds/jvm/mvn_cmd.rs:110:    Regex::new(r"^\[INFO\] --- (?:maven-)?(surefire|failsafe)(?:-plugin)?:\S+ \([^)]*\) @ .* ---$")
+src/cmds/jvm/mvn_cmd.rs:111:        .unwrap()
+src/cmds/jvm/mvn_cmd.rs:112:});
+src/cmds/jvm/mvn_cmd.rs:125:    LazyLock::new(|| Regex::new(r"^\[INFO\] Building .*\[\d+/\d+\]\s*$").unwrap());
+src/cmds/jvm/mvn_cmd.rs:129:    LazyLock::new(|| Regex::new(r"^\[INFO\] -+< .+ >-+$").unwrap());
+src/cmds/jvm/mvn_cmd.rs:134:    LazyLock::new(|| Regex::new(r"^\[INFO\] Reactor Summary for ").unwrap());
+src/cmds/jvm/mvn_cmd.rs:138:    LazyLock::new(|| Regex::new(r"/[^:]+\.java:\[\d+,\d+\]").unwrap());
+src/cmds/php/phpt_cmd.rs:163:    static STATUS_RE: LazyLock<Regex> = LazyLock::new(|| {
+src/cmds/php/phpt_cmd.rs:164:        // Matches a status line. Anchor: either start-of-line ("FAIL desc [x.phpt]")
+src/cmds/php/phpt_cmd.rs:165:        // or immediately after the test bracket ("TEST N/M [x.phpt]PASS desc [x.phpt]").
+src/cmds/php/phpt_cmd.rs:166:        // We only accept the token after `]` or at line start so that prose like
+src/cmds/php/phpt_cmd.rs:167:        // "FAILED TEST SUMMARY" does not match.
+src/cmds/php/phpt_cmd.rs:168:        Regex::new(
+src/cmds/php/phpt_cmd.rs:169:            r"(?:^|\])(PASS|FAIL|SKIP|BORK|WARN|XLEAK|LEAK|XFAIL)\s+(.*?)\s*\[([^\[\]]+\.phpt)\]",
+src/cmds/php/phpt_cmd.rs:170:        )
+src/cmds/php/phpt_cmd.rs:171:        .unwrap()
+src/cmds/php/phpt_cmd.rs:172:    });
+src/cmds/php/phpt_cmd.rs:173:    static STAT_RE: LazyLock<Regex> = LazyLock::new(|| {
+src/cmds/php/phpt_cmd.rs:174:        Regex::new(
+src/cmds/php/phpt_cmd.rs:175:            r"^\s*(Tests passed|Tests failed|Tests skipped|Tests warned|Expected fail|Expected leak|Tests leaked|Tests borked)\s*:\s*(\d+)",
+src/cmds/php/phpt_cmd.rs:176:        )
+src/cmds/php/phpt_cmd.rs:177:        .unwrap()
+src/cmds/php/phpt_cmd.rs:178:    });
+src/cmds/php/phpt_cmd.rs:180:        LazyLock::new(|| Regex::new(r"^\s*Number of tests\s*:\s*(\d+)").unwrap());
+src/cmds/php/phpt_cmd.rs:182:        LazyLock::new(|| Regex::new(r"^\s*Time taken\s*:\s*([0-9.]+)").unwrap());
+src/cmds/cloud/aws_cmd.rs:1327:    LazyLock::new(|| Regex::new(r"^(upload|download|delete|copy|move):").unwrap());
+src/cmds/js/tsc_cmd.rs:22:static TSC_ERROR: LazyLock<Regex> = LazyLock::new(|| {
+src/cmds/js/tsc_cmd.rs:23:    Regex::new(r"^(.+?)\((\d+),(\d+)\):\s+(error|warning)\s+(TS\d+):\s+(.+)$").unwrap()
+src/cmds/js/tsc_cmd.rs:24:});
+src/cmds/js/tsc_cmd.rs:26:static TSC_PRETTY_ERROR: LazyLock<Regex> = LazyLock::new(|| {
+src/cmds/js/tsc_cmd.rs:27:    Regex::new(r"^(.+?):(\d+):(\d+)\s+-\s+(error|warning)\s+(TS\d+):\s+(.+)$").unwrap()
+src/cmds/js/tsc_cmd.rs:28:});
+src/cmds/js/tsc_cmd.rs:30:    LazyLock::new(|| Regex::new(r"^(error|warning)\s+(TS\d+):\s+(.+)$").unwrap());
+src/core/utils.rs:54:        LazyLock::new(|| Regex::new(r"\x1b\[[0-9;]*[a-zA-Z]").unwrap());
+src/cmds/python/uv_cmd.rs:20:    LazyLock::new(|| Regex::new(r#"^\s*File ".*", line \d+.*$"#).unwrap());
+src/cmds/python/uv_cmd.rs:22:    LazyLock::new(|| Regex::new(r"^\s*[A-Za-z_][A-Za-z0-9_.]*(?:Error|Exception):").unwrap());
+src/cmds/python/uv_cmd.rs:24:    LazyLock::new(|| Regex::new(r"^\s*at .+:\d+:\d+.*$").unwrap());
+src/cmds/python/uv_cmd.rs:25:static ERROR_START_PATTERNS: LazyLock<Vec<Regex>> = LazyLock::new(|| {
+src/cmds/python/uv_cmd.rs:26:    vec![
+src/cmds/python/uv_cmd.rs:27:        Regex::new(r"(?i)\berror\b").unwrap(),
+src/cmds/python/uv_cmd.rs:28:        Regex::new(r"(?i)\bfailed\b").unwrap(),
+src/cmds/python/uv_cmd.rs:29:        Regex::new(r"(?i)\bfailure\b").unwrap(),
+src/cmds/python/uv_cmd.rs:30:        Regex::new(r"(?i)\bexception\b").unwrap(),
+src/cmds/python/uv_cmd.rs:31:        Regex::new(r"(?i)\bpanic\b").unwrap(),
+src/cmds/python/uv_cmd.rs:32:        Regex::new(r"(?i)\bwarn(?:ing)?\b").unwrap(),
+src/cmds/python/uv_cmd.rs:33:        Regex::new(r"(?i)\bassert(?:ion)?\b").unwrap(),
+src/cmds/python/uv_cmd.rs:34:        Regex::new(r"^\s*FAILED\b").unwrap(),
+src/cmds/python/uv_cmd.rs:35:        Regex::new(r"^\s*ERROR\b").unwrap(),
+src/cmds/python/uv_cmd.rs:36:        Regex::new(r"^\s*E\s+").unwrap(),
+src/cmds/python/uv_cmd.rs:37:        Regex::new(r"^\s*Caused by:").unwrap(),
+src/cmds/python/uv_cmd.rs:38:        Regex::new(r"^\s*note:").unwrap(),
+src/cmds/python/uv_cmd.rs:39:        Regex::new(r"^\s*help:").unwrap(),
+src/cmds/python/uv_cmd.rs:40:    ]
+src/cmds/python/uv_cmd.rs:41:});
+src/core/filter.rs:158:static MULTIPLE_BLANK_LINES: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\n{3,}").unwrap());
+src/core/filter.rs:233:    LazyLock::new(|| Regex::new(r"^(use |import |from |require\(|#include)").unwrap());
+src/core/filter.rs:234:static FUNC_SIGNATURE: LazyLock<Regex> = LazyLock::new(|| {
+src/core/filter.rs:235:    Regex::new(
+src/core/filter.rs:236:        r"^(pub\s+)?(async\s+)?(fn|def|function|func|class|struct|enum|trait|interface|type)\s+\w+",
+src/core/filter.rs:237:    )
+src/core/filter.rs:238:    .unwrap()
+src/core/filter.rs:239:});
+src/cmds/rust/cargo_cmd.rs:1050:        static RE: LazyLock<regex::Regex> = LazyLock::new(|| {
+src/cmds/rust/cargo_cmd.rs:1051:            regex::Regex::new(
+src/cmds/rust/cargo_cmd.rs:1052:                r"test result: (\w+)\.\s+(\d+) passed;\s+(\d+) failed;\s+(\d+) ignored;\s+(\d+) measured;\s+(\d+) filtered out(?:;\s+finished in ([\d.]+)s)?"
+src/cmds/rust/cargo_cmd.rs:1053:            ).unwrap()
+src/cmds/rust/cargo_cmd.rs:1054:        });
+src/cmds/python/mypy_cmd.rs:57:    static MYPY_DIAG: LazyLock<Regex> = LazyLock::new(|| {
+src/cmds/python/mypy_cmd.rs:58:        Regex::new(r"^(.+?):(\d+)(?::\d+)?: (error|warning|note): (.+?)(?:\s+\[(.+)\])?$").unwrap()
+src/cmds/python/mypy_cmd.rs:59:    });
+src/cmds/scala/sbt_cmd.rs:10:static TEST_SUMMARY_RE: LazyLock<Regex> = LazyLock::new(|| {
+src/cmds/scala/sbt_cmd.rs:11:    Regex::new(
+src/cmds/scala/sbt_cmd.rs:12:        r"Tests: succeeded (\d+), failed (\d+), canceled (\d+), ignored (\d+), pending (\d+)",
+src/cmds/scala/sbt_cmd.rs:13:    )
+src/cmds/scala/sbt_cmd.rs:14:    .unwrap()
+src/cmds/scala/sbt_cmd.rs:15:});
+src/cmds/scala/sbt_cmd.rs:20:static MUNIT_SUMMARY_RE: LazyLock<Regex> = LazyLock::new(|| {
+src/cmds/scala/sbt_cmd.rs:21:    Regex::new(r"^\[info\] (?:Passed|Failed): Total \d+, Failed (\d+), Errors (\d+), Passed (\d+)")
+src/cmds/scala/sbt_cmd.rs:22:        .unwrap()
+src/cmds/scala/sbt_cmd.rs:23:});
+src/cmds/scala/sbt_cmd.rs:28:    LazyLock::new(|| Regex::new(r"Suites: completed (\d+), aborted (\d+)").unwrap());
+src/cmds/scala/sbt_cmd.rs:32:    LazyLock::new(|| Regex::new(r"Run completed in (\d+) seconds?").unwrap());
+src/cmds/scala/sbt_cmd.rs:36:    LazyLock::new(|| Regex::new(r"\[info\] Compiling (\d+) Scala source").unwrap());
+src/cmds/scala/sbt_cmd.rs:40:    LazyLock::new(|| Regex::new(r"\[success\] Total time: (\d+) s").unwrap());
+src/cmds/scala/sbt_cmd.rs:43:static ERROR_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^\[error\]").unwrap());
+src/cmds/scala/sbt_cmd.rs:46:static NOISE_RE: LazyLock<Regex> = LazyLock::new(|| {
+src/cmds/scala/sbt_cmd.rs:47:    Regex::new(
+src/cmds/scala/sbt_cmd.rs:48:        r"^\[info\] (welcome to sbt|loading |set current project|Updating |Resolved |Fetching |downloading |Done )"
+src/cmds/scala/sbt_cmd.rs:49:    ).unwrap()
+src/cmds/scala/sbt_cmd.rs:50:});
+src/core/toml_filter.rs:399:static REGISTRY: LazyLock<TomlFilterRegistry> = LazyLock::new(TomlFilterRegistry::load);
+src/core/toml_filter.rs:422:static MATCH_SET: LazyLock<RegexSet> = LazyLock::new(build_match_set);


### PR DESCRIPTION
Closes #3856

## What
Adds `rtk ast-grep`, filtering ast-grep's structural search output the same way `rtk grep`/`rtk rg` already do — groups matches by file, caps per-file/total, collapses overflow to a count hint.

## Why
ast-grep matches span multiple lines per hit (whole statement/block), so raw output on a repo-wide search gets big fast. No filter covered it yet.

## Numbers
Real repo-wide test search: 1528 tokens raw -> 235 filtered (~85% savings). `--json` stays untouched since that's an explicit structured-output ask.

## Scope
- New `src/cmds/system/ast_grep_cmd.rs`
- Wired into `main.rs` (`Commands::AstGrep`, `is_operational_command`, `PASSTHROUGH`)
- Hook rewrite rule in `src/discover/rules.rs` — `pipeline_safety: ProducerOnly` (safe as a pipeline's first stage, never its last: no piped-stdin support yet)
- Output shapes other than plain `run` (`scan` diagnostics, `--heading`, paths the `path:line:` parser can't read) pass through untouched rather than being grouped
- Unit tests + real-fixture savings test (`tests/fixtures/ast_grep_lazylock_raw.*`)

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets`
- [x] `cargo test` (new module + touched rule/classification tests pass)