### PR TITLE
feat(hook): support OpenCode 2.0 plugin format

### DIFF
--- a/hooks/README.md
+++ b/hooks/README.md
@@ -188,13 +188,13 @@ Returns `{}` when no rewrite (Cursor requires JSON for all paths).
 
 ### OpenCode (TypeScript Plugin)
 
-Mutates `args.command` in-place via the zx library:
+Supports OpenCode 1.0 (`tool.execute.before`) and OpenCode 2.0 (`execute.before` / `create.before`), mutating commands in-place via `rtk rewrite`:
 
 ```typescript
-const result = await $`rtk rewrite ${command}`.quiet().nothrow()
-const rewritten = String(result.stdout).trim()
+const { stdout } = await execFileAsync("rtk", ["rewrite", command], { timeout: 3000 })
+const rewritten = String(stdout).trim()
 if (rewritten && rewritten !== command) {
-  (args as Record<string, unknown>).command = rewritten
+  // mutates command in-place
 }
 ```
 

--- a/hooks/opencode/rtk.ts
+++ b/hooks/opencode/rtk.ts
@@ -1,16 +1,52 @@
 import type { Plugin } from "@opencode-ai/plugin"
+import { execFile } from "node:child_process"
+import { promisify } from "node:util"
 
 // RTK OpenCode plugin — rewrites commands to use rtk for token savings.
-// Requires: rtk >= 0.23.0 in PATH.
+// Supports both OpenCode 1.0 (legacy plugin format) and OpenCode 2.0 (event-driven plugin API).
+// Requires: rtk in PATH.
 //
 // This is a thin delegating plugin: all rewrite logic lives in `rtk rewrite`,
 // which is the single source of truth (src/discover/registry.rs).
 // To add or change rewrite rules, edit the Rust registry — not this file.
 
-export const RtkOpenCodePlugin: Plugin = async ({ $ }) => {
+const execFileAsync = promisify(execFile)
+
+async function checkRtk(): Promise<boolean> {
   try {
-    await $`which rtk`.quiet()
+    await execFileAsync("which", ["rtk"])
+    return true
   } catch {
+    return false
+  }
+}
+
+async function rewriteCommand(command: string): Promise<string> {
+  if (!command || typeof command !== "string") return command
+  try {
+    const { stdout } = await execFileAsync("rtk", ["rewrite", command], { timeout: 3000 })
+    const rewritten = String(stdout).trim()
+    return rewritten || command
+  } catch {
+    return command
+  }
+}
+
+// OpenCode 1.0 hook implementation
+export const RtkOpenCodePlugin: Plugin = async ({ $ } = {} as any) => {
+  let hasRtk = false
+  try {
+    if ($) {
+      await $`which rtk`.quiet()
+      hasRtk = true
+    } else {
+      hasRtk = await checkRtk()
+    }
+  } catch {
+    hasRtk = false
+  }
+
+  if (!hasRtk) {
     console.warn("[rtk] rtk binary not found in PATH — plugin disabled")
     return {}
   }
@@ -26,8 +62,7 @@ export const RtkOpenCodePlugin: Plugin = async ({ $ }) => {
       if (typeof command !== "string" || !command) return
 
       try {
-        const result = await $`rtk rewrite ${command}`.quiet().nothrow()
-        const rewritten = String(result.stdout).trim()
+        const rewritten = await rewriteCommand(command)
         if (rewritten && rewritten !== command) {
           ;(args as Record<string, unknown>).command = rewritten
         }
@@ -37,3 +72,57 @@ export const RtkOpenCodePlugin: Plugin = async ({ $ }) => {
     },
   }
 }
+
+// OpenCode 2.0 plugin implementation
+const rtkPlugin = {
+  id: "rtk",
+  server: RtkOpenCodePlugin,
+  setup: async (context: any) => {
+    const hasRtk = await checkRtk()
+    if (!hasRtk) {
+      console.warn("[rtk] rtk binary not found in PATH — plugin disabled")
+      return
+    }
+
+    // Hook tool execution for OpenCode 2.0 (tool: 'shell', 'bash', or 'execute')
+    if (context?.tool?.hook) {
+      await context.tool.hook("execute.before", async (event: any) => {
+        const tool = String(event?.tool ?? "").toLowerCase()
+        if (tool !== "bash" && tool !== "shell" && tool !== "execute") return
+        const input = event?.input
+        if (!input || typeof input !== "object") return
+
+        const command = (input as Record<string, unknown>).command
+        if (typeof command !== "string" || !command) return
+
+        try {
+          const rewritten = await rewriteCommand(command)
+          if (rewritten && rewritten !== command) {
+            ;(input as Record<string, unknown>).command = rewritten
+          }
+        } catch {
+          // rtk rewrite failed — pass through unchanged
+        }
+      })
+    }
+
+    // Hook shell process creation if available
+    if (context?.shell?.hook) {
+      await context.shell.hook("create.before", async (event: any) => {
+        const command = event?.command
+        if (typeof command !== "string" || !command) return
+
+        try {
+          const rewritten = await rewriteCommand(command)
+          if (rewritten && rewritten !== command) {
+            event.command = rewritten
+          }
+        } catch {
+          // rtk rewrite failed — pass through unchanged
+        }
+      })
+    }
+  },
+}
+
+export default rtkPlugin

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -6170,6 +6170,16 @@ mod tests {
     }
 
     #[test]
+    fn test_opencode_plugin_dual_compatibility_v1_and_v2() {
+        assert!(OPENCODE_PLUGIN.contains("RtkOpenCodePlugin"));
+        assert!(OPENCODE_PLUGIN.contains("tool.execute.before"));
+        assert!(OPENCODE_PLUGIN.contains("export default rtkPlugin"));
+        assert!(OPENCODE_PLUGIN.contains("id: \"rtk\""));
+        assert!(OPENCODE_PLUGIN.contains("setup: async"));
+        assert!(OPENCODE_PLUGIN.contains("execute.before"));
+    }
+
+    #[test]
     fn test_migration_warns_on_missing_end_marker() {
         let input = format!("{} v2 -->\nOLD STUFF\nNo end marker", RTK_BLOCK_START);
         let (result, migrated) = remove_rtk_block(&input);


### PR DESCRIPTION
## Summary

- Add OpenCode 2.0 plugin compatibility to `hooks/opencode/rtk.ts` via default export `{ id, setup }`, hooking `execute.before` (tool) and `create.before` (shell).
- Maintain backward compatibility for OpenCode 1.0 via `RtkOpenCodePlugin` named export and `server` property.
- Switch command execution to `node:child_process` `execFile` to eliminate dependency on `$` shell interpolation and prevent shell injection.
- Closes #3898

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [x] Verified `test_opencode_plugin_dual_compatibility_v1_and_v2` unit test in `src/hooks/init.rs`
- [x] Verified plugin module structure matches OpenCode 2.0 plugin contracts
