### PR TITLE
fix(test): hint POSIX test misuse toward rtk run

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,8 @@ rtk err <cmd>                   # Filter errors only from any command
 rtk test <cmd>                  # Generic test wrapper - failures only (-90%)
 ```
 
+`rtk test` expects a test-runner command, for example `rtk test cargo test`. It is not POSIX `test`; use `rtk run "test -d path"` or direct `test -d path` for shell condition checks.
+
 ### Build & Lint
 ```bash
 rtk lint                        # ESLint grouped by rule/file

--- a/docs/guide/resources/troubleshooting.md
+++ b/docs/guide/resources/troubleshooting.md
@@ -62,6 +62,18 @@ rtk gain    # should now show token savings stats
    cat ~/.claude/settings.json | grep rtk
    ```
 
+## `rtk test -d path` does not check for a directory
+
+**Cause:** `rtk test` runs test-runner commands and filters failures. It is not POSIX `test`.
+
+**Fix:**
+
+```bash
+rtk run "test -d path"
+# or
+test -d path
+```
+
 ## RTK not found after `cargo install`
 
 **Symptom:**

--- a/docs/usage/FEATURES.md
+++ b/docs/usage/FEATURES.md
@@ -571,6 +571,8 @@ rtk test bun test
 rtk test pytest
 ```
 
+`rtk test` attend une commande de runner de tests. Ce n'est pas le builtin POSIX `test`; pour verifier une condition shell, utilisez `rtk run "test -d path"` ou `test -d path` directement.
+
 **Avant / Apres :**
 ```
 # cargo test (200+ lignes en cas d'echec)   # rtk test cargo test (~20 lignes)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1445,6 +1445,24 @@ enum DenoCommands {
     Other(Vec<OsString>),
 }
 
+const POSIX_TEST_UNARY_FLAGS: &[&str] = &[
+    "-b", "-c", "-d", "-e", "-f", "-g", "-h", "-k", "-L", "-n", "-O", "-p", "-r", "-S", "-s", "-u",
+    "-w", "-x", "-z", "-G",
+];
+
+fn posix_test_misuse_message(command: &[String]) -> Option<String> {
+    let first = command.first()?;
+    if !POSIX_TEST_UNARY_FLAGS.contains(&first.as_str()) {
+        return None;
+    }
+
+    let expression = command.join(" ");
+    Some(format!(
+        "rtk test is for test runners, not POSIX test; use `rtk run \"test {}\"` or direct `test {}`",
+        expression, expression
+    ))
+}
+
 /// Route `bunx <tool>` and `bun x <tool>` to the matching tool filter,
 /// falling back to the generic bunx runner for unrecognized tools.
 fn run_bunx_tool(args: &[String], verbose: u8, skip_env: bool) -> Result<i32> {
@@ -2038,6 +2056,9 @@ fn run_cli() -> Result<i32> {
         }
 
         Commands::Test { command } => {
+            if let Some(message) = posix_test_misuse_message(&command) {
+                anyhow::bail!("{}", message);
+            }
             let cmd = command.join(" ");
             runner::run_test(&cmd, cli.verbose)?
         }
@@ -3541,6 +3562,32 @@ mod tests {
                 Commands::Ctest { args } => assert_eq!(args, vec![flag]),
                 _ => panic!("Expected Ctest command"),
             }
+        }
+    }
+
+    #[test]
+    fn test_posix_test_flag_gets_targeted_message() {
+        let command = vec!["-d".to_string(), "path".to_string()];
+        let message = posix_test_misuse_message(&command).unwrap();
+        assert!(message.contains("rtk test is for test runners"));
+        assert!(message.contains("rtk run \"test -d path\""));
+    }
+
+    #[test]
+    fn test_test_runner_command_does_not_get_posix_message() {
+        let command = vec!["cargo".to_string(), "test".to_string()];
+        assert!(posix_test_misuse_message(&command).is_none());
+    }
+
+    #[test]
+    fn test_test_command_with_dash_d_still_parses() {
+        let cli = Cli::try_parse_from(["rtk", "test", "-d", "path"]).unwrap();
+        match cli.command {
+            Commands::Test { command } => {
+                assert_eq!(command, vec!["-d", "path"]);
+                assert!(posix_test_misuse_message(&command).is_some());
+            }
+            _ => panic!("Expected Test command"),
         }
     }
 


### PR DESCRIPTION
## Summary
- `rtk test` expects a test-runner command. A leading POSIX unary flag (e.g. `-d`) now emits a targeted message pointing at `rtk run "test ..."` or direct `test ...`.
- Real runner invocations (`cargo test`, `pytest -x`) are untouched; `-h` stays intercepted by clap.

Split out of #2287 per review: this is the sound, unrelated half. The `find` guard stays for follow-up work (#3410, #3681).

## Test plan
- NEW unit tests in `src/main.rs`: POSIX flag gets message, runner command does not, `-d` still parses as Test command.
- Verified locally: `cargo fmt --check` clean, `cargo clippy --all-targets` zero warnings, 3 new unit tests pass.
- Manual: `rtk test -d /tmp` emits the targeted hint (exit 1); `rtk run "test -d /tmp"` works (exit 0); `rtk test cargo test` unaffected.