### PR TITLE
fix(grep): recognize -D/--devices as a value-taking flag

### DIFF
--- a/src/cmds/system/search.rs
+++ b/src/cmds/system/search.rs
@@ -22,9 +22,12 @@ use std::sync::LazyLock;
 /// Short single-char flags that consume one following token (or inline remainder)
 /// as their value. `-e` is handled separately — its value goes to `patterns`.
 /// Includes all rg short flags that take a value argument except `-e` and `-r`
-/// (stripped) and `-E` (dialect, left to #2138). Failure mode for a missing
-/// entry: the value becomes a positional (visible wrong result, not silent).
-const VALUE_FLAGS_SHORT: &[u8] = b"ABCMTdfgjmt";
+/// (stripped) and `-E` (dialect, left to #2138). Also includes grep's own
+/// `-D` (`--devices=ACTION`, #3881) alongside its lowercase `-d`
+/// (`--directories`/rg `--max-depth`) twin — `D` isn't an rg flag. Failure
+/// mode for a missing entry: the value becomes a positional (visible wrong
+/// result, not silent).
+const VALUE_FLAGS_SHORT: &[u8] = b"ABCDMTdfgjmt";
 
 /// Long flags that consume the NEXT token as their value (space-separated form).
 /// Inline `=` form (`--flag=value`) is one token and passes through unchanged.
@@ -37,6 +40,7 @@ const VALUE_FLAGS_LONG: &[&str] = &[
     "--colors",
     "--context",
     "--context-separator",
+    "--devices",
     "--encoding",
     "--engine",
     "--field-context-separator",
@@ -1243,6 +1247,43 @@ mod tests {
         assert_eq!(patterns, vec!["foo"]);
         assert_eq!(paths, vec!["src"]);
         assert_eq!(flags, vec!["-M", "120"]);
+    }
+
+    // --- #3881: grep's -D/--devices=ACTION ---
+
+    #[test]
+    fn test_extract_short_devices() {
+        // -D skip: device-file action, value must not become pattern
+        let (patterns, paths, flags) = extract_pattern_path(&["-D", "skip", "foo", "src"]);
+        assert_eq!(patterns, vec!["foo"]);
+        assert_eq!(paths, vec!["src"]);
+        assert_eq!(flags, vec!["-D", "skip"]);
+    }
+
+    #[test]
+    fn test_extract_short_devices_inline() {
+        // -Dskip: inline value, same as -D skip
+        let (patterns, paths, flags) = extract_pattern_path(&["-Dskip", "foo", "src"]);
+        assert_eq!(patterns, vec!["foo"]);
+        assert_eq!(paths, vec!["src"]);
+        assert_eq!(flags, vec!["-D", "skip"]);
+    }
+
+    #[test]
+    fn test_extract_long_devices() {
+        let (patterns, paths, flags) = extract_pattern_path(&["--devices", "skip", "foo", "src"]);
+        assert_eq!(patterns, vec!["foo"]);
+        assert_eq!(paths, vec!["src"]);
+        assert_eq!(flags, vec!["--devices", "skip"]);
+    }
+
+    #[test]
+    fn test_extract_long_devices_inline_eq() {
+        // --devices=skip is one token (inline =): passes through as-is
+        let (patterns, paths, flags) = extract_pattern_path(&["foo", "src", "--devices=skip"]);
+        assert_eq!(patterns, vec!["foo"]);
+        assert_eq!(paths, vec!["src"]);
+        assert_eq!(flags, vec!["--devices=skip"]);
     }
 
     #[test]

--- a/tests/grep_faithful_format_test.rs
+++ b/tests/grep_faithful_format_test.rs
@@ -209,3 +209,18 @@ fn dash_m_max_count_is_per_file_like_grep_n() {
     let f2 = write(d.path(), "b.txt", "hit\nhit\nhit\n");
     assert_eq_grep_with_and_without_n(&["-m", "2", "hit", &f1, &f2]); // 2 per file, both files
 }
+
+// Regression (#3881): `-D`/`--devices=ACTION` (grep's device-file handling,
+// e.g. `-D skip`) is value-taking, like `-d`/`--directories`. Before the fix,
+// uppercase `-D` and the space-separated `--devices` form were not recognized
+// as consuming a value, so the action word ("skip") was misparsed as the
+// pattern and the real pattern/path positionals shifted — grep then errored
+// on a nonexistent path instead of searching.
+#[test]
+fn dash_capital_d_devices_matches_grep_n() {
+    let d = tempfile::tempdir().unwrap();
+    let f = write(d.path(), "d.txt", "apple pie\napple\nzebra apple juice\n");
+    assert_eq_grep_with_and_without_n(&["-D", "skip", "apple", &f]);
+    assert_eq_grep_with_and_without_n(&["--devices", "skip", "apple", &f]);
+    assert_eq_grep_with_and_without_n(&["--devices=skip", "apple", &f]); // inline form was already fine
+}


### PR DESCRIPTION
## Summary

GNU grep's `-D ACTION` / `--devices ACTION` (`read`|`skip`, how to handle
device/FIFO/socket files) takes a value, exactly like `-d`/`--directories`.
RTK's `VALUE_FLAGS_SHORT` recognized lowercase `-d` but not uppercase `-D`,
and `VALUE_FLAGS_LONG` had no `--devices` entry at all. As a result the
action word (`skip`) was left as an ordinary positional, which shifted the
real search pattern and path out of position — the shifted "path" usually
doesn't exist, so grep exited 2 with no output instead of searching.

```
grep     -D skip apple f1.txt   # 3 matches, exit 0
rtk grep -D skip apple f1.txt   # (empty), exit 2 — before this fix
```

## Fix

- Add `D` to `VALUE_FLAGS_SHORT` in `src/cmds/system/search.rs`, alongside
  its lowercase `-d` twin.
- Add `--devices` to `VALUE_FLAGS_LONG` so the space-separated long form
  (`--devices skip`) also consumes its value correctly. (`--devices=skip`,
  a single token, already worked.)

## Test plan

- Added unit tests in `search.rs` covering `-D skip`, inline `-Dskip`,
  `--devices skip`, and `--devices=skip`.
- Added an end-to-end byte-for-byte test in
  `tests/grep_faithful_format_test.rs` (`dash_capital_d_devices_matches_grep_n`)
  that runs the compiled `rtk` binary against real `grep -D`/`--devices` and
  diffs stdout + exit code, with and without `-n` — the same harness shape
  that would have caught this as a regression.
- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [x] Manual testing: `rtk <command>` output inspected

Fixes #3881