### PR TITLE
perf(discover): compile capture regexes only for selected rules

### DIFF
--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -3,7 +3,7 @@
 use crate::core::utils::composer_bin_dirs;
 use regex::{Regex, RegexSet};
 use std::path::Path;
-use std::sync::LazyLock;
+use std::sync::{LazyLock, OnceLock};
 
 use super::lexer::{
     advance_quote_state, coalesce_words, is_crlf_at, shell_split, split_on_operators, tokenize,
@@ -54,12 +54,10 @@ pub fn category_avg_tokens(category: &str, subcmd: &str) -> usize {
 static REGEX_SET: LazyLock<RegexSet> = LazyLock::new(|| {
     RegexSet::new(RULES.iter().map(|r| r.pattern)).expect("invalid regex patterns")
 });
-static COMPILED: LazyLock<Vec<Regex>> = LazyLock::new(|| {
-    RULES
-        .iter()
-        .map(|r| Regex::new(r.pattern).expect("invalid regex"))
-        .collect()
-});
+// Hooks start a fresh process for each command. The RegexSet selects the rule;
+// only that rule needs a capture regex, not the entire registry.
+static COMPILED: LazyLock<Vec<OnceLock<Regex>>> =
+    LazyLock::new(|| RULES.iter().map(|_| OnceLock::new()).collect());
 static ENV_PREFIX: LazyLock<Regex> = LazyLock::new(|| {
     let double_quoted = r#""(?:[^"\\]|\\.)*""#;
     let single_quoted = r#"'(?:[^'\\]|\\.)*'"#;
@@ -171,7 +169,10 @@ pub fn classify_command(cmd: &str) -> Classification {
         let rule = &RULES[idx];
 
         // Extract subcommand for savings override and status detection
-        let (savings, status) = if let Some(caps) = COMPILED[idx].captures(cmd_clean) {
+        let (savings, status) = if let Some(caps) = COMPILED[idx]
+            .get_or_init(|| Regex::new(rule.pattern).expect("invalid regex"))
+            .captures(cmd_clean)
+        {
             if let Some(sub) = caps.get(1) {
                 // Collapse internal whitespace so a two-word capture ("pm  ls")
                 // still matches its single-spaced key in the tables below.
@@ -1599,6 +1600,65 @@ fn strip_word_prefix<'a>(cmd: &'a str, prefix: &str) -> Option<&'a str> {
 mod tests {
     use super::super::report::RtkStatus;
     use super::*;
+
+    #[test]
+    fn capture_regexes_initialize_only_for_selected_rules() {
+        const CHILD: &str = "RTK_TEST_LAZY_CAPTURE_CHILD";
+        if std::env::var_os(CHILD).is_none() {
+            // Other tests classify commands concurrently. A fresh test process
+            // gives this assertion its own uninitialized registry.
+            let output = std::process::Command::new(
+                std::env::current_exe().expect("test executable"),
+            )
+            .args([
+                "--exact",
+                "discover::registry::tests::capture_regexes_initialize_only_for_selected_rules",
+                "--nocapture",
+            ])
+            .env(CHILD, "1")
+            .output()
+            .expect("isolated test");
+            assert!(
+                output.status.success(),
+                "{}\n{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+            assert!(String::from_utf8_lossy(&output.stdout).contains("1 passed"));
+            return;
+        }
+
+        assert!(matches!(
+            classify_command("unsupported-tool example"),
+            Classification::Unsupported { .. }
+        ));
+        assert!(COMPILED.iter().all(|regex| regex.get().is_none()));
+        let mut selected = std::collections::BTreeSet::new();
+        for command in [
+            "git status",
+            "cargo test",
+            "git status",
+            "npm run build",
+            "cargo test",
+        ] {
+            let idx = REGEX_SET
+                .matches(command)
+                .into_iter()
+                .next_back()
+                .expect("matching rule");
+            selected.insert(idx);
+            let classification = classify_command(command);
+            assert!(matches!(classification, Classification::Supported { .. }));
+            assert_eq!(classification, classify_command(command));
+            for (index, regex) in COMPILED.iter().enumerate() {
+                assert_eq!(
+                    regex.get().is_some(),
+                    selected.contains(&index),
+                    "{command}: rule {index}"
+                );
+            }
+        }
+    }
 
     fn rewrite_command_no_prefixes(cmd: &str, excluded: &[String]) -> Option<String> {
         super::rewrite_command(cmd, excluded, &[])


### PR DESCRIPTION
## Summary

Reduce startup work for command rewriting. A fresh RTK process currently compiles every rule's capture regex even when it needs only one.

### 1. Compile only the selected rule's capture regex

`27ccddd` keeps the shared `RegexSet` and rule-selection order unchanged. It replaces the eagerly populated capture-regex vector with one lazy slot per rule. Repeated calls reuse the initialized regex.

```diff
 RegexSet selects the matching rule
-Compile every rule's capture regex
+Initialize or reuse only the selected rule's capture regex
 Extract subcommand, savings override and status
```

**Review question:** Does this change only initialization cost, while preserving the selected rule and its capture-derived metadata?

### Suggested review order

1. `COMPILED` in `src/discover/registry.rs`: check that each slot still corresponds to the same rule index.
2. `classify_command`: check the unchanged rule selection and the new `get_or_init` call.
3. `capture_regexes_initialize_only_for_selected_rules`: check unsupported, repeated and different commands. It uses a fresh test process to avoid interference from other tests initializing the shared registry.

### Core behavior to validate

| Command history in one process | Expected initialization |
|---|---|
| Unsupported command | No capture regexes |
| First supported command | Only its selected rule |
| Same command again | Reuse the existing regex |
| Command selecting another rule | Initialize that additional rule only |

Supported rewrite cases were **12-18% faster** in the local measurement. The unsupported control was essentially unchanged. Startup still exceeds the 10 ms target; this PR does not reduce output bytes.

<details>
<summary>Benchmark results and method</summary>

Release binaries from `e53ec1c` and this change on macOS. Each input had 40 samples per binary after four warmups, interleaved in seeded randomized order (seed 42). Python `subprocess.run` and `perf_counter_ns` measured process wall time, including launch and configuration overhead. Hyperfine was not installed.

| Rewrite input | Before median, ms | After median, ms |
|---|---:|---:|
| `git status --short` | 21.794 | 18.810 |
| `rg -n needle src` | 23.790 | 20.547 |
| `bun test --isolate tests` | 23.843 | 21.001 |
| `pnpm run test` | 23.779 | 20.249 |
| `git status --short && git diff --stat && rg -n needle src` | 24.189 | 19.812 |
| `unsupported-tool example` | 21.939 | 21.865 |

Stdout, stderr and exit codes matched for every sample. The unsupported control does not exercise capture-regex compilation.

</details>

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test --all`: 3,210 passed, 8 ignored; no clippy warnings.
- [x] Manual testing: inspected and compared before/after `rtk rewrite` output for the benchmark cases.
- [x] `git diff --check`.

Verified on macOS. Windows and ignored external-service tests were not run. No dependencies or rewrite rules changed.

Review range: `develop` at `e53ec1c` to `27ccddd`.
