### PR TITLE
fix(aws): report the filter fallback only with -v

### DIFF
--- a/src/cmds/cloud/aws_cmd.rs
+++ b/src/cmds/cloud/aws_cmd.rs
@@ -356,8 +356,13 @@ fn run_aws_filtered(
         return Ok(exit_code);
     }
 
+    // Falling back to raw output is the normal path for shapes the filter
+    // does not model (e.g. a `--query` that yields a scalar), not a fault the
+    // agent should see: keep the notice for -v only.
     let result = filter_fn(&stdout).unwrap_or_else(|| {
-        eprintln!("rtk: filter warning: aws filter returned None, passing through raw output");
+        if verbose > 0 {
+            eprintln!("rtk: aws filter returned None, passing through raw output");
+        }
         FilterResult::new(stdout.clone())
     });
 


### PR DESCRIPTION
## Summary

- Every `aws` call whose JSON the filter does not model (a `--query` returning a scalar, an empty list) printed `rtk: filter warning: aws filter returned None, passing through raw output` to stderr. The raw output is the intended result there, not an error, and the marker lands in the agent's context on every such call (`aws iam get-role --query 'Role.Arn'` in my transcripts).
- The notice is kept for `-v`, in line with the Transparency principle: no RTK-specific markers in default output.

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [x] Manual testing: existing aws unit tests (87) green; behaviour change is stderr-only