### PR TITLE
feat(config): honour RTK_CONFIG_DIR to relocate the config directory

### DIFF
--- a/docs/guide/getting-started/configuration.md
+++ b/docs/guide/getting-started/configuration.md
@@ -14,6 +14,8 @@ sidebar:
 | Linux | `~/.config/rtk/config.toml` |
 | macOS | `~/Library/Application Support/rtk/config.toml` |
 
+Set `RTK_CONFIG_DIR` to read `config.toml` and the global `filters.toml` from another directory instead; `rtk config` prints the path in effect.
+
 ```bash
 rtk config            # show current configuration
 rtk config --create   # create config file with defaults
@@ -83,6 +85,7 @@ since the agent must type `rtk` itself. `rtk init` prints a note when it does th
 | Variable | Description |
 |----------|-------------|
 | `RTK_DISABLED=1` | Disable RTK for a single command (`RTK_DISABLED=1 git status`) |
+| `RTK_CONFIG_DIR` | Override the config directory that holds `config.toml` and the global `filters.toml` (an empty value is ignored) |
 | `RTK_TEE_DIR` | Override the tee directory |
 | `RTK_TELEMETRY_DISABLED=1` | Disable telemetry |
 | `RTK_HOOK_AUDIT=1` | Enable hook audit logging |

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -256,8 +256,9 @@ impl Config {
 }
 
 fn get_config_path() -> Result<PathBuf> {
-    let config_dir = dirs::config_dir().unwrap_or_else(|| PathBuf::from("."));
-    Ok(config_dir.join(RTK_DATA_DIR).join(CONFIG_TOML))
+    let config_dir =
+        super::constants::config_dir().unwrap_or_else(|| PathBuf::from(".").join(RTK_DATA_DIR));
+    Ok(config_dir.join(CONFIG_TOML))
 }
 
 pub fn show_config() -> Result<()> {
@@ -281,6 +282,25 @@ pub fn show_config() -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The only test in this crate that sets `RTK_CONFIG_DIR`, so it needs no
+    /// lock; the variable is put back before asserting so a failure cannot
+    /// leak the override into other tests in the process.
+    #[test]
+    fn test_get_config_path_honours_rtk_config_dir() {
+        use crate::core::constants::RTK_CONFIG_DIR_ENV;
+
+        let dir = std::env::temp_dir().join("rtk_test_config_dir_env");
+        let previous = std::env::var_os(RTK_CONFIG_DIR_ENV);
+        std::env::set_var(RTK_CONFIG_DIR_ENV, &dir);
+        let overridden = get_config_path();
+        match previous {
+            Some(value) => std::env::set_var(RTK_CONFIG_DIR_ENV, value),
+            None => std::env::remove_var(RTK_CONFIG_DIR_ENV),
+        }
+
+        assert_eq!(overridden.ok(), Some(dir.join(CONFIG_TOML)));
+    }
 
     #[test]
     fn test_hooks_config_deserialize() {

--- a/src/core/constants.rs
+++ b/src/core/constants.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 pub const RTK_DATA_DIR: &str = "rtk";
 pub const HISTORY_DB: &str = "history.db";
 pub const CONFIG_TOML: &str = "config.toml";
@@ -29,3 +31,54 @@ pub const RTK_META_COMMANDS: &[&str] = &[
     "deps",
     "json",
 ];
+
+/// Environment variable naming the directory that holds `config.toml` and the
+/// global `filters.toml`, in place of `<config_dir>/rtk`. Distinct from
+/// [`RTK_DATA_DIR`], which is the path segment appended to the platform default.
+pub const RTK_CONFIG_DIR_ENV: &str = "RTK_CONFIG_DIR";
+
+/// Where rtk's user configuration lives: `config.toml`, the global
+/// `filters.toml` and `filters/*.toml`.
+///
+/// `RTK_CONFIG_DIR` wins when set and non-empty, mirroring `RTK_DB_PATH` for
+/// the tracking database; otherwise this is the platform config directory plus
+/// rtk's own segment (`~/.config/rtk` on Linux, `~/Library/Application
+/// Support/rtk` on macOS). `None` only when the variable is unset or empty and
+/// the platform gives no answer.
+pub fn config_dir() -> Option<PathBuf> {
+    config_dir_from(std::env::var_os(RTK_CONFIG_DIR_ENV).map(PathBuf::from))
+}
+
+/// The resolution behind [`config_dir`], taking the environment value as a
+/// parameter so it can be tested without mutating process-global state.
+fn config_dir_from(override_dir: Option<PathBuf>) -> Option<PathBuf> {
+    match override_dir {
+        Some(dir) if !dir.as_os_str().is_empty() => Some(dir),
+        _ => dirs::config_dir().map(|d| d.join(RTK_DATA_DIR)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn platform_default() -> Option<PathBuf> {
+        dirs::config_dir().map(|d| d.join(RTK_DATA_DIR))
+    }
+
+    #[test]
+    fn test_config_dir_env_override_wins() {
+        let custom = std::env::temp_dir().join("rtk_test_config_dir_override");
+        assert_eq!(config_dir_from(Some(custom.clone())), Some(custom));
+    }
+
+    #[test]
+    fn test_config_dir_unset_uses_platform_default() {
+        assert_eq!(config_dir_from(None), platform_default());
+    }
+
+    #[test]
+    fn test_config_dir_empty_behaves_like_unset() {
+        assert_eq!(config_dir_from(Some(PathBuf::new())), platform_default());
+    }
+}

--- a/src/core/telemetry.rs
+++ b/src/core/telemetry.rs
@@ -345,8 +345,8 @@ fn build_meta_usage(tracker: &tracking::Tracker) -> serde_json::Value {
 
 /// Check if user has a config.toml file.
 fn detect_has_config() -> bool {
-    dirs::config_dir()
-        .map(|d| d.join("rtk/config.toml").exists())
+    crate::core::constants::config_dir()
+        .map(|d| d.join(crate::core::constants::CONFIG_TOML).exists())
         .unwrap_or(false)
 }
 
@@ -410,8 +410,8 @@ fn count_custom_toml_filters() -> usize {
     }
 
     // Global: ~/.config/rtk/filters/*.toml
-    if let Some(config_dir) = dirs::config_dir() {
-        if let Ok(entries) = std::fs::read_dir(config_dir.join("rtk/filters")) {
+    if let Some(config_dir) = crate::core::constants::config_dir() {
+        if let Ok(entries) = std::fs::read_dir(config_dir.join("filters")) {
             count += entries
                 .filter_map(|e| e.ok())
                 .filter(|e| e.path().extension().is_some_and(|ext| ext == "toml"))

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -1648,8 +1648,9 @@ fn generate_global_filters_template(ctx: InitContext) -> Result<()> {
     let InitContext {
         verbose, dry_run, ..
     } = ctx;
-    let config_dir = dirs::config_dir().unwrap_or_else(|| std::path::PathBuf::from(".config"));
-    let rtk_dir = config_dir.join(crate::core::constants::RTK_DATA_DIR);
+    let rtk_dir = crate::core::constants::config_dir().unwrap_or_else(|| {
+        std::path::PathBuf::from(".config").join(crate::core::constants::RTK_DATA_DIR)
+    });
     let path = rtk_dir.join("filters.toml");
 
     if path.exists() {

--- a/src/hooks/trust.rs
+++ b/src/hooks/trust.rs
@@ -304,7 +304,14 @@ pub fn run_trust(list: bool, yes: bool) -> Result<()> {
         if had_error {
             anyhow::bail!("Filter file present but not valid TOML — see the error above.");
         }
-        anyhow::bail!("No custom filters found (.rtk/filters.toml or ~/.config/rtk/filters.toml)");
+        let global = crate::core::constants::config_dir()
+            .map(|d| {
+                d.join(crate::core::constants::FILTERS_TOML)
+                    .display()
+                    .to_string()
+            })
+            .unwrap_or_else(|| "~/.config/rtk/filters.toml".to_string());
+        anyhow::bail!("No custom filters found (.rtk/filters.toml or {global})");
     }
     if !enabled_any {
         if !interactive {
@@ -482,7 +489,7 @@ mod tests {
     fn test_gated_filter_paths_covers_project_and_global() {
         let paths = gated_filter_paths();
         assert_eq!(paths[0], PathBuf::from(".rtk/filters.toml"));
-        if dirs::config_dir().is_some() {
+        if crate::core::constants::config_dir().is_some() {
             assert_eq!(paths.len(), 2);
             assert!(paths[1].ends_with("filters.toml"));
             assert!(paths[1].is_absolute());

--- a/src/hooks/trust.rs
+++ b/src/hooks/trust.rs
@@ -205,12 +205,8 @@ pub fn gated_filter_paths() -> Vec<PathBuf> {
 
 pub fn gated_filter_paths_labeled() -> Vec<(&'static str, PathBuf)> {
     let mut paths = vec![("project", PathBuf::from(".rtk/filters.toml"))];
-    if let Some(dir) = dirs::config_dir() {
-        paths.push((
-            "global",
-            dir.join(RTK_DATA_DIR)
-                .join(crate::core::constants::FILTERS_TOML),
-        ));
+    if let Some(dir) = crate::core::constants::config_dir() {
+        paths.push(("global", dir.join(crate::core::constants::FILTERS_TOML)));
     }
     paths
 }


### PR DESCRIPTION
## Summary

- Adds `constants::config_dir()`, the one place that answers where rtk's user configuration lives. It returns `$RTK_CONFIG_DIR` when the variable is set and non-empty, and `dirs::config_dir().join("rtk")` otherwise. Precedence mirrors `RTK_DB_PATH`: the environment wins, and with the variable unset every path resolves exactly as before.
- Routes every consumer of that directory through it: `get_config_path()` for `config.toml` (which `Config::load`/`save`, `cached_config` and `rtk config` all go through), `trust::gated_filter_paths_labeled()` for the global `filters.toml`, telemetry's `detect_has_config()` and its `filters/*.toml` count, and `rtk init -g`'s global filters template so the file it writes is the one rtk will read.
- `rtk config` prints the resolved path, so the override is visible. An empty value behaves like unset. No new config I/O on the hook's hot path: the helper reads one environment variable and is only called where `dirs::config_dir()` already was.
- Documents the variable in the "Environment variables" table and under "Config file location".

Motivation:

1. Agent sandboxes that mount `$HOME` as a volume hide any config baked into the image, so `[hooks] exclude_commands` cannot ship with the image. With this an image can point rtk at a read-only config directory outside the volume.
2. Test isolation on Windows, where `dirs::config_dir()` resolves through the shell API and ignores the environment. #3874 proposes the sibling `RTK_DATA_DIR` for the data directory; this PR deliberately leaves the data directory to that discussion and does not overlap #3758. (If #3758 lands first, the `RTK_DATA_DIR` import in `trust.rs` becomes unused and this branch will be rebased to drop it.)

Refs #3874

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets`: zero warnings
- [x] `cargo clippy --all-targets -- -W clippy::unwrap_used -W clippy::panic -W clippy::expect_used`: no hits on the changed lines (run with `--cap-lints warn`, since the pre-existing hits in `build.rs` otherwise stop the pass before the crate is linted)
- [x] `cargo test --all` with `HOME` redirected to a scratch directory: 3124 unit tests (4 new: resolver set / unset / empty, and `get_config_path()` honouring the variable) plus every integration suite pass; the same run on pristine `develop` was green at 3120
- [x] Manual: `RTK_CONFIG_DIR=/tmp/x ./target/debug/rtk config` prints `Config: /tmp/x/config.toml`; `RTK_CONFIG_DIR=` (empty) and unset both print the platform default
- [x] Manual: with `RTK_CONFIG_DIR` pointing at a directory holding a `filters.toml`, `rtk trust -y` from an empty directory finds and trusts that file and `rtk trust --list` shows it; without the variable, `rtk trust` reports no custom filters
