### PR TITLE
fix(npm): stream watch commands without filtering

### DIFF
--- a/src/cmds/js/npm_cmd.rs
+++ b/src/cmds/js/npm_cmd.rs
@@ -152,13 +152,10 @@ fn run_filtered(
         opts = opts.inherit_stdin();
     }
 
-    runner::run_filtered(
-        cmd,
-        name,
-        &args_display,
-        filter_npm_output,
-        opts,
-    )
+    if runner::is_watch_mode(args) {
+        return runner::run(cmd, name, &args_display, runner::RunMode::Passthrough, opts);
+    }
+    runner::run_filtered(cmd, name, &args_display, filter_npm_output, opts)
 }
 
 /// Filter npm run output - strip boilerplate, progress bars, npm WARN

--- a/src/core/runner.rs
+++ b/src/core/runner.rs
@@ -455,8 +455,14 @@ impl TestEcosystem {
 /// until the child does, so a watched run prints nothing at all and loses the
 /// buffer on Ctrl-C. Callers send these through unfiltered instead.
 pub fn is_watch_mode(args: &[String]) -> bool {
-    args.iter()
-        .any(|a| a == "--watch" || a.starts_with("--watch="))
+    // Values may be paths (for example Deno's --watch=src), not booleans.
+    // Conservatively bypass capture for every valued form as well.
+    args.iter().any(|arg| {
+        arg == "--watch"
+            || arg.starts_with("--watch=")
+            || arg == "--watchAll"
+            || arg.starts_with("--watchAll=")
+    })
 }
 
 /// Run a prebuilt test command (no shell), showing only failures.
@@ -940,6 +946,17 @@ mod err_test_runner_tests {
 
         let valued: Vec<String> = ["--watch=src"].iter().map(|s| s.to_string()).collect();
         assert!(is_watch_mode(&valued));
+
+        for flag in [
+            "--watchAll",
+            "--watchAll=true",
+            "--watchAll=src",
+            "--watch=false",
+            "--watchAll=false",
+        ] {
+            assert!(is_watch_mode(&[flag.into()]), "{flag}");
+        }
+        assert!(!is_watch_mode(&["--watchAllOfThese".into()]));
 
         // A path or flag that merely starts with the same letters is not it.
         let plain: Vec<String> = ["--watchdog", "./watch", "-w"]

--- a/tests/npm_watch_test.rs
+++ b/tests/npm_watch_test.rs
@@ -1,0 +1,114 @@
+#![cfg(unix)]
+
+use std::fs;
+use std::io::{BufRead, BufReader, Write};
+use std::os::unix::fs::PermissionsExt;
+use std::process::{Command, Stdio};
+use std::sync::mpsc;
+use std::time::Duration;
+
+// The child waits for input after printing. Observing the line before sending
+// input proves passthrough is live, rather than merely unfiltered at exit.
+#[test]
+fn npm_and_npx_watch_output_is_live_and_preserves_execution() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    for tool in ["npm", "npx"] {
+        let executable = dir.path().join(tool);
+        fs::write(
+            &executable,
+            "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$ARGV_LOG\"\nprintf 'npm notice watch ready\\n'\nread -r reply\n[ \"$reply\" = continue ] || exit 9\n[ \"$SKIP_ENV_VALIDATION\" = 1 ] || exit 8\nexit 7\n",
+        )
+        .expect("write executable");
+        fs::set_permissions(&executable, fs::Permissions::from_mode(0o755)).expect("chmod");
+        for flag in [
+            "--watch",
+            "--watch=src",
+            "--watchAll",
+            "--watchAll=true",
+            "--watch=false",
+            "--watchAll=false",
+        ] {
+            let args = if tool == "npm" {
+                vec!["run", "custom", "--", flag, "a b", "literal; echo unsafe"]
+            } else {
+                vec!["custom", flag, "a b", "literal; echo unsafe"]
+            };
+            let argv_log = dir.path().join("argv.txt");
+            let mut child = Command::new(env!("CARGO_BIN_EXE_rtk"))
+                .args(["--skip-env", tool])
+                .args(&args)
+                .env(
+                    "PATH",
+                    format!(
+                        "{}:{}",
+                        dir.path().display(),
+                        std::env::var("PATH").expect("PATH")
+                    ),
+                )
+                .env("ARGV_LOG", &argv_log)
+                .env("RTK_DB_PATH", dir.path().join("history.db"))
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .spawn()
+                .expect("spawn rtk");
+            let stdout = child.stdout.take().expect("stdout");
+            let (tx, rx) = mpsc::channel();
+            let reader = std::thread::spawn(move || {
+                let mut line = String::new();
+                BufReader::new(stdout)
+                    .read_line(&mut line)
+                    .expect("read line");
+                let _ = tx.send(line);
+            });
+            let observed = rx.recv_timeout(Duration::from_secs(5));
+            let live = child.try_wait().expect("try_wait").is_none();
+            // Always release the stub before asserting, including on failure.
+            if let Some(mut stdin) = child.stdin.take() {
+                let _ = stdin.write_all(b"continue\n");
+            }
+            let output = child.wait_with_output().expect("wait");
+            reader.join().expect("reader");
+            assert_eq!(
+                observed.expect("output before child exit"),
+                "npm notice watch ready\n",
+                "{tool} {flag}"
+            );
+            assert!(live, "child exited before input: {tool} {flag}");
+            assert_eq!(output.status.code(), Some(7));
+            assert_eq!(
+                fs::read_to_string(&argv_log).expect("argv"),
+                format!("{}\n", args.join("\n"))
+            );
+        }
+    }
+}
+
+#[test]
+fn unrelated_flags_still_filter_npm_output() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let npm = dir.path().join("npm");
+    fs::write(
+        &npm,
+        "#!/bin/sh\nprintf 'npm notice boilerplate\\nbuild complete\\n'\n",
+    )
+    .expect("write npm");
+    fs::set_permissions(&npm, fs::Permissions::from_mode(0o755)).expect("chmod");
+    for flag in ["--no-watch", "--watchAllOfThese", "--watchdog"] {
+        let output = Command::new(env!("CARGO_BIN_EXE_rtk"))
+            .args(["npm", "run", "custom", "--", flag])
+            .env(
+                "PATH",
+                format!(
+                    "{}:{}",
+                    dir.path().display(),
+                    std::env::var("PATH").expect("PATH")
+                ),
+            )
+            .env("RTK_DB_PATH", dir.path().join("history.db"))
+            .output()
+            .expect("run rtk");
+        assert!(output.status.success());
+        assert_eq!(String::from_utf8_lossy(&output.stdout), "build complete\n");
+    }
+}


### PR DESCRIPTION
## Summary

Show npm/npx watch output while the command is running, rather than waiting for a process that may never exit. Keep stdin available for interaction.

### 1. Bypass buffered filtering for explicit watch flags

`0a26acc` sends watch invocations in `npm_cmd::run_filtered` through the existing passthrough runner. The shared detector also recognizes Jest's `--watchAll` and valued forms.

```text
npm/npx reaches the generic npm handler
  Explicit watch flag?
    Yes -> live, unfiltered output with inherited stdin
    No  -> existing buffered filter
```

The reproduction uses a child that prints `npm notice watch ready`, then waits for input. Before the fix, capture closed its stdin and filtering reduced its output to `ok`. The new test must receive the ready line while the child is still alive, then send input and observe exit 7.

**Review question:** Does watch mode bypass capture without changing the command, arguments, environment or exit status?

### Suggested review order

1. `is_watch_mode` in `src/core/runner.rs`: check exact and valued flags, and rejection of similarly named flags.
2. `run_filtered` in `src/cmds/js/npm_cmd.rs`: check that passthrough uses the already-constructed command, including `--skip-env`.
3. `tests/npm_watch_test.rs`: check the live-output/input handshake, literal arguments and non-watch behavior. A test that only reads output after exit would not catch this bug.

### Core behavior to validate

| Arguments | Expected path |
|---|---|
| `--watch`, `--watch=src`, `--watchAll`, `--watchAll=true` | Live passthrough |
| `--watch=false`, `--watchAll=false` | Conservative passthrough |
| `--watchdog`, `--watchAllOfThese`, `--no-watch` | Existing filter |

Valued forms remain conservative because the shared detector serves tools that accept watch paths, not just booleans. Watch output intentionally stays uncompressed.

This does not detect watch behavior hidden inside a package script, or change dedicated handlers for recognized npx tools.

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test --all`: 3,211 passed, 8 ignored; no clippy warnings.
- [x] Manual testing: reproduced the failure through the real CLI with a controlled executable on PATH.
- [x] Live-output regression failed before the fix and passed afterward for npm and the unknown-tool npx path.
- [x] `git diff --check`.

Verified on macOS. Native process tests are Unix-gated; Windows and ignored external-service tests were not run.

Review range: `develop` at `e53ec1c` to `0a26acc`.
