### PR TITLE
fix(find): make ext histogram ordering deterministic on equal counts (#3914)

### DIFF
--- a/src/cmds/system/find_cmd.rs
+++ b/src/cmds/system/find_cmd.rs
@@ -706,7 +706,7 @@ fn render(
     if by_ext.len() > 1 {
         body.push('\n');
         let mut exts: Vec<_> = by_ext.iter().collect();
-        exts.sort_by(|a, b| b.1.cmp(a.1));
+        exts.sort_by(|a, b| b.1.cmp(a.1).then_with(|| a.0.cmp(b.0)));
         let ext_str: Vec<String> = exts
             .iter()
             .take(5)
@@ -1453,5 +1453,24 @@ mod tests {
         assert!(filtered_hint(&[]).is_none());
         let h = filtered_hint(&["secret.txt".to_string(), ".hidden/h.txt".to_string()]).unwrap();
         assert!(h.starts_with("... (2 filtered"), "{h}");
+    }
+
+    #[test]
+    fn deterministic_extension_summary_ordering_on_tied_counts() {
+        let timer = tracking::TimedExecution::start();
+        let mut files = Vec::new();
+        for dir in ["d1", "d2", "d3", "d4", "d5"] {
+            for ext in ["rs", "py", "js", "md", "json", "toml"] {
+                files.push(format!("{}/file_{}.{}", dir, ext, ext));
+            }
+        }
+        let shown1 = render(files.clone(), 50, false, &[], "find", "raw", &timer);
+        let shown2 = render(files, 50, false, &[], "find", "raw", &timer);
+        assert_eq!(shown1, shown2);
+        // Equal counts (5 each). Alphabetical tie-break: .js(5) .json(5) .md(5) .py(5) .rs(5)
+        assert!(
+            shown1.contains("ext: .js(5) .json(5) .md(5) .py(5) .rs(5)"),
+            "unexpected ext line: {shown1}"
+        );
     }
 }


### PR DESCRIPTION
## Summary
Resolves #3914.

In `rtk find`, the extension histogram line (`ext: .rs(12) .py(12) ...`) was previously sorted solely by count via `exts.sort_by(|a, b| b.1.cmp(a.1))`. Since Rust's default `HashMap` uses per-process randomized hashing (`RandomState`), tied extensions appeared in non-deterministic order between runs, causing flaky diffs and snapshots.

## Changes
- Updated extension sorting in `src/cmds/system/find_cmd.rs` to break ties alphabetically by extension name:
  ```rust
  exts.sort_by(|a, b| b.1.cmp(a.1).then_with(|| a.0.cmp(b.0)));
  ```
- Added unit test `deterministic_extension_summary_ordering_on_tied_counts` verifying deterministic output ordering when counts are tied.

## Validation
- `cargo test --bin rtk find_cmd` passed (62/62 tests passing).
- `git diff --check` passed cleanly.
