### PR TITLE
feat(rewrite): honour RTK_DISABLED=1 from the environment

### DIFF
--- a/docs/guide/getting-started/configuration.md
+++ b/docs/guide/getting-started/configuration.md
@@ -82,7 +82,7 @@ since the agent must type `rtk` itself. `rtk init` prints a note when it does th
 
 | Variable | Description |
 |----------|-------------|
-| `RTK_DISABLED=1` | Disable RTK for a single command (`RTK_DISABLED=1 git status`) |
+| `RTK_DISABLED=1` | Disable RTK for a single command (`RTK_DISABLED=1 git status`). Also honoured when exported in the environment: `rtk rewrite` then passes every command through, so hooks and plugins that delegate to it stand down for that shell or process tree. |
 | `RTK_TEE_DIR` | Override the tee directory |
 | `RTK_TELEMETRY_DISABLED=1` | Disable telemetry |
 | `RTK_HOOK_AUDIT=1` | Enable hook audit logging |

--- a/docs/guide/getting-started/supported-agents.md
+++ b/docs/guide/getting-started/supported-agents.md
@@ -288,6 +288,8 @@ Hooks never block command execution. If RTK is missing, the hook exits cleanly a
 RTK_DISABLED=1 git status    # runs raw git status, no rewrite
 ```
 
+Exported in the environment (`export RTK_DISABLED=1`) it applies to every command instead: `rtk rewrite` passes them all through, so the hooks and plugins that delegate to it stand down for that shell or process tree.
+
 Or exclude commands permanently in `~/.config/rtk/config.toml`:
 
 ```toml

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -3008,8 +3008,13 @@ mod tests {
             }
         }
 
+        // The exported form of the variable is a passthrough before the
+        // registry runs (rewrite_cmd.rs), which would skip the warning under
+        // test here — so a developer's own `export RTK_DISABLED=1` must not
+        // reach the child.
         let output = std::process::Command::new(&rtk_bin)
             .args(["rewrite", "RTK_DISABLED=1 git status"])
+            .env_remove("RTK_DISABLED")
             .output()
             .expect("Failed to run rtk");
 

--- a/src/hooks/rewrite_cmd.rs
+++ b/src/hooks/rewrite_cmd.rs
@@ -17,7 +17,14 @@ use std::io::Write;
 /// | 3    | rewritten| Ask rule matched — hook rewrites but lets Claude Code prompt.|
 pub fn run(cmd: &str) -> anyhow::Result<()> {
     let disabled_by_env = rewrite_disabled_by_env();
-    let (excluded, transparent_prefixes) = crate::core::config::hook_rewrite_params();
+    // A disabled invocation never consults the exclusions or transparent
+    // prefixes, so it does not read config.toml either: the passthrough costs
+    // one environment lookup and no file I/O.
+    let (excluded, transparent_prefixes) = if disabled_by_env {
+        Default::default()
+    } else {
+        crate::core::config::hook_rewrite_params()
+    };
 
     match evaluate(cmd, disabled_by_env, &excluded, &transparent_prefixes) {
         RewriteOutcome::Allow(rewritten) => {

--- a/src/hooks/rewrite_cmd.rs
+++ b/src/hooks/rewrite_cmd.rs
@@ -12,13 +12,14 @@ use std::io::Write;
 /// | Exit | Stdout   | Meaning                                                      |
 /// |------|----------|--------------------------------------------------------------|
 /// | 0    | rewritten| Rewrite allowed — hook may auto-allow the rewritten command. |
-/// | 1    | (none)   | No RTK equivalent — hook passes through unchanged.           |
+/// | 1    | (none)   | No RTK equivalent, or `RTK_DISABLED=1` exported — hook passes through unchanged. |
 /// | 2    | (none)   | Deny rule matched — hook defers to Claude Code native deny.  |
 /// | 3    | rewritten| Ask rule matched — hook rewrites but lets Claude Code prompt.|
 pub fn run(cmd: &str) -> anyhow::Result<()> {
+    let disabled_by_env = rewrite_disabled_by_env();
     let (excluded, transparent_prefixes) = crate::core::config::hook_rewrite_params();
 
-    match evaluate(cmd, &excluded, &transparent_prefixes) {
+    match evaluate(cmd, disabled_by_env, &excluded, &transparent_prefixes) {
         RewriteOutcome::Allow(rewritten) => {
             print!("{}", rewritten);
             let _ = std::io::stdout().flush();
@@ -42,7 +43,34 @@ enum RewriteOutcome {
     Ask(String),
 }
 
-fn evaluate(cmd: &str, excluded: &[String], transparent_prefixes: &[String]) -> RewriteOutcome {
+/// `RTK_DISABLED=1` exported in the process environment (#1153, #3791).
+///
+/// The `RTK_DISABLED=1 <cmd>` prefix, handled per segment by the registry
+/// (#345), opts one command out; the exported form opts out every command the
+/// process sees, so a parent that sets it once stands the hook down for its
+/// whole process tree. Only the exact value `1` counts, like the other `RTK_*`
+/// switches, so a child can be re-enabled with `RTK_DISABLED=0`.
+fn rewrite_disabled_by_env() -> bool {
+    std::env::var("RTK_DISABLED").as_deref() == Ok("1")
+}
+
+/// Decide the outcome for `cmd`.
+///
+/// `disabled_by_env` is [`rewrite_disabled_by_env`], read once by the caller
+/// and passed in for the same reason the verdict is a parameter of
+/// [`evaluate_with_verdict`]: tests stay off the process-global environment.
+/// When set, the answer is a passthrough before the permission settings, the
+/// lexer, or the registry are consulted, so a disabled host never has its
+/// settings files read or a rewrite computed.
+fn evaluate(
+    cmd: &str,
+    disabled_by_env: bool,
+    excluded: &[String],
+    transparent_prefixes: &[String],
+) -> RewriteOutcome {
+    if disabled_by_env {
+        return RewriteOutcome::Passthrough;
+    }
     evaluate_with_verdict(cmd, check_command(cmd), excluded, transparent_prefixes)
 }
 
@@ -199,6 +227,59 @@ mod tests {
                 evaluate_with_verdict("git status", PermissionVerdict::Default, &[], &[]),
                 RewriteOutcome::Ask(_)
             ));
+        }
+    }
+
+    /// `RTK_DISABLED=1` exported in the environment is a passthrough for every
+    /// command (#1153), decided before the permission settings are read:
+    /// `evaluate` never reaches `check_command` when the flag is set, so the
+    /// disabled cases are independent of the developer's own Claude Code
+    /// settings.
+    mod disabled_by_env {
+        use super::super::{evaluate, evaluate_with_verdict, RewriteOutcome};
+        use crate::hooks::permissions::PermissionVerdict;
+
+        #[test]
+        fn test_disabled_by_env_passes_through_rewritable_command() {
+            assert_eq!(
+                evaluate("git status", true, &[], &[]),
+                RewriteOutcome::Passthrough
+            );
+        }
+
+        #[test]
+        fn test_disabled_by_env_passes_through_already_rtk_command() {
+            assert_eq!(
+                evaluate("rtk git status", true, &[], &[]),
+                RewriteOutcome::Passthrough
+            );
+        }
+
+        /// With the flag off, `git status` still rewrites. Which of
+        /// `Allow`/`Ask`/`Deny` comes back depends on the developer's own
+        /// Claude Code settings (#3146); only `Passthrough` would mean the
+        /// flag leaked into the enabled path.
+        #[test]
+        fn test_enabled_env_still_rewrites() {
+            assert_ne!(
+                evaluate("git status", false, &[], &[]),
+                RewriteOutcome::Passthrough
+            );
+        }
+
+        /// The in-command prefix (#345) is unchanged: with the flag off it is
+        /// still the registry's decision.
+        #[test]
+        fn test_prefix_form_still_passes_through_without_env() {
+            assert_eq!(
+                evaluate_with_verdict(
+                    "RTK_DISABLED=1 git status",
+                    PermissionVerdict::Default,
+                    &[],
+                    &[]
+                ),
+                RewriteOutcome::Passthrough
+            );
         }
     }
 

--- a/tests/rewrite_disabled_env_test.rs
+++ b/tests/rewrite_disabled_env_test.rs
@@ -1,0 +1,54 @@
+//! End-to-end check of `RTK_DISABLED=1` exported in the environment for
+//! `rtk rewrite` (#1153): the exported form is a passthrough — exit 1 and
+//! nothing on stdout — decided before any registry work, and only the exact
+//! value `1` counts.
+
+use std::process::{Command, Output, Stdio};
+
+fn rtk_rewrite(cmd: &str, rtk_disabled: Option<&str>) -> std::io::Result<Output> {
+    let mut rtk = Command::new(env!("CARGO_BIN_EXE_rtk"));
+    rtk.args(["rewrite", cmd])
+        // A developer's own `export RTK_DISABLED=1` must not reach the child.
+        .env_remove("RTK_DISABLED")
+        .env("RTK_TELEMETRY_DISABLED", "1")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    if let Some(value) = rtk_disabled {
+        rtk.env("RTK_DISABLED", value);
+    }
+    rtk.output()
+}
+
+#[test]
+fn rtk_disabled_in_env_is_a_passthrough() -> std::io::Result<()> {
+    let out = rtk_rewrite("git status", Some("1"))?;
+
+    assert_eq!(out.status.code(), Some(1), "passthrough exit code");
+    assert!(
+        out.stdout.is_empty(),
+        "no rewrite may be printed, got: {}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    Ok(())
+}
+
+/// Only the exact value `1` disables the rewrite, so a parent that exported
+/// `RTK_DISABLED=1` can hand a child `RTK_DISABLED=0` to re-enable it.
+/// `rtk git status` is already RTK, so the rewrite is its own input whatever
+/// permission rules or `exclude_commands` the host running the tests has.
+#[test]
+fn rtk_disabled_other_value_still_rewrites() -> std::io::Result<()> {
+    let out = rtk_rewrite("rtk git status", Some("0"))?;
+
+    assert_eq!(
+        String::from_utf8_lossy(&out.stdout).trim(),
+        "rtk git status"
+    );
+    assert!(
+        matches!(out.status.code(), Some(0) | Some(3)),
+        "allow or ask exit code expected, got {:?}",
+        out.status.code()
+    );
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- `rtk rewrite` now honours `RTK_DISABLED=1` exported in its environment: the outcome is a passthrough (exit 1, nothing on stdout), decided before the permission settings, the lexer and the registry are consulted. Until now only the `RTK_DISABLED=1 <cmd>` prefix inside the command text was recognised: `RTK_DISABLED=1 rtk rewrite "git status"` still printed `rtk git status` and exited 3.
- Why this entry point: `rtk rewrite` is the single source of truth that every shipped hook and plugin (the Claude and Cursor shell hooks, OpenCode, Pi/OMP, Hermes) and every embedding host calls, so one switch covers all of them. Today only the Pi extension checks `process.env.RTK_DISABLED` on its own (`hooks/pi/rtk.ts`); that check keeps working and becomes redundant rather than required, and a host that spawns `rtk rewrite` directly no longer has to reimplement it before every spawn.
- How it composes: the in-command prefix keeps its per-segment registry handling and stderr warning (#345); the exported form applies to the whole invocation and prints nothing. Only the exact value `1` counts, as with `RTK_TELEMETRY_DISABLED` and `RTK_HOOK_AUDIT`, so a parent that exported it can hand one child `RTK_DISABLED=0` to re-enable it. Every other exit code is unchanged, no file I/O is added to the rewrite path, and the shipped hook scripts are untouched.
- Not covered here: the native `rtk hook <agent>` entry points in `hook_cmd.rs` call the registry directly rather than going through `rewrite_cmd`, so they still ignore the variable. That is the exact case reported in #3791 and is left for a follow-up.
- Tests: the flag is threaded into `evaluate` as a parameter (the `evaluate_with_verdict` pattern from #3146), so the unit tests never touch the process environment. A small integration test spawns the binary to pin the exit-code/stdout contract and the "only `1` counts" rule. The existing registry subprocess test now clears `RTK_DISABLED` for its child, so a developer's own export cannot mask the prefix warning it asserts on.

Refs #1153 #3791

#1167 is the earlier attempt at the same feature; it calls `process::exit(1)` at the top of `run()` and has been conflicting since April. This PR keeps the decision in the testable path instead.

## Test plan

- [x] `cargo fmt --all -- --check`; `cargo clippy --all-targets` (clean); soft lints `-W clippy::unwrap_used -W clippy::panic -W clippy::expect_used` (no new warnings)
- [x] `cargo test --all` with an isolated `HOME`/`RTK_DB_PATH`/`RTK_TEE_DIR`: the full suite passes (3124 in the main crate plus the integration suites), including the 4 new unit tests and the 2 new end-to-end tests
- [x] Manual: `RTK_DISABLED=1 ./target/debug/rtk rewrite "git status"; echo $?` prints nothing and `1`; without the variable, or with `RTK_DISABLED=0`, it prints `rtk git status` and `3`; `rtk rewrite "RTK_DISABLED=1 git status"` still exits 1 with the existing stderr warning
- [x] Through the Claude shell hook: a `git status` PreToolUse payload piped into `RTK_DISABLED=1 bash hooks/claude/rtk-rewrite.sh` emits nothing and exits 0; without the variable the rewrite is emitted
- [x] `hooks/claude/test-rtk-rewrite.sh` against this build: 57/66 pass and the `RTK_DISABLED` prefix section passes; the same 9 cases (unrelated `rg`/pipeline expectations and the audit-log cases the v3 script does not implement) fail identically against the 0.48.0 release binary
