### PR TITLE
docs(guide): add a guide for embedding rtk in a custom agent harness

### DIFF
--- a/docs/guide/getting-started/embedding.md
+++ b/docs/guide/getting-started/embedding.md
@@ -35,7 +35,7 @@ Three more details of the call:
 
 - **Read stdout only.** Stderr can carry advisory lines: a once-a-day "No hook installed" notice on machines where `~/.claude` exists without an RTK hook, or an `RTK_DISABLED=1 detected` message.
 - **Compare output with input.** A command that already starts with `rtk` comes back unchanged (still exit 3), and there is nothing to substitute.
-- **`RTK_DISABLED=1` is a prefix, not an environment variable.** `rtk rewrite "RTK_DISABLED=1 git status"` exits 1; setting the variable in the environment of the `rtk rewrite` process changes nothing. If you want an environment kill switch, check it in the host before calling rtk, as the Pi extension does.
+- **Check `RTK_DISABLED` yourself before spawning `rtk rewrite`**, as the Pi extension does. Releases up to 0.48.0 honor it only as an in-command prefix (`rtk rewrite "RTK_DISABLED=1 git status"` exits 1); [rtk-ai/rtk#3917](https://github.com/rtk-ai/rtk/pull/3917) makes `rtk rewrite` honor the exported variable as well.
 
 `rtk rewrite` does not run the command and does not open the savings database. Compound commands are handled (`cargo fmt --all && cargo test` becomes `rtk cargo fmt --all && rtk cargo test`); commands containing redirects or command substitution pass through with exit 1.
 

--- a/docs/guide/getting-started/embedding.md
+++ b/docs/guide/getting-started/embedding.md
@@ -7,7 +7,7 @@ sidebar:
 
 # Embedding rtk in your own agent harness
 
-This page is for people who build an agent harness and want the rewrite step inside their own bash tool, rather than installing one of the hooks listed in [Supported Agents](supported-agents.md). Every shipped hook is a thin delegate around one binary call, `rtk rewrite`, and that call is the whole integration surface. Everything below was verified against rtk 0.48.0.
+This page is for people who build an agent harness and want the rewrite step inside their own bash tool, rather than installing one of the hooks listed in [Supported Agents](supported-agents.md). The Pi, OpenCode and Hermes plugins and the legacy shell hooks are thin delegates around one binary call, `rtk rewrite`; the Rust-binary hooks that `rtk init` installs today (`rtk hook claude` and friends) run the same registry in-process. For a host of your own, `rtk rewrite` is the whole integration surface. Everything below was verified against rtk 0.48.0.
 
 ## What `rtk rewrite` returns
 
@@ -37,7 +37,7 @@ Three more details of the call:
 - **Compare output with input.** A command that already starts with `rtk` comes back unchanged (still exit 3), and there is nothing to substitute.
 - **Check `RTK_DISABLED` yourself before spawning `rtk rewrite`**, as the Pi extension does. Releases up to 0.48.0 honor it only as an in-command prefix (`rtk rewrite "RTK_DISABLED=1 git status"` exits 1); [rtk-ai/rtk#3917](https://github.com/rtk-ai/rtk/pull/3917) makes `rtk rewrite` honor the exported variable as well.
 
-`rtk rewrite` does not run the command and does not open the savings database. Compound commands are handled (`cargo fmt --all && cargo test` becomes `rtk cargo fmt --all && rtk cargo test`); commands containing redirects or command substitution pass through with exit 1.
+`rtk rewrite` does not run the command and does not open the savings database. Compound commands are handled (`cargo fmt --all && cargo test` becomes `rtk cargo fmt --all && rtk cargo test`); commands containing a file redirect (`> out.txt`) or command substitution pass through with exit 1; a file-descriptor duplication such as `2>&1` does not block the rewrite.
 
 ## Where the call goes
 
@@ -151,4 +151,4 @@ The figures from `rtk gain` measure bash output bytes, converted to tokens by es
 
 ## Verified against
 
-rtk 0.48.0 on macOS. Exit codes come from `src/hooks/rewrite_cmd.rs` and `hooks/pi/rtk.ts`, the `rtk gain` field names from `src/core/tracking.rs`, and every command above was run against that binary.
+rtk 0.48.0 on macOS. Exit codes come from `src/hooks/rewrite_cmd.rs` and `hooks/pi/rtk.ts`, the `rtk gain --format json` field names from `ExportSummary` in `src/analytics/gain.rs` (mirroring `GainSummary` in `src/core/tracking.rs`), and every command above was run against that binary.

--- a/docs/guide/getting-started/embedding.md
+++ b/docs/guide/getting-started/embedding.md
@@ -1,0 +1,154 @@
+---
+title: Embedding rtk in your own agent harness
+description: Call rtk rewrite from your own bash tool instead of installing a shipped hook — the exit-code contract, where the call goes, fail-open rules, and per-session accounting
+sidebar:
+  order: 5
+---
+
+# Embedding rtk in your own agent harness
+
+This page is for people who build an agent harness and want the rewrite step inside their own bash tool, rather than installing one of the hooks listed in [Supported Agents](supported-agents.md). Every shipped hook is a thin delegate around one binary call, `rtk rewrite`, and that call is the whole integration surface. Everything below was verified against rtk 0.48.0.
+
+## What `rtk rewrite` returns
+
+`rtk rewrite "<command>"` prints the rewritten command to stdout (no trailing newline) and reports its decision in the exit code. The contract is defined in [`src/hooks/rewrite_cmd.rs`](https://github.com/rtk-ai/rtk/blob/master/src/hooks/rewrite_cmd.rs):
+
+| Exit | Stdout | Meaning | What your host should do |
+|------|--------|---------|--------------------------|
+| 0 | rewritten command | Rewrite, and an explicit Claude Code allow rule matched | Run the rewritten command |
+| 1 | empty | No RTK equivalent | Run the original command |
+| 2 | empty | A Claude Code deny rule matched | Your call. The rule comes from Claude Code's settings, so the usual choice is to run the original command and let your own policy decide |
+| 3 | rewritten command | Rewrite, with an "ask" rule matched or no rule matched at all | Run the rewritten command |
+
+The exit code carries a permission verdict read from Claude Code's settings files (`.claude/settings.json` in the project and `~/.claude/settings.json`, plus their `.local` variants). Outside Claude Code those files usually do not exist, so no rule matches, the verdict is `Default`, and **exit 3 is the ordinary answer for every rewritable command**:
+
+```bash
+$ rtk rewrite "git status"; echo " -> exit $?"
+rtk git status -> exit 3
+$ rtk rewrite "htop"; echo " -> exit $?"
+ -> exit 1
+```
+
+A host that treats 3 as anything other than 0 has RTK silently switched off. Treat 0 and 3 identically: when stdout is non-empty, that is the command to run. On a machine that also has Claude Code installed, its allow and deny rules show up as 0 and 2; treating 0 and 3 alike keeps your host indifferent to that.
+
+Three more details of the call:
+
+- **Read stdout only.** Stderr can carry advisory lines: a once-a-day "No hook installed" notice on machines where `~/.claude` exists without an RTK hook, or an `RTK_DISABLED=1 detected` message.
+- **Compare output with input.** A command that already starts with `rtk` comes back unchanged (still exit 3), and there is nothing to substitute.
+- **`RTK_DISABLED=1` is a prefix, not an environment variable.** `rtk rewrite "RTK_DISABLED=1 git status"` exits 1; setting the variable in the environment of the `rtk rewrite` process changes nothing. If you want an environment kill switch, check it in the host before calling rtk, as the Pi extension does.
+
+`rtk rewrite` does not run the command and does not open the savings database. Compound commands are handled (`cargo fmt --all && cargo test` becomes `rtk cargo fmt --all && rtk cargo test`); commands containing redirects or command substitution pass through with exit 1.
+
+## Where the call goes
+
+Run the rewrite **after your own approval gate and before you spawn the shell**:
+
+```
+agent asks for "git status"
+  -> your policy check or permission prompt sees "git status"
+  -> rtk rewrite "git status"        prints "rtk git status", exit 3
+  -> the shell runs "rtk git status"
+  -> the model reads the filtered output
+```
+
+A person approving a command then sees the command the agent asked for, not the rewritten one, and allow or deny patterns written for `git ...` keep matching. If your transcript shows the executed command, show the rewritten form there so the substitution stays visible.
+
+## Fail open
+
+The command must always run, with or without rtk. Run the original command unchanged when:
+
+- `rtk` is not on `PATH`
+- `rtk --version` reports a version older than 0.25.0, the release that added `rtk rewrite` (the shipped hooks check for 0.23.0; on 0.23.0 and 0.24.0 the call exits 2 with nothing on stdout, one more reason to run the original on exit 2 rather than block)
+- `rtk rewrite` has not answered within about 2 seconds (the Pi and Hermes hooks use a 2 s timeout; a rewrite normally answers in under 20 ms)
+- it prints nothing to stdout
+- it exits with any code other than 0 or 3, or crashes
+- spawning it fails with `E2BIG` because the command is very long (`ARG_MAX` is 1 MiB on macOS)
+
+Probe `rtk --version` once per host process and remember the answer; do not re-probe on every command. The reference implementation is the Pi extension, [`hooks/pi/rtk.ts`](https://github.com/rtk-ai/rtk/blob/master/hooks/pi/rtk.ts): about 140 lines covering the version probe, the timeout, and the 0/3 handling.
+
+## A minimal sketch
+
+```python
+import shutil
+import subprocess
+
+TIMEOUT_S = 2
+
+
+def rtk_ready() -> bool:
+    """Probe once per process and remember the result."""
+    if shutil.which("rtk") is None:
+        return False
+    try:
+        out = subprocess.run(["rtk", "--version"], capture_output=True, text=True,
+                             timeout=TIMEOUT_S).stdout          # "rtk 0.48.0"
+        major, minor, _ = (int(x) for x in out.split()[1].split("."))
+        return (major, minor) >= (0, 25)
+    except (OSError, subprocess.TimeoutExpired, ValueError, IndexError):
+        return False
+
+
+def rewrite(command: str) -> str:
+    """Return the command to spawn. Every failure returns the input unchanged."""
+    try:
+        r = subprocess.run(["rtk", "rewrite", command], capture_output=True, text=True,
+                           timeout=TIMEOUT_S)
+    except (OSError, subprocess.TimeoutExpired):    # missing, E2BIG, crash, too slow
+        return command
+    if r.returncode in (0, 3) and r.stdout.strip():
+        return r.stdout.strip()
+    return command                                   # 1: no filter, 2: deny, anything else
+```
+
+Call `rewrite()` on the approved command string and hand the result to the same shell you would have used anyway. `rtk` has to be on the `PATH` of that shell too.
+
+## Accounting per invocation
+
+Every filtered command records its raw and filtered sizes in a SQLite history that `rtk gain` reads. The default file is shared by every project and session run under the same account, so a host that runs several sessions at once cannot attribute savings from it. Give each command its own database instead: point `RTK_DB_PATH` at a fresh temporary path, read the totals once when the command finishes, then delete the file.
+
+```bash
+export RTK_DB_PATH=/tmp/session-42/cmd-7.db   # a path that does not exist yet
+rtk git status                                # the filtered command creates the file
+rtk gain --format json                        # totals for that file only
+rm "$RTK_DB_PATH"
+```
+
+`rtk gain --format json` against a path that does not exist yet creates it and returns zeros. Without `--all` the document holds only a `summary` object, with these fields (this one is after a single `rtk git status` in a clean checkout):
+
+```json
+{
+  "summary": {
+    "total_commands": 1,
+    "total_input": 18,
+    "total_output": 13,
+    "total_saved": 5,
+    "avg_savings_pct": 27.77777777777778,
+    "total_time_ms": 26,
+    "avg_time_ms": 26
+  }
+}
+```
+
+`total_input`, `total_output`, and `total_saved` are estimated tokens (`bytes / 4`); `total_time_ms` and `avg_time_ms` are execution time in milliseconds. `RTK_DB_PATH` takes precedence over `tracking.database_path` in `config.toml`, and an empty pre-created file works as well as a missing one. The variable has no effect on `rtk rewrite`, which never opens the database.
+
+## Sandbox environment
+
+Set `RTK_TELEMETRY_DISABLED=1` in the environment of every rtk process. Telemetry is opt-in (it requires consent given through `rtk init` or `rtk telemetry enable`), so a fresh sandbox sends nothing anyway; the variable states the intent and holds if a shared config ever turns it on. See [Telemetry & Privacy](../resources/telemetry.md).
+
+## Escape hatch and exclusions
+
+- `rtk proxy <cmd>` runs a command with raw, unfiltered output. It is still recorded in the history, at zero savings. Use it when the agent needs the complete output of a command RTK would otherwise condense.
+- Commands that must never be rewritten go in `[hooks] exclude_commands` in `config.toml`; `rtk rewrite` answers exit 1 for a matching command. See [Excluding commands from auto-rewrite](configuration.md#excluding-commands-from-auto-rewrite) for the matching rules.
+
+```toml
+[hooks]
+exclude_commands = ["git rebase", "git cherry-pick"]
+```
+
+## What the numbers mean
+
+The figures from `rtk gain` measure bash output bytes, converted to tokens by estimate. They are not a bill, and they do not translate into cost at the same rate. Read [How RTK Savings Work](../resources/savings-explained.md) before putting them on a dashboard.
+
+## Verified against
+
+rtk 0.48.0 on macOS. Exit codes come from `src/hooks/rewrite_cmd.rs` and `hooks/pi/rtk.ts`, the `rtk gain` field names from `src/core/tracking.rs`, and every command above was run against that binary.

--- a/docs/guide/getting-started/supported-agents.md
+++ b/docs/guide/getting-started/supported-agents.md
@@ -263,6 +263,8 @@ Strips only RTK's `[[hooks]]` block and the `~/.vibe/prompts/rtk.md` file. Any o
 
 Rules file integrations (Cline, Windsurf, Codex, Kilo Code, Antigravity) rely on the model following instructions. Full hook integrations (Claude Code, Cursor, Gemini) are guaranteed — the command is rewritten before the agent sees it. Plugin integrations (OpenCode, Pi) use in-place mutation via the agent's TypeScript extension API.
 
+Building a harness of your own? A host can skip these hooks and call `rtk rewrite` from its own bash tool. [Embedding rtk in your own agent harness](embedding.md) covers the exit-code contract, where the call goes, the fail-open rules, and per-session accounting.
+
 ## Windows support
 
 The shell hook (`rtk-rewrite.sh`) requires a Unix shell. On native Windows:


### PR DESCRIPTION
## Summary

- Adds `docs/guide/getting-started/embedding.md`, a one-page guide for hosts that call `rtk rewrite` from their own bash tool instead of installing one of the shipped hooks. Nothing in `docs/` covered that case; the shipped hooks are the only worked examples and each is tied to one agent's JSON format.
- Documents the `rtk rewrite` exit-code contract as a non-Claude-Code host sees it. Outside Claude Code no settings files exist, `PermissionVerdict::Default` maps to exit 3, so **exit 3 is the ordinary answer for every rewritable command**. A host that treats 3 as anything but 0 has RTK silently switched off. That trap is the reason the page exists.
- Covers call ordering (after the host's own approval gate, before the shell is spawned), the fail-open rules with `hooks/pi/rtk.ts` as the reference implementation, a minimal Python sketch, per-invocation `RTK_DB_PATH` accounting with the verified `rtk gain --format json` field names, `RTK_TELEMETRY_DISABLED=1` for sandboxes, `rtk proxy` and `[hooks] exclude_commands`, and links to the savings caveat instead of restating it.
- Cross-links the page from the "Integration tiers explained" section of `supported-agents.md`. Sidebar order 5 in the frontmatter, matching the other getting-started pages.
- The `RTK_DISABLED` note is written to stay true once #3917 (honour the exported variable in `rtk rewrite`) lands: it tells the host to check the variable itself, states that releases up to 0.48.0 honour it only as an in-command prefix, and links #3917.
- **Version floor, for the maintainers to decide.** The page says `rtk rewrite` needs 0.25.0. The release history agrees on three independent lines: the rewrite command file (`src/rewrite_cmd.rs` at the time, `src/hooks/rewrite_cmd.rs` since 46fa31c) is absent at v0.23.0 and v0.24.0 and present at v0.25.0 (GitHub contents API); commit f447a3d, `feat: rtk rewrite — single source of truth for LLM hook rewrites (#241)` of 2026-03-05, is not an ancestor of v0.24.0 and is first contained in v0.25.0; and `CHANGELOG.md` lists `rtk rewrite` under 0.25.0 (2026-03-05). The v0.23.0 and v0.24.0 release binaries answer `rtk rewrite "git status"` with exit 2 and empty stdout. The 0.23.0 floor in `hooks/pi/rtk.ts` (header comment and `MIN_SUPPORTED_RTK_MINOR`), `hooks/claude/rtk-rewrite.sh`, `hooks/cursor/rtk-rewrite.sh`, `hooks/README.md`, `hooks/claude/README.md` and `hooks/cursor/README.md` is therefore inconsistent with the release history. This PR leaves those files alone. Either floor is safe for a fail-open host, and the page says so.

## Test plan

- Ran every command on the page against rtk 0.48.0 with `RTK_DB_PATH` pointed at a scratch directory and `RTK_TELEMETRY_DISABLED=1`: `rtk rewrite "git status"` prints `rtk git status` and exits 3; `htop`, a redirect, and an `RTK_DISABLED=1` prefix exit 1 with empty stdout; a compound command rewrites both sides; an already-prefixed command comes back unchanged.
- Simulated allow, deny, ask and no-rule verdicts with a temporary `HOME` holding a `.claude/settings.json`: exit 0, 2, 3, 3 as documented. A `[hooks] exclude_commands` entry in a temporary `config.toml` makes the excluded command exit 1.
- `rtk gain --format json` against a path that does not exist creates it and returns zeros; after one `rtk git status` the `summary` object holds exactly the seven fields listed on the page; `rtk proxy` is tracked at zero savings; no sidecar files are left behind, so deleting the one file is enough. A missing parent directory and an empty pre-created file both work.
- Executed the Python sketch from the page against the real binary, an empty `PATH`, a 1.5 MB argument (`E2BIG`), and the v0.23.0 and v0.24.0 release binaries: every failure path returns the original command.
- Cross-checked the version floor three ways: the GitHub contents API for the rewrite command file at v0.23.0, v0.24.0 and v0.25.0; `git log --diff-filter=A --follow` plus `git merge-base --is-ancestor` and `git tag --contains` on a full clone; and the `CHANGELOG.md` entry. All three give 0.25.0.
- Checked that every relative link and anchor in the new page resolves and that the two linked source files exist on `master`.
