### PR TITLE
fix(tee): note that tee files may contain sensitive data in the hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,7 +437,7 @@ When a command fails, RTK saves the full unfiltered output so the LLM can read i
 
 ```
 FAILED: 2/15 tests
-[full output: ~/.local/share/rtk/tee/1707753600_cargo_test.log]
+[full output: ~/.local/share/rtk/tee/1707753600_cargo_test.log — may contain sensitive data]
 ```
 
 For the full config reference (all sections, env vars, per-project filters), see the [Configuration guide](https://www.rtk-ai.app/guide/getting-started/configuration).

--- a/docs/contributing/TECHNICAL.md
+++ b/docs/contributing/TECHNICAL.md
@@ -281,7 +281,7 @@ Analytics commands (`rtk gain`, `rtk cc-economics`, `rtk session`) query this da
 On command failure (non-zero exit code):
 
 1. Raw unfiltered output is saved to `~/.local/share/rtk/tee/{epoch}_{slug}.log`
-2. A hint line is printed: `[full output: ~/.../tee/1234_cargo_test.log]`
+2. A hint line is printed: `[full output: ~/.../tee/1234_cargo_test.log — may contain sensitive data]`
 3. LLM agents can re-read the file instead of re-running the failed command
 
 Tee is configurable (enabled/disabled, min size, max files, max file size) and never affects command output or exit code on failure.

--- a/docs/guide/getting-started/configuration.md
+++ b/docs/guide/getting-started/configuration.md
@@ -70,7 +70,7 @@ When a command fails, RTK saves the full raw output to a local file and prints t
 
 ```
 FAILED: 2/15 tests
-[full output: ~/.local/share/rtk/tee/1707753600_cargo_test.log]
+[full output: ~/.local/share/rtk/tee/1707753600_cargo_test.log — may contain sensitive data]
 ```
 
 Your AI assistant can then read the file if it needs more detail, without re-running the command.

--- a/docs/usage/FEATURES.md
+++ b/docs/usage/FEATURES.md
@@ -1376,7 +1376,7 @@ Quand une commande echoue, RTK sauvegarde automatiquement la sortie brute comple
 **Sortie :**
 ```
 FAILED: 2/15 tests
-[full output: ~/.local/share/rtk/tee/1707753600_cargo_test.log]
+[full output: ~/.local/share/rtk/tee/1707753600_cargo_test.log — may contain sensitive data]
 ```
 
 **Configuration :**

--- a/src/core/tee.rs
+++ b/src/core/tee.rs
@@ -261,8 +261,14 @@ fn display_shell_path(path: &std::path::Path) -> String {
     format!("\"{}\"", escape_double_quoted_path(&display))
 }
 
+/// The tee file is raw, unfiltered output: failing commands routinely echo
+/// tokens, API keys, and connection strings, so the hint says so before an
+/// agent quotes the file into a transcript or a bug report.
 fn format_hint(path: &std::path::Path) -> String {
-    format!("[full output: {}]", display_shell_path(path))
+    format!(
+        "[full output: {} — may contain sensitive data]",
+        display_shell_path(path)
+    )
 }
 
 /// Convenience: tee + format hint in one call.
@@ -588,6 +594,15 @@ mod tests {
     }
 
     #[test]
+    fn test_format_hint_warns_about_sensitive_data() {
+        let path = PathBuf::from("/tmp/rtk/tee/123_cargo_test.log");
+        assert_eq!(
+            format_hint(&path),
+            "[full output: /tmp/rtk/tee/123_cargo_test.log — may contain sensitive data]"
+        );
+    }
+
+    #[test]
     fn test_display_shell_path_preserves_simple_paths() {
         let path = PathBuf::from("/tmp/rtk/tee/123_cargo_test.log");
         assert_eq!(display_shell_path(&path), "/tmp/rtk/tee/123_cargo_test.log");
@@ -644,7 +659,7 @@ mod tests {
 
         assert_eq!(
             hint,
-            "[full output: \"$HOME/Library/Application Support/rtk/tee/123_go_test.log\"]"
+            "[full output: \"$HOME/Library/Application Support/rtk/tee/123_go_test.log\" — may contain sensitive data]"
         );
         assert!(
             !hint.contains("\\ "),


### PR DESCRIPTION
Tee files hold raw, unfiltered output, and a failing command's stderr routinely echoes tokens, API keys, or connection strings. The recovery hint pointed an agent at the file without saying so, so it could be quoted into a transcript or a bug report unaware.

Append "— may contain sensitive data" inside the existing brackets. The "[full output: " prefix that ctest and other filters match on is unchanged, and the path stays shell-quoted for copy-paste.

Follow-up to #656: the 0600/0700 permission work already on develop (9cf7a6d, a1bbcaf) covered everything in that branch except this wording.

## Summary
<!-- What does this PR do? Keep it short (1-3 bullet points). -->

Follow-up to #656, which @KuSh closed as covered by the 0600/0700 tee permission work already on develop (9cf7a6d, a1bbcaf) — apart from the hint wording, which is all this PR carries.
	•	`format_hint` now emits `[full output: <path> — may contain sensitive data]`. Tee files are raw, unfiltered output and a failing command’s stderr routinely echoes tokens, API keys, or connection strings; the hint pointed an agent at the file without saying so.
	•	Updated the four docs that print the hint verbatim (README, docs/usage/FEATURES.md, docs/guide/getting-started/configuration.md, docs/contributing/TECHNICAL.md).
The notice goes inside the existing brackets, after the path, on purpose:
	•	The `[full output:`  prefix is unchanged, so the line filters in `ctest_cmd.rs` (starts_with("`[full output:`")) and the `vitest_cmd.rs` hint tests keep matching.
	•	The path stays shell-quoted by `display_shell_path` and remains directly copy-pasteable.
	•	Nothing parses a path back out of the hint, so the trailing clause is safe.

**NOTE**: Cost is ~6 tokens per hint, and only on the failure/truncation paths that tee at all; `guard::never_worse` still caps the emitted total at the raw output.

Deliberately out of scope: `force_tee_tail_hint ([see remaining: tail -n +N <path>]`) points at the same files but is a runnable shell command rather than prose, and #656’s ask was the `[full output: …]` line. Happy to extend it in this PR if you’d prefer the two hints to match.

## Test plan
<!-- How did you verify this works? -->

- [x] cargo fmt --all && cargo clippy --all-targets && cargo test
	•	3108/3108 unit tests pass, clippy clean, fmt clean.
	•	One pre-existing unrelated failure in this sandbox: `copilot_selfheal_test::unwritable_hooks_dir_never_breaks_the_hook` chmods a dir to 0555 and expects the write to fail, which root bypasses. Confirmed identical on unmodified develop.
	•	New `test_format_hint_warns_about_sensitive_data` (exact-string), plus the existing `test_format_hint_avoids_backslash_escaped_whitespace` exact-equality assertion updated — it still guards against backslash-escaped whitespace.
	•	Manual testing: `rtk cargo test --test copilot_selfheal_test` against a failing suite prints

```
[full output: /…/tee/1788748449_cargo_test.log — may contain sensitive data]
```

and the file is `-rw-------`, confirming the merged permission fix.

> **Important:** All PRs must target the `develop` branch (not `master`).
> See [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) for details.

co-authored with Claude Code Opus 5
