### PR TITLE
fix(grep): treat -h as --no-filename instead of clap help

### DIFF
--- a/src/cmds/system/search.rs
+++ b/src/cmds/system/search.rs
@@ -386,15 +386,45 @@ impl StreamFilter for SearchStreamFilter {
     }
 }
 
+/// Whether grep/rg would print the filename. `-H`/`-h` (and their long forms)
+/// are explicit and the last one wins, exactly as in grep; without either the
+/// engine shows a name for multiple files, a directory, or a recursive search.
 fn show_file(paths: &[String], extra_args: &[String]) -> bool {
+    let mut explicit: Option<bool> = None;
+    for f in extra_args {
+        match f.as_str() {
+            "--with-filename" => explicit = Some(true),
+            "--no-filename" => explicit = Some(false),
+            _ if f.starts_with('-') && !f.starts_with("--") => {
+                // Combined short flags (`-hn`, `-nH`) apply left to right.
+                for ch in f[1..].chars() {
+                    match ch {
+                        'H' => explicit = Some(true),
+                        'h' => explicit = Some(false),
+                        _ => {}
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    if let Some(e) = explicit {
+        return e;
+    }
     paths.len() > 1
         || paths.iter().any(|p| std::path::Path::new(p).is_dir())
-        || has_short_flag(extra_args, 'H')
         || has_short_flag(extra_args, 'r')
         || has_short_flag(extra_args, 'R')
-        || extra_args
-            .iter()
-            .any(|f| f == "--with-filename" || f == "--recursive")
+        || extra_args.iter().any(|f| f == "--recursive")
+}
+
+/// True when `-h`/`--no-filename` is the last filename directive: even with
+/// several files grep then prints bare lines.
+fn no_filename_requested(extra_args: &[String]) -> bool {
+    !show_file(&[], extra_args)
+        && extra_args.iter().any(|f| {
+            f == "--no-filename" || (f.starts_with('-') && !f.starts_with("--") && f[1..].contains('h'))
+        })
 }
 
 fn show_line(extra_args: &[String]) -> bool {
@@ -505,10 +535,11 @@ pub fn run(
     // --version / --help: pass through to the engine without filtering.
     // Note: Clap strips `--` before populating trailing_var_arg, so both
     // `rtk grep --version` and `rtk grep -- --version` land here identically.
-    if args
-        .iter()
-        .any(|a| a == "--version" || a == "--help" || a == "-h")
-    {
+    // `-h` is help only for rg; for grep it is --no-filename and stays a
+    // regular flag (see `show_file`).
+    if args.iter().any(|a| {
+        a == "--version" || a == "--help" || (a == "-h" && matches!(engine, Engine::Rg))
+    }) {
         let mut cmd = resolved_command(engine.bin());
         cmd.args(args);
         let result = exec_capture(&mut cmd).context("search failed")?;
@@ -614,7 +645,8 @@ pub fn run(
     // show one (multiple files, a directory, -r or -H), the line number only with
     // -n. We force -nH--null for robust parsing, then drop what the engine itself
     // would not have shown.
-    let show_file = by_file.len() > 1 || show_file(&paths, &extra_args);
+    let show_file = show_file(&paths, &extra_args)
+        || (by_file.len() > 1 && !no_filename_requested(&extra_args));
     let show_line = show_line(&extra_args);
 
     // Faithful baseline: exactly what the real command prints, full content.
@@ -1436,6 +1468,28 @@ mod tests {
         assert!(show_line(&flags(&["--line-number"])));
         assert!(show_line(&flags(&["-rn"])));
         assert!(show_line(&flags(&["-in"])));
+    }
+
+    #[test]
+    fn show_file_honours_no_filename_in_every_spelling() {
+        let two = flags(&["a.txt", "b.txt"]);
+        assert!(show_file(&two, &flags(&[])));
+        assert!(!show_file(&two, &flags(&["-h"])));
+        assert!(!show_file(&two, &flags(&["--no-filename"])));
+        assert!(!show_file(&two, &flags(&["-hn"])));
+        assert!(!show_file(&two, &flags(&["-rh"])));
+        assert!(no_filename_requested(&flags(&["-ho"])));
+        assert!(!no_filename_requested(&flags(&["-o"])));
+    }
+
+    #[test]
+    fn show_file_last_filename_flag_wins_like_grep() {
+        let one = flags(&["a.txt"]);
+        assert!(show_file(&one, &flags(&["-h", "-H"])));
+        assert!(!show_file(&one, &flags(&["-H", "-h"])));
+        assert!(!show_file(&one, &flags(&["-Hh"])));
+        assert!(show_file(&one, &flags(&["--no-filename", "--with-filename"])));
+        assert!(!no_filename_requested(&flags(&["-h", "-H"])));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -316,6 +316,10 @@ enum Commands {
     },
 
     /// Compact grep - strips whitespace, truncates, groups by file
+    // `-h` is grep's --no-filename, not help: clap must not swallow it before
+    // it reaches search.rs (`rtk grep -h foo a b` printed rtk's usage text).
+    // `--help` still passes through to the engine there.
+    #[command(disable_help_flag = true)]
     Grep {
         // rtk's own options here are long-only: a short form shadows the native
         // grep/rg flag of the same letter and captures it before it can reach

--- a/tests/grep_faithful_format_test.rs
+++ b/tests/grep_faithful_format_test.rs
@@ -209,3 +209,24 @@ fn dash_m_max_count_is_per_file_like_grep_n() {
     let f2 = write(d.path(), "b.txt", "hit\nhit\nhit\n");
     assert_eq_grep_with_and_without_n(&["-m", "2", "hit", &f1, &f2]); // 2 per file, both files
 }
+
+/// `-h` is grep's --no-filename, not help: clap must not intercept it, and the
+/// output must match grep byte for byte (no names even with several files).
+#[test]
+fn dash_h_is_no_filename_not_help() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let a = dir.path().join("a.txt");
+    let b = dir.path().join("b.txt");
+    std::fs::write(&a, "needle one\nhay\n").unwrap();
+    std::fs::write(&b, "needle two\n").unwrap();
+    let (a, b) = (a.to_str().unwrap(), b.to_str().unwrap());
+    assert_eq_grep_with_and_without_n(&["-h", "needle", a, b]);
+    assert_eq_grep_with_and_without_n(&["-ho", "needle", a, b]);
+    assert_eq_grep_with_and_without_n(&["-H", "needle", a]);
+    assert_eq_grep_with_and_without_n(&["-h", "-H", "needle", a]);
+    let (out, _) = rtk_grep(&["-h", "needle", a, b]);
+    assert!(
+        !out.contains("Usage:"),
+        "-h must not print rtk help:\n{out}"
+    );
+}


### PR DESCRIPTION
Refs #3663 (the `-h` half; `-l`/`-m`/`-t` are already long-only on `develop`).

## Summary

- `rtk grep -h PATTERN FILES` printed rtk's usage text: clap's auto help flag captured `-h` before it reached the engine, where it is `--no-filename`. Agents piping `grep -ho ... | sort | uniq -c` got the help screen and fell back to `rtk proxy grep`. Seen in my Claude Code transcripts 5 times across 3 sessions.
- `disable_help_flag` on `Grep` (same precedent as `Psql`). `--help` still passes through to the engine unchanged; `-h` stays help for `rg` only.
- `show_file` now applies grep's last-one-wins rule to `-h`/`-H`/`--no-filename`/`--with-filename`, including clustered short flags (`-hn`, `-rh`, `-Hh`), and with `-h` the compact output drops the filename even for several files, so the result is byte-identical to grep.

Overlaps with #2532, #2635, #3085, #3664 on the clap side; this one is rebased on current `develop` (no conflict), keeps the scope to grep, and pins the multi-file `-h` output against real grep in `grep_faithful_format_test.rs`. `rtk ls -h` is left to #3664.

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test` (3109 lib tests + integration, all green)
- [x] Manual testing: `rtk grep -h foo a b`, `rtk grep -hn foo a b`, `rtk grep -H foo a`, `rtk grep -h -H foo a`, `rtk grep --help` — compared against `grep`