### PR TITLE
fix(diff): name the unreadable file in the error

### DIFF
--- a/src/cmds/git/diff_cmd.rs
+++ b/src/cmds/git/diff_cmd.rs
@@ -2,7 +2,7 @@
 
 use crate::core::guard::never_worse;
 use crate::core::tracking;
-use anyhow::Result;
+use anyhow::{Context, Result};
 use std::fs;
 use std::path::Path;
 
@@ -19,8 +19,12 @@ pub fn run(file1: &Path, file2: &Path, verbose: u8) -> Result<i32> {
         eprintln!("Comparing: {} vs {}", file1.display(), file2.display());
     }
 
-    let content1 = fs::read_to_string(file1)?;
-    let content2 = fs::read_to_string(file2)?;
+    // Name the file: a bare "No such file or directory" leaves the agent
+    // guessing which of the two paths was wrong.
+    let content1 = fs::read_to_string(file1)
+        .with_context(|| format!("cannot read {}", file1.display()))?;
+    let content2 = fs::read_to_string(file2)
+        .with_context(|| format!("cannot read {}", file2.display()))?;
     let lines1: Vec<&str> = content1.lines().collect();
     let lines2: Vec<&str> = content2.lines().collect();
     let diff = compute_diff(&lines1, &lines2);

--- a/tests/diff_byte_accuracy_test.rs
+++ b/tests/diff_byte_accuracy_test.rs
@@ -44,3 +44,22 @@ fn small_crlf_vs_lf_diff_prints_whitespace_message() {
         "byte-different files must not be reported identical:\n{stdout}"
     );
 }
+
+/// A missing operand must be named in the error, like diff itself does.
+#[test]
+fn missing_file_error_names_the_path() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let present = dir.path().join("present.txt");
+    std::fs::write(&present, "x\n").unwrap();
+    let missing = dir.path().join("missing.yaml");
+    let out = std::process::Command::new(env!("CARGO_BIN_EXE_rtk"))
+        .args(["diff", present.to_str().unwrap(), missing.to_str().unwrap()])
+        .output()
+        .expect("rtk diff");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(!out.status.success());
+    assert!(
+        stderr.contains("missing.yaml"),
+        "stderr must name the path:\n{stderr}"
+    );
+}


### PR DESCRIPTION
## Summary

- `rtk diff a.yaml b.yaml` with a wrong path printed only `rtk: No such file or directory (os error 2)`, so the agent could not tell which operand was missing and re-ran the comparison through `git diff` instead. The error now carries the path (`rtk: cannot read b.yaml: No such file or directory`), as `diff` itself does.
- Integration test pins that the path appears in stderr and the exit code is non-zero.

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [x] Manual testing: `rtk diff present.txt missing.yaml`