### PR TITLE
fix(filters): never collapse rsync dry runs to "ok (synced)"

### DIFF
--- a/src/core/toml_filter.rs
+++ b/src/core/toml_filter.rs
@@ -1336,6 +1336,23 @@ strip_ansi = true
         assert_eq!(found.unwrap().name, "terraform-plan");
     }
 
+    /// Pin the load-bearing ordering invariant of the rsync dry-run fix:
+    /// "dry-run-rsync" must sort (and therefore match) before "rsync" so a
+    /// dry run is never collapsed to "ok (synced)". If a rename ever breaks
+    /// the alphabetical precedence, this fails instead of silently
+    /// reintroducing fabricated sync success.
+    #[test]
+    fn test_dry_run_rsync_preempts_rsync_builtin() {
+        let filters = make_filters(BUILTIN_TOML);
+        let dry = find_filter_in("rsync -avn src/ dst/", &filters).expect("dry-run should match");
+        assert_eq!(dry.name, "dry-run-rsync");
+        let abbrev =
+            find_filter_in("rsync --dry -av src/ dst/", &filters).expect("--dry should match");
+        assert_eq!(abbrev.name, "dry-run-rsync");
+        let real = find_filter_in("rsync -av src/ dst/", &filters).expect("real sync should match");
+        assert_eq!(real.name, "rsync");
+    }
+
     #[test]
     fn test_find_filter_no_match_returns_none() {
         let filters = make_filters(

--- a/src/core/toml_filter.rs
+++ b/src/core/toml_filter.rs
@@ -2048,6 +2048,7 @@ match_command = "^make\\b"
             "composer-install",
             "df",
             "dotnet-build",
+            "dry-run-rsync",
             "du",
             "fail2ban-client",
             "gcloud",
@@ -2102,8 +2103,8 @@ match_command = "^make\\b"
         let filters = make_filters(BUILTIN_TOML);
         assert_eq!(
             filters.len(),
-            63,
-            "Expected exactly 63 built-in filters, got {}. \
+            64,
+            "Expected exactly 64 built-in filters, got {}. \
              Update this count when adding/removing filters in src/filters/.",
             filters.len()
         );
@@ -2209,11 +2210,11 @@ expected = "output line 1\noutput line 2"
         let combined = format!("{}\n\n{}", BUILTIN_TOML, new_filter);
         let filters = make_filters(&combined);
 
-        // All 63 existing filters still present + 1 new = 64
+        // All 64 existing filters still present + 1 new = 65
         assert_eq!(
             filters.len(),
-            64,
-            "Expected 64 filters after concat (63 built-in + 1 new)"
+            65,
+            "Expected 65 filters after concat (64 built-in + 1 new)"
         );
 
         // New filter is discoverable

--- a/src/filters/dry-run-rsync.toml
+++ b/src/filters/dry-run-rsync.toml
@@ -1,0 +1,45 @@
+[filters.dry-run-rsync]
+# Guards against a false "ok (synced)" on dry runs. rsync prints "total size
+# is" on every non-error run — including --dry-run/-n runs that report real
+# pending changes — so the `rsync` filter's match_output short-circuit would
+# claim a sync happened when nothing was transferred. macOS openrsync makes
+# output-based detection impossible (its dry-run summary carries no
+# "(DRY RUN)" marker), so this filter matches on the command flags instead
+# and passes output through with only light noise stripping.
+# NOTE: the name must sort alphabetically before "rsync" — filters are
+# matched in BTreeMap (name) order, first match wins.
+description = "Pass rsync --dry-run/-n output through — never claim 'synced' for a dry run"
+match_command = "^rsync\\b.*(--dry-run\\b|\\s-[a-zA-Z]*n[a-zA-Z]*(\\s|$))"
+strip_ansi = true
+strip_lines_matching = [
+  "^\\s*$",
+  "^sending incremental file list",
+]
+max_lines = 60
+
+[[tests.dry-run-rsync]]
+name = "openrsync-style dry run with pending changes passes through"
+input = """
+Transfer starting: 2 files
+file1.txt
+
+sent 105 bytes  received 20 bytes  113636 bytes/sec
+total size is 4  speedup is 0.03
+"""
+expected = """Transfer starting: 2 files
+file1.txt
+sent 105 bytes  received 20 bytes  113636 bytes/sec
+total size is 4  speedup is 0.03"""
+
+[[tests.dry-run-rsync]]
+name = "GNU-style dry run with DRY RUN marker passes through"
+input = """
+sending incremental file list
+file1.txt
+
+sent 1,234 bytes  received 42 bytes  2,552.00 bytes/sec
+total size is 98,765  speedup is 77.31 (DRY RUN)
+"""
+expected = """file1.txt
+sent 1,234 bytes  received 42 bytes  2,552.00 bytes/sec
+total size is 98,765  speedup is 77.31 (DRY RUN)"""

--- a/src/filters/dry-run-rsync.toml
+++ b/src/filters/dry-run-rsync.toml
@@ -9,13 +9,16 @@
 # NOTE: the name must sort alphabetically before "rsync" — filters are
 # matched in BTreeMap (name) order, first match wins.
 description = "Pass rsync --dry-run/-n output through — never claim 'synced' for a dry run"
-match_command = "^rsync\\b.*(--dry-run\\b|\\s-[a-zA-Z]*n[a-zA-Z]*(\\s|$))"
+# --dry[-a-z]* : rsync accepts getopt_long prefix abbreviation (--dry ==
+# --dry-run), so match any unambiguous prefix, not just the full spelling.
+match_command = "^rsync\\b.*(--dry[-a-z]*|\\s-[a-zA-Z]*n[a-zA-Z]*(\\s|$))"
 strip_ansi = true
 strip_lines_matching = [
   "^\\s*$",
   "^sending incremental file list",
 ]
 max_lines = 60
+on_empty = "(dry run produced no output — add -v to list pending changes)"
 
 [[tests.dry-run-rsync]]
 name = "openrsync-style dry run with pending changes passes through"

--- a/src/filters/rsync.toml
+++ b/src/filters/rsync.toml
@@ -7,8 +7,11 @@ strip_lines_matching = [
   "^sending incremental file list",
   "^sent \\d",
 ]
+# "DRY RUN" in unless: GNU rsync appends "(DRY RUN)" to the summary line on
+# -n runs — never report a dry run as synced. (openrsync prints no marker;
+# dry-run-rsync.toml catches those by command flags before this filter.)
 match_output = [
-  { pattern = "total size is", message = "ok (synced)", unless = "error|failed|No such file" },
+  { pattern = "total size is", message = "ok (synced)", unless = "error|failed|No such file|DRY RUN" },
 ]
 max_lines = 20
 
@@ -34,6 +37,18 @@ rsync error: error in file system (code 11) at receiver.c(741) [Receiver=3.2.7]
 """
 expected = """rsync: [Receiver] mkdir "/remote/path" failed: Permission denied (13)
 rsync error: error in file system (code 11) at receiver.c(741) [Receiver=3.2.7]"""
+
+[[tests.rsync]]
+name = "GNU dry-run marker blocks the synced short-circuit"
+input = """
+sending incremental file list
+file1.txt
+
+sent 1,234 bytes  received 42 bytes  2,552.00 bytes/sec
+total size is 98,765  speedup is 77.31 (DRY RUN)
+"""
+expected = """file1.txt
+total size is 98,765  speedup is 77.31 (DRY RUN)"""
 
 [[tests.rsync]]
 name = "errors not swallowed when total size present"


### PR DESCRIPTION
## Summary

- Adds a `dry-run-rsync` built-in filter that matches on the command flags (`--dry-run`, `--dry` prefix, or a short-flag cluster containing `n`) and passes the transfer listing through with only blank-line / `sending incremental file list` stripping. macOS `openrsync` prints no `(DRY RUN)` marker, so output-based detection cannot work; matching on the flags is the only reliable signal.
- `rsync.toml` gains `DRY RUN` in its `unless` guard so GNU rsync dry runs (which do print the marker) are never short-circuited to `ok (synced)` either.
- Pins the precedence with a test: built-in filters are matched in `BTreeMap` name order, first match wins, so `dry-run-rsync` must sort before `rsync` (documented in the TOML). Built-in count assertions bumped 63 → 64.

Fixes #2807

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [x] Manual testing: issue #2807 repro (`rtk rsync -aLnv src/ dst/ > out.txt`) now writes the listing (capped at 60 lines with the usual tee hint) instead of one `ok (synced)` line; a real `rtk rsync -a src/ dst/` still prints `ok (synced)`.
- [x] `guard::never_worse` holds: passthrough only removes lines.
