### PR TITLE
fix(npm): compact Jest script output without dropping diagnostics

### DIFF
--- a/src/cmds/js/npm_cmd.rs
+++ b/src/cmds/js/npm_cmd.rs
@@ -1,9 +1,16 @@
 //! Filters npm output and auto-injects the "run" subcommand when appropriate.
 
-use std::io::IsTerminal;
 use crate::core::runner;
 use crate::core::utils::resolved_command;
 use anyhow::Result;
+use regex::Regex;
+use std::io::IsTerminal;
+use std::sync::LazyLock;
+
+static JEST_FOOTER: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?m)^[ \t]*(Test Suites|Tests):[ \t]+(?:[0-9]+ (?:failed|passed|skipped|todo),[ \t]+)*[0-9]+ total[ \t]*\r?$")
+        .expect("valid Jest footer regex")
+});
 
 /// Known npm subcommands that should NOT get "run" injected.
 /// Shared between production code and tests to avoid drift.
@@ -161,8 +168,38 @@ fn run_filtered(
     )
 }
 
+/// Scripts may invoke any runner. Remove passing-suite headers only when both
+/// Jest count footers are present; preserve all other bytes, including diagnostics.
+fn compact_script_tests(output: &str) -> Option<String> {
+    let clean = crate::core::utils::strip_ansi(output);
+    let mut suites = false;
+    let mut tests = false;
+    for capture in JEST_FOOTER.captures_iter(&clean) {
+        suites |= &capture[1] == "Test Suites";
+        tests |= &capture[1] == "Tests";
+    }
+    if !suites || !tests {
+        return None;
+    }
+    Some(
+        output
+            .split_inclusive('\n')
+            .filter(|line| {
+                !crate::core::utils::strip_ansi(line)
+                    .trim_start()
+                    .starts_with("PASS ")
+            })
+            .collect(),
+    )
+}
+
 /// Filter npm run output - strip boilerplate, progress bars, npm WARN
 fn filter_npm_output(output: &str) -> String {
+    if let Some(compact) = compact_script_tests(output) {
+        // Generic boilerplate rules can eat blank lines and ellipses in Jest
+        // assertion diffs. Recognized test output must not go through them.
+        return compact;
+    }
     let mut result = Vec::new();
 
     for line in output.lines() {
@@ -199,6 +236,35 @@ fn filter_npm_output(output: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn jest_script_output_keeps_every_non_passing_suite_line() {
+        for raw in [
+            "PASS good.test.ts\nFAIL bad.test.ts\n  Expected: 1\n  Received: 2\n  ...\n\n  at bad.test.ts:12:3\nTest Suites: 1 failed, 1 passed, 2 total\nTests: 1 failed, 1 passed, 2 total\n",
+            "\x1b[32mPASS\x1b[0m good.test.ts\r\n\x1b[31mFAIL\x1b[0m bad.test.ts\r\nTest Suites: 1 failed, 1 passed, 2 total\r\nTests: 1 failed, 1 passed, 2 total\r\n",
+            include_str!("../../../tests/fixtures/script_jest_obsolete_snapshots_raw.txt"),
+        ] {
+            let expected: String = raw.split_inclusive('\n')
+                .filter(|line| !crate::core::utils::strip_ansi(line).trim_start().starts_with("PASS "))
+                .collect();
+            assert_eq!(filter_npm_output(raw), expected);
+        }
+    }
+
+    #[test]
+    fn unknown_script_output_does_not_lose_pass_lines() {
+        for raw in [
+            "PASS custom validation\nimportant output",
+            "PASS good.test.ts\nTest Suites: 1 passed, 1 total",
+            "PASS custom validation\nTest Suites: custom\nTests: custom",
+            "PASS custom validation\nTest Suites: custom total\nTests: custom total",
+            "12 passing (1s)",
+            "No tests found",
+            "error TS2353: invalid property",
+        ] {
+            assert_eq!(filter_npm_output(raw), raw);
+        }
+    }
 
     #[test]
     fn test_filter_npm_output() {

--- a/tests/fixtures/script_jest_obsolete_snapshots_raw.txt
+++ b/tests/fixtures/script_jest_obsolete_snapshots_raw.txt
@@ -1,0 +1,70 @@
+PASS example-app src/features/example/components/component1.test.tsx
+PASS example-app src/features/example/components/component2.test.tsx
+PASS example-app src/features/example/components/component3.test.tsx
+PASS example-app src/features/example/components/component4.test.tsx
+PASS example-app src/features/example/components/component5.test.tsx
+PASS example-app src/features/example/components/component6.test.tsx
+PASS example-app src/features/example/components/component7.test.tsx
+PASS example-app src/features/example/components/component8.test.tsx
+PASS example-app src/features/example/components/component9.test.tsx
+ › 4 snapshots obsolete.
+   • getStatusIcon status=%s falls back 1
+   • getStatusIcon status=%s falls back 2
+   • getStatusIcon typeName=%s falls back to unknown icon 1
+   • getStatusIcon typeName=%s falls back to unknown icon 2
+PASS example-app src/features/example/components/component10.test.tsx
+PASS example-app src/features/example/components/component11.test.tsx
+PASS example-app src/features/example/components/component12.test.tsx
+PASS example-app src/features/example/components/component13.test.tsx
+PASS example-app src/features/example/components/component14.test.tsx
+PASS example-app src/features/example/components/component15.test.tsx
+PASS example-app src/features/example/components/component16.test.tsx
+PASS example-app src/features/example/components/component17.test.tsx
+PASS example-app src/features/example/components/component18.test.tsx
+PASS example-app src/features/example/components/component19.test.tsx
+PASS example-app src/features/example/components/component20.test.tsx
+PASS example-app src/features/example/components/component21.test.tsx
+PASS example-app src/features/example/components/component22.test.tsx
+PASS example-app src/features/example/components/component23.test.tsx
+PASS example-app src/features/example/components/component24.test.tsx
+PASS example-app src/features/example/components/component25.test.tsx
+PASS example-app src/features/example/components/component26.test.tsx
+PASS example-app src/features/example/components/component27.test.tsx
+PASS example-app src/features/example/components/component28.test.tsx
+PASS example-app src/features/example/components/component29.test.tsx
+PASS example-app src/features/example/components/component30.test.tsx
+PASS example-app src/features/example/components/component31.test.tsx
+PASS example-app src/features/example/components/component32.test.tsx
+PASS example-app src/features/example/components/component33.test.tsx
+PASS example-app src/features/example/components/component34.test.tsx
+PASS example-app src/features/example/components/component35.test.tsx
+PASS example-app src/features/example/components/component36.test.tsx
+PASS example-app src/features/example/components/component37.test.tsx
+PASS example-app src/features/example/components/component38.test.tsx
+PASS example-app src/features/example/components/component39.test.tsx
+PASS example-app src/features/example/components/component40.test.tsx
+PASS example-app src/features/example/components/component41.test.tsx
+PASS example-app src/features/example/components/component42.test.tsx
+PASS example-app src/features/example/components/component43.test.tsx
+PASS example-app src/features/example/components/component44.test.tsx
+PASS example-app src/features/example/components/component45.test.tsx
+PASS example-app src/features/example/components/component46.test.tsx
+PASS example-app src/features/example/components/component47.test.tsx
+PASS example-app src/features/example/components/component48.test.tsx
+PASS example-app src/features/example/components/component49.test.tsx
+PASS example-app src/features/example/components/component50.test.tsx
+PASS example-app src/features/example/components/component51.test.tsx
+PASS example-app src/features/example/components/component52.test.tsx
+
+Snapshot Summary
+ › 4 snapshots obsolete from 1 test suite. To remove them all, re-run jest with `-u`.
+   ↳ src/features/example/components/component9.test.tsx
+       • getStatusIcon status=%s falls back 1
+       • getStatusIcon status=%s falls back 2
+       • getStatusIcon typeName=%s falls back to unknown icon 1
+       • getStatusIcon typeName=%s falls back to unknown icon 2
+
+Test Suites: 52 passed, 52 total
+Tests:       386 passed, 386 total
+Snapshots:   4 obsolete, 11 passed, 11 total
+Time:        9.462 s

--- a/tests/npm_script_output_test.rs
+++ b/tests/npm_script_output_test.rs
@@ -1,0 +1,71 @@
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::process::Command;
+
+#[test]
+fn npm_scripts_preserve_argv_diagnostics_and_child_exit_codes() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let npm = dir.path().join("npm");
+    fs::write(
+        &npm,
+        "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$ARGV_LOG\"\ncat \"$FIXTURE\" >&2\nexit \"$EXIT_CODE\"\n",
+    )
+    .expect("write npm");
+    fs::set_permissions(&npm, fs::Permissions::from_mode(0o755)).expect("chmod");
+    let historical = include_str!("fixtures/script_jest_obsolete_snapshots_raw.txt");
+    let failure = format!(
+        "{}FAIL broken.test.ts\n  Expected: 1\n  Received: 2\n  ...\n\n  at broken.test.ts:12:3\nTest Suites: 1 failed, 100 passed, 101 total\nTests: 1 failed, 100 passed, 101 total\n",
+        (0..100).map(|i| format!("PASS component{i}.test.ts\n")).collect::<String>()
+    );
+    let args = ["run", "test", "--", "a b.test.ts", "literal; echo unsafe"];
+    let fixture = dir.path().join("fixture.txt");
+    let argv = dir.path().join("argv.txt");
+    for (raw, code, compact) in [
+        (historical, 1, true),
+        (failure.as_str(), 7, true),
+        (failure.as_str(), 0, true),
+        ("PASS custom validation\n12 passing\n", 0, false),
+        ("error: failed to load configuration\n", 4, false),
+        ("", 0, false),
+    ] {
+        fs::write(&fixture, raw).expect("fixture");
+        let output = Command::new(env!("CARGO_BIN_EXE_rtk"))
+            .arg("npm")
+            .args(args)
+            .env(
+                "PATH",
+                format!(
+                    "{}:{}",
+                    dir.path().display(),
+                    std::env::var("PATH").expect("PATH")
+                ),
+            )
+            .env("ARGV_LOG", &argv)
+            .env("FIXTURE", &fixture)
+            .env("EXIT_CODE", code.to_string())
+            .env("RTK_DB_PATH", dir.path().join("history.db"))
+            .output()
+            .expect("run npm");
+        assert_eq!(output.status.code(), Some(code));
+        assert_eq!(
+            fs::read_to_string(&argv).expect("argv"),
+            format!("{}\n", args.join("\n"))
+        );
+        let shown = String::from_utf8_lossy(&output.stdout);
+        if compact {
+            let expected: String = raw
+                .split_inclusive('\n')
+                .filter(|line| !line.starts_with("PASS "))
+                .collect();
+            assert_eq!(shown, format!("{expected}\n"));
+            assert!(
+                shown.len() * 100 < raw.len() * 40,
+                "expected >60% byte reduction"
+            );
+        } else {
+            assert!(shown.contains(raw.trim_end()), "{shown}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Make `rtk npm run test` quieter when its output is recognizably Jest, without losing the details needed to diagnose a failure. The script name does not select the filter: npm still runs the original command.

### 1. Remove passing-suite headers, keep the rest

`157f3c0` adds a small compactor in `src/cmds/js/npm_cmd.rs`. It requires both numeric Jest count footers before removing `PASS` headers. Recognized output then skips npm's generic filter, which previously removed blank lines and `...` from assertion diagnostics.

```text
Captured npm output
  Both numeric Jest footers present?
    Yes -> remove PASS headers; preserve all other bytes
    No  -> use the existing npm filter
```

**Review question:** Is recognition narrow enough, and does the recognized-output path preserve all non-PASS content?

### Suggested review order

1. `compact_script_tests` and the early return in `filter_npm_output`: check recognition and what gets removed.
2. The unit tests in the same file: check ANSI, CRLF, diagnostic spacing and incomplete or misleading footers.
3. `tests/npm_script_output_test.rs` and its fixture: check real CLI argument forwarding, stderr capture and exit status.

### Core behavior to validate

| Input | Expected result |
|---|---|
| Jest pass/fail output with both count footers | Remove PASS headers; retain failures and counts |
| All tests pass, but snapshots are obsolete | Retain snapshot diagnostics and exit 1 |
| Unknown runner or incomplete footers | Keep existing npm filtering; do not apply Jest compaction |

The anonymized fixture replay shrank **4,398 raw bytes to 768 emitted bytes (82.5%)**, retaining exit 1. The fixture was captured behind Yarn and replayed through a fake npm executable and the real RTK CLI. This measures output bytes, not billing savings or average npm savings.

No rewrite rules, Yarn support, runner flags or capture/streaming behavior change. This complements, rather than duplicates, npm routing proposals #3672 and #3726.

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test --all`: 3,212 passed, 8 ignored; no clippy warnings.
- [x] Manual testing: inspected the release-CLI fixture replay and obsolete-snapshot diagnostics.
- [x] Diagnostic-preservation regression failed before the fix and passed afterward.
- [x] `git diff --check`.

Verified on macOS. Native process tests are Unix-gated; Windows and ignored external-service tests were not run.

Review range: `develop` at `e53ec1c` to `157f3c0`.
