### PR TITLE
fix(go): propagate golangci-lint exit code instead of swallowing 1

### DIFF
--- a/src/cmds/go/go_cmd.rs
+++ b/src/cmds/go/go_cmd.rs
@@ -286,9 +286,10 @@ fn run_go_tool_golangci_lint(args: &[OsString], verbose: u8) -> Result<i32> {
         shown,
     );
 
-    // golangci-lint: exit 0 = clean, exit 1 = lint issues found (not an error),
-    // exit 2+ = config/build error, None = killed by signal (OOM, SIGKILL)
-    Ok(if exit_code == 1 { 0 } else { exit_code })
+    // golangci-lint exit codes must reach callers unchanged: 0 = clean,
+    // 1 = lint issues found (pre-commit hooks, Makefiles and agents gate on
+    // this), 2+ = config/build error.
+    Ok(exit_code)
 }
 
 /// Parse go test -json output (NDJSON format)

--- a/src/cmds/go/golangci_cmd.rs
+++ b/src/cmds/go/golangci_cmd.rs
@@ -160,9 +160,10 @@ fn run_filtered(original_args: &[String], invocation: &RunInvocation, verbose: u
         crate::core::runner::RunOptions::stdout_only(),
     )?;
 
-    // golangci-lint: exit 0 = clean, exit 1 = lint issues found (not an error),
-    // exit 2+ = config/build error, None = killed by signal (OOM, SIGKILL)
-    Ok(if exit_code == 1 { 0 } else { exit_code })
+    // golangci-lint exit codes must reach callers unchanged: 0 = clean,
+    // 1 = lint issues found (pre-commit hooks, Makefiles and agents gate on
+    // this), 2+ = config/build error.
+    Ok(exit_code)
 }
 
 fn run_passthrough(args: &[String], verbose: u8) -> Result<i32> {

--- a/tests/golangci_exit_code_test.rs
+++ b/tests/golangci_exit_code_test.rs
@@ -1,0 +1,82 @@
+//! #2735 — `rtk golangci-lint run` must not swallow the tool's exit code.
+//!
+//! golangci-lint exits 1 when it finds issues; pre-commit hooks, Makefile
+//! chains and agents gate on that signal. The filtered path used to rewrite
+//! exit 1 to 0, reporting success for a failing tree.
+
+#![cfg(unix)]
+
+use std::process::Command;
+
+fn rtk() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_rtk"))
+}
+
+fn available(bin: &str) -> bool {
+    Command::new(bin)
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn project_with(main_go: &str) -> tempfile::TempDir {
+    let dir = tempfile::tempdir().unwrap();
+    std::process::Command::new("go")
+        .args(["mod", "init", "lintcheck"])
+        .current_dir(dir.path())
+        .output()
+        .expect("go mod init");
+    std::fs::write(dir.path().join("main.go"), main_go).unwrap();
+    std::fs::write(
+        dir.path().join(".golangci.yml"),
+        "version: \"2\"\nlinters:\n  default: none\n  enable: [ineffassign]\n",
+    )
+    .unwrap();
+    dir
+}
+
+#[test]
+fn golangci_lint_issues_exit_nonzero() {
+    if !available("golangci-lint") || !available("go") {
+        return;
+    }
+    let dir = project_with("package main\n\nfunc main() {\n\tx := 1\n\tx = 2\n\t_ = x\n}\n");
+
+    let out = rtk()
+        .args(["golangci-lint", "run", "./..."])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        !out.status.success(),
+        "lint issues must exit non-zero, got 0. stdout:\n{stdout}"
+    );
+    assert_eq!(
+        out.status.code(),
+        Some(1),
+        "golangci-lint reports issues with exit 1"
+    );
+    assert!(stdout.contains("ineffassign"), "findings still shown:\n{stdout}");
+}
+
+#[test]
+fn golangci_lint_clean_exit_zero() {
+    if !available("golangci-lint") || !available("go") {
+        return;
+    }
+    let dir = project_with("package main\n\nfunc main() {\n\t_ = 1\n}\n");
+
+    let out = rtk()
+        .args(["golangci-lint", "run", "./..."])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success(),
+        "clean tree must exit 0, got {:?}. stdout:\n{stdout}",
+        out.status.code()
+    );
+}


### PR DESCRIPTION
## Summary

`rtk golangci-lint run` printed the (correctly filtered) findings but **exited 0 even when golangci-lint found issues**. The filtered path rewrote exit 1 → 0, so pre-commit hooks, Makefile `&&` chains, and "did lint pass?" checks saw success for a failing tree (#2735). The same mapping existed in the `rtk go tool golangci-lint` path.

## Fix

Pass the tool's exit code through unchanged in both wrapper paths:

- `src/cmds/go/golangci_cmd.rs` (`run_filtered`)
- `src/cmds/go/go_cmd.rs` (`run_go_tool_golangci_lint`)

Exit semantics now reach callers as golangci-lint defines them: `0` = clean, `1` = issues found, `2+` = config/build error. Filtered output is unchanged.

## Test

New `tests/golangci_exit_code_test.rs` (integration, follows the existing availability-gated pattern):

- real `golangci-lint run` on a tree with an `ineffassign` finding → **exit 1** (was 0), findings still visible in filtered output
- clean tree → **exit 0**
- skipped when `golangci-lint` or `go` is not installed

Verified locally against golangci-lint 2.6.2 with the exact repro from the issue:

```
direct binary → exit=1
rtk (fixed)   → exit=1   (was 0)
```

All 50 existing `--bin rtk golangci` unit tests pass unchanged.

Fixes #2735
