### PR TITLE
fix(ruff): match format routing to first argument

### DIFF
--- a/src/cmds/python/ruff_cmd.rs
+++ b/src/cmds/python/ruff_cmd.rs
@@ -48,7 +48,7 @@ struct RuffDiagnostic {
 pub fn run(args: &[String], verbose: u8) -> Result<i32> {
     let is_check = is_check_invocation(args);
 
-    let is_format = args.iter().any(|a| a == "format");
+    let is_format = is_format_invocation(args);
 
     let mut cmd = resolved_command("ruff");
 
@@ -117,6 +117,10 @@ fn is_check_invocation(args: &[String]) -> bool {
     args.first().is_none_or(|arg| {
         arg == "check" || (!arg.starts_with('-') && !RUFF_SUBCOMMANDS.contains(&arg.as_str()))
     })
+}
+
+fn is_format_invocation(args: &[String]) -> bool {
+    args.first().is_some_and(|a| a == "format")
 }
 
 /// Filter ruff check JSON output - group by rule and file
@@ -414,6 +418,12 @@ mod tests {
     fn top_level_flags_are_not_misclassified_as_paths() {
         assert!(!is_check_invocation(&["--version".to_string()]));
         assert!(!is_check_invocation(&["--help".to_string()]));
+    }
+
+    #[test]
+    fn test_ruff_format_routing_requires_first_argument() {
+        assert!(is_format_invocation(&["format".to_string(), "--check".to_string()]));
+        assert!(!is_format_invocation(&["help".to_string(), "format".to_string()]));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Route Ruff format filtering only when `format` is the first argument.
- Add a focused regression test covering `format --check` and `help format`.

## 中文说明

修复 Ruff 参数路由：只有首个参数是 `format` 时才进入 format 过滤；后续参数中的 `format` 不再意外绕过 passthrough 截断。

## Testing

- `cargo fmt --all`
- `cargo clippy --all-targets`
- `cargo test --all` (3258 unit tests passed, 8 ignored; all integration tests passed)
- Focused red-green regression test: `ruff_format_routing_requires_first_argument`

Fixes #3928