### PR TITLE
fix(benchmark): skip find's disclosure note and tee pointer when counting names

### DIFF
--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -213,6 +213,8 @@ count_find_names() {
     /^[0-9]+F [0-9]+D:$/ { next }   # "356F 63D:" summary header
     /^\+[0-9]+ more$/    { next }   # "+256 more" truncation marker
     /^ext: /             { next }   # extension histogram footer
+    /^\.\.\. \(/          { next }   # "... (8 filtered)" disclosure note
+    /^\[see remaining: / { next }   # tee pointer for the disclosed entries
     NF == 0              { next }
     { n += NF - ($1 ~ /\/$/ ? 1 : 0) }   # grouped lines lead with "dir/"
     END { print n + 0 }
@@ -226,6 +228,8 @@ count_find_total() {
     /^[0-9]+F [0-9]+D:$/ { total = $1 + 0; next }
     /^\+[0-9]+ more$/    { more = substr($1, 2) + 0; next }
     /^ext: /             { next }
+    /^\.\.\. \(/          { next }
+    /^\[see remaining: / { next }
     NF == 0              { next }
     { shown += NF - ($1 ~ /\/$/ ? 1 : 0) }
     END { print (total ? total : shown + more) + 0 }


### PR DESCRIPTION
## Summary

The `--max` cap check counts every unrecognised line as names. `find` now ends its output with `... (N filtered)` and a `[see remaining: …]` pointer (#3854), so `rtk find '*' --max 10` counted 19 and the job went red.

## Changes

Two `next` rules in `count_find_names` / `count_find_total`.

## Test

`./scripts/benchmark.sh`: `find --max 10 cap` 10/410, `find --max 100 cap` 100/410.