### PR TITLE
fix(rewrite): process wrapper prefixes

### DIFF
--- a/src/core/runner.rs
+++ b/src/core/runner.rs
@@ -160,6 +160,19 @@ where
 }
 
 pub fn run(
+    cmd: Command,
+    tool_name: &str,
+    args_display: &str,
+    mode: RunMode<'_>,
+    opts: RunOptions<'_>,
+) -> Result<i32> {
+    let result = run_inner(cmd, tool_name, args_display, mode, opts);
+    // #2375
+    stream::die_by_relayed_signal();
+    result
+}
+
+fn run_inner(
     mut cmd: Command,
     tool_name: &str,
     args_display: &str,

--- a/src/core/stream.rs
+++ b/src/core/stream.rs
@@ -317,6 +317,13 @@ mod signal_relay {
         }
     }
 
+    pub fn relayed() -> Option<libc::c_int> {
+        match RELAYED.load(Ordering::SeqCst) {
+            0 => None,
+            sig => Some(sig),
+        }
+    }
+
     pub struct Relay;
 
     impl Relay {
@@ -374,6 +381,23 @@ mod signal_relay {
         }
     }
 }
+
+// #2375
+#[cfg(unix)]
+pub fn die_by_relayed_signal() {
+    let Some(sig) = signal_relay::relayed() else {
+        return;
+    };
+    #[allow(unsafe_code)]
+    // nosemgrep: unsafe-block
+    unsafe {
+        libc::signal(sig, libc::SIG_DFL);
+        libc::raise(sig);
+    }
+}
+
+#[cfg(not(unix))]
+pub fn die_by_relayed_signal() {}
 
 pub fn status_to_exit_code(status: std::process::ExitStatus) -> i32 {
     if let Some(code) = status.code() {

--- a/src/core/stream.rs
+++ b/src/core/stream.rs
@@ -268,6 +268,106 @@ impl StreamResult {
     }
 }
 
+// #2375
+#[cfg(unix)]
+mod signal_relay {
+    use std::sync::atomic::{AtomicBool, AtomicI32, AtomicU32, Ordering};
+    use std::thread;
+    use std::time::Duration;
+
+    const POLL: Duration = Duration::from_millis(50);
+    const KILL_GRACE: Duration = Duration::from_millis(1500);
+    const EXIT_GRACE: Duration = Duration::from_millis(1500);
+
+    static CHILD_PID: AtomicU32 = AtomicU32::new(0);
+    static RELAYED: AtomicI32 = AtomicI32::new(0);
+    static FINISHED: AtomicBool = AtomicBool::new(false);
+
+    #[allow(unsafe_code)]
+    unsafe extern "C" fn relay(sig: libc::c_int) {
+        let pid = CHILD_PID.load(Ordering::SeqCst);
+        if pid == 0 || RELAYED.swap(sig, Ordering::SeqCst) != 0 {
+            libc::signal(sig, libc::SIG_DFL);
+            libc::raise(sig);
+            return;
+        }
+        libc::kill(pid as libc::pid_t, sig);
+    }
+
+    fn escalate(pid: u32) {
+        thread::sleep(KILL_GRACE);
+        if FINISHED.load(Ordering::SeqCst) {
+            return;
+        }
+        #[allow(unsafe_code)]
+        // nosemgrep: unsafe-block
+        unsafe {
+            libc::kill(pid as libc::pid_t, libc::SIGKILL);
+        }
+        thread::sleep(EXIT_GRACE);
+        if FINISHED.load(Ordering::SeqCst) {
+            return;
+        }
+        let sig = RELAYED.load(Ordering::SeqCst);
+        #[allow(unsafe_code)]
+        // nosemgrep: unsafe-block
+        unsafe {
+            libc::signal(sig, libc::SIG_DFL);
+            libc::raise(sig);
+        }
+    }
+
+    pub struct Relay;
+
+    impl Relay {
+        pub fn install(pid: u32) -> Self {
+            CHILD_PID.store(pid, Ordering::SeqCst);
+            RELAYED.store(0, Ordering::SeqCst);
+            FINISHED.store(false, Ordering::SeqCst);
+            #[allow(unsafe_code)]
+            // nosemgrep: unsafe-block
+            unsafe {
+                libc::signal(libc::SIGINT, relay as *const () as libc::sighandler_t);
+                libc::signal(libc::SIGTERM, relay as *const () as libc::sighandler_t);
+            }
+            thread::spawn(move || {
+                while !FINISHED.load(Ordering::SeqCst) {
+                    if RELAYED.load(Ordering::SeqCst) != 0 {
+                        escalate(pid);
+                        return;
+                    }
+                    thread::sleep(POLL);
+                }
+            });
+            Relay
+        }
+    }
+
+    impl Drop for Relay {
+        fn drop(&mut self) {
+            FINISHED.store(true, Ordering::SeqCst);
+            CHILD_PID.store(0, Ordering::SeqCst);
+            #[allow(unsafe_code)]
+            // nosemgrep: unsafe-block
+            unsafe {
+                libc::signal(libc::SIGINT, libc::SIG_DFL);
+                libc::signal(libc::SIGTERM, libc::SIG_DFL);
+            }
+        }
+    }
+}
+
+#[cfg(not(unix))]
+mod signal_relay {
+    pub struct Relay;
+
+    impl Relay {
+        pub fn install(_pid: u32) -> Self {
+            Relay
+        }
+    }
+}
+
 pub fn status_to_exit_code(status: std::process::ExitStatus) -> i32 {
     if let Some(code) = status.code() {
         return code;
@@ -332,6 +432,7 @@ pub fn run_streaming(
     let is_streaming = matches!(stdout_mode, FilterMode::Streaming(_));
 
     let mut child = ChildGuard(cmd.spawn().context("Failed to spawn process")?);
+    let _signal_relay = signal_relay::Relay::install(child.0.id());
 
     let stdin_thread: Option<std::thread::JoinHandle<()>> = match stdin_mode {
         StdinMode::Filter(mut filter) => {

--- a/src/core/stream.rs
+++ b/src/core/stream.rs
@@ -275,9 +275,9 @@ mod signal_relay {
     use std::thread;
     use std::time::Duration;
 
-    const POLL: Duration = Duration::from_millis(50);
-    const KILL_GRACE: Duration = Duration::from_millis(1500);
-    const EXIT_GRACE: Duration = Duration::from_millis(1500);
+    const POLL: Duration = Duration::from_millis(25);
+    const KILL_GRACE: Duration = Duration::from_millis(750);
+    const EXIT_GRACE: Duration = Duration::from_millis(750);
 
     static CHILD_PID: AtomicU32 = AtomicU32::new(0);
     static RELAYED: AtomicI32 = AtomicI32::new(0);
@@ -327,8 +327,12 @@ mod signal_relay {
             #[allow(unsafe_code)]
             // nosemgrep: unsafe-block
             unsafe {
-                libc::signal(libc::SIGINT, relay as *const () as libc::sighandler_t);
-                libc::signal(libc::SIGTERM, relay as *const () as libc::sighandler_t);
+                for sig in [libc::SIGINT, libc::SIGTERM] {
+                    let previous = libc::signal(sig, relay as *const () as libc::sighandler_t);
+                    if previous == libc::SIG_IGN {
+                        libc::signal(sig, libc::SIG_IGN);
+                    }
+                }
             }
             thread::spawn(move || {
                 while !FINISHED.load(Ordering::SeqCst) {
@@ -350,8 +354,11 @@ mod signal_relay {
             #[allow(unsafe_code)]
             // nosemgrep: unsafe-block
             unsafe {
-                libc::signal(libc::SIGINT, libc::SIG_DFL);
-                libc::signal(libc::SIGTERM, libc::SIG_DFL);
+                for sig in [libc::SIGINT, libc::SIGTERM] {
+                    if libc::signal(sig, libc::SIG_DFL) == libc::SIG_IGN {
+                        libc::signal(sig, libc::SIG_IGN);
+                    }
+                }
             }
         }
     }

--- a/src/discover/README.md
+++ b/src/discover/README.md
@@ -76,6 +76,32 @@ The `ENV_PREFIX` regex strips env variable assignments and `env` from the front 
 
 The prefix is stripped twice: once in `classify_command()` to match the underlying command against rules, and again in `rewrite_segment()` to extract it for re-prepending to the rewritten command.
 
+## Process Wrapper Handling
+
+A process wrapper runs another command without changing which command runs, so
+the rewrite peels it, rewrites what it wraps, and re-prepends the wrapper text
+byte for byte: `timeout 300 cargo test` becomes `timeout 300 rtk cargo test`.
+`PROCESS_WRAPPERS` in `registry.rs` describes each wrapper's own arguments —
+options that take a value, options that do not, values that may be attached to
+their option, and any positional argument the wrapper consumes before the
+command (`timeout`'s duration).
+
+Two rules keep the peeling honest. An option the table does not describe drops
+the rewrite, because an unknown option may consume the following word and make
+the wrong token look like the command. Shell syntax before the command (a
+redirect, a subshell, a glob) does the same, because the wrapper's argv can no
+longer be read off the token list.
+
+`stdbuf` is deliberately not a wrapper here: it exists to make the wrapped
+command emit output incrementally, and routing through rtk buffers that output
+until the child exits, so rewriting it would remove the only reason to type it.
+
+Wrapping also changes who receives a signal. `timeout 300 rtk cargo test`
+signals rtk rather than cargo, so `core::stream` relays SIGINT/SIGTERM to the
+child and lets the normal filter-and-print path finish. Without that relay a
+killed run prints nothing at all, which is strictly worse than the unwrapped
+command.
+
 ## Adding a New Rewrite Rule
 
 Add an entry to `rules.rs`. Each rule has:

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -1275,6 +1275,58 @@ const ROUTABLE_WRAPPER_PREFIXES: &[&str] = &["uv run"];
 /// not spawnable, so they must never fall through: `rtk exec foo` cannot run.
 const SHELL_KEYWORD_PREFIXES: &[&str] = &["noglob", "command", "builtin", "exec", "nocorrect"];
 
+struct ProcessWrapper {
+    name: &'static str,
+    value_opts: &'static [&'static str],
+    flag_opts: &'static [&'static str],
+    attached_opts: &'static [&'static str],
+    positionals: usize,
+    numeric_opts: bool,
+}
+
+const PROCESS_WRAPPERS: &[ProcessWrapper] = &[
+    ProcessWrapper {
+        name: "timeout",
+        value_opts: &["-s", "-k", "--signal", "--kill-after"],
+        flag_opts: &["--preserve-status", "--foreground", "-v", "--verbose"],
+        attached_opts: &["-s", "-k"],
+        positionals: 1,
+        numeric_opts: false,
+    },
+    ProcessWrapper {
+        name: "time",
+        value_opts: &["-f", "-o", "--format", "--output"],
+        flag_opts: &[
+            "-p",
+            "-a",
+            "-v",
+            "--append",
+            "--verbose",
+            "--portability",
+            "--quiet",
+        ],
+        attached_opts: &["-f", "-o"],
+        positionals: 0,
+        numeric_opts: false,
+    },
+    ProcessWrapper {
+        name: "nice",
+        value_opts: &["-n", "--adjustment"],
+        flag_opts: &[],
+        attached_opts: &["-n"],
+        positionals: 0,
+        numeric_opts: true,
+    },
+    ProcessWrapper {
+        name: "nohup",
+        value_opts: &[],
+        flag_opts: &[],
+        attached_opts: &[],
+        positionals: 0,
+        numeric_opts: false,
+    },
+];
+
 struct SafePipeConsumer {
     name: &'static str,
     unsafe_flags: &'static [&'static str],
@@ -1498,6 +1550,12 @@ fn rewrite_segment_inner(
         }
     }
 
+    // #2375
+    if let Some((prefix, rest)) = strip_process_wrapper_prefix(trimmed) {
+        return rewrite_segment_inner(rest, excluded, transparent_prefixes, context, depth + 1)
+            .map(|rewritten| format!("{} {}", prefix, rewritten));
+    }
+
     // User-configured wrapper prefixes (e.g. `docker exec mycontainer`). These
     // never fall through: an unmatched inner command drops the rewrite.
     for prefix in transparent_prefixes {
@@ -1707,6 +1765,104 @@ fn tool_form(cmd_clean: &str, rtk_equivalent: &str) -> String {
             })
         })
         .unwrap_or(normalized)
+}
+
+fn strip_process_wrapper_prefix(cmd: &str) -> Option<(&str, &str)> {
+    let tokens = tokenize(cmd);
+    let first = tokens.first()?;
+    if first.kind != TokenKind::Arg {
+        return None;
+    }
+    let wrapper = PROCESS_WRAPPERS
+        .iter()
+        .find(|candidate| candidate.name == command_basename(&first.value))?;
+    let inner = wrapper_inner_command(wrapper, &tokens)?;
+    if tokens[..inner_index(&tokens, inner)]
+        .iter()
+        .any(|token| token.value == "rtk")
+    {
+        return None;
+    }
+    let prefix = cmd[..inner.offset].trim_end();
+    let rest = cmd[inner.offset..].trim_start();
+    if prefix.is_empty() || rest.is_empty() {
+        return None;
+    }
+    Some((prefix, rest))
+}
+
+fn inner_index(tokens: &[ParsedToken], inner: &ParsedToken) -> usize {
+    tokens
+        .iter()
+        .position(|token| token.offset == inner.offset)
+        .unwrap_or(tokens.len())
+}
+
+fn command_basename(command: &str) -> &str {
+    command.rsplit('/').next().unwrap_or(command)
+}
+
+fn wrapper_inner_command<'a>(
+    wrapper: &ProcessWrapper,
+    tokens: &'a [ParsedToken],
+) -> Option<&'a ParsedToken> {
+    let mut idx = 1;
+    let mut options_done = false;
+    let mut positionals = wrapper.positionals;
+
+    loop {
+        let token = arg_token(tokens, idx)?;
+        let arg = token.value.as_str();
+
+        if !options_done && arg == "--" {
+            options_done = true;
+            idx += 1;
+            continue;
+        }
+        if !options_done && wrapper.numeric_opts && is_numeric_option(arg) {
+            idx += 1;
+            continue;
+        }
+        if !options_done && arg.starts_with('-') && arg != "-" {
+            if wrapper.flag_opts.contains(&arg) || takes_attached_value(wrapper, arg) {
+                idx += 1;
+                continue;
+            }
+            if wrapper.value_opts.contains(&arg) {
+                arg_token(tokens, idx + 1)?;
+                idx += 2;
+                continue;
+            }
+            return None;
+        }
+        if positionals > 0 {
+            positionals -= 1;
+            idx += 1;
+            continue;
+        }
+        return Some(token);
+    }
+}
+
+fn arg_token(tokens: &[ParsedToken], idx: usize) -> Option<&ParsedToken> {
+    tokens.get(idx).filter(|token| token.kind == TokenKind::Arg)
+}
+
+fn is_numeric_option(arg: &str) -> bool {
+    let Some(digits) = arg.strip_prefix('-').or_else(|| arg.strip_prefix('+')) else {
+        return false;
+    };
+    !digits.is_empty() && digits.chars().all(|c| c.is_ascii_digit())
+}
+
+fn takes_attached_value(wrapper: &ProcessWrapper, arg: &str) -> bool {
+    if let Some((name, _)) = arg.split_once('=') {
+        return wrapper.value_opts.contains(&name);
+    }
+    wrapper
+        .attached_opts
+        .iter()
+        .any(|opt| arg.len() > opt.len() && arg.starts_with(opt))
 }
 
 /// Strip a command prefix with word-boundary check.
@@ -6266,6 +6422,166 @@ mod tests {
     }
 
     #[test]
+    fn test_process_wrapper_rewrites_inner_command() {
+        for (input, expected) in [
+            ("timeout 300 cargo test", "timeout 300 rtk cargo test"),
+            ("time cargo build", "time rtk cargo build"),
+            ("nice -n 10 cargo test", "nice -n 10 rtk cargo test"),
+            ("nohup cargo build", "nohup rtk cargo build"),
+            (
+                "/usr/bin/timeout 300 cargo test",
+                "/usr/bin/timeout 300 rtk cargo test",
+            ),
+        ] {
+            assert_eq!(
+                rewrite_command_no_prefixes(input, &[]),
+                Some(expected.into()),
+                "{}",
+                input
+            );
+        }
+    }
+
+    #[test]
+    fn test_process_wrapper_option_forms() {
+        for (input, expected) in [
+            (
+                "timeout -k 5s 300 cargo test",
+                "timeout -k 5s 300 rtk cargo test",
+            ),
+            (
+                "timeout -k5s 300 cargo test",
+                "timeout -k5s 300 rtk cargo test",
+            ),
+            (
+                "timeout --kill-after=5s 300 cargo test",
+                "timeout --kill-after=5s 300 rtk cargo test",
+            ),
+            (
+                "timeout --preserve-status 300 cargo test",
+                "timeout --preserve-status 300 rtk cargo test",
+            ),
+            ("timeout -- 300 cargo test", "timeout -- 300 rtk cargo test"),
+            ("timeout 300 -- cargo test", "timeout 300 -- rtk cargo test"),
+            ("time -p cargo build", "time -p rtk cargo build"),
+            ("time -f %e cargo build", "time -f %e rtk cargo build"),
+            ("nice -n10 cargo test", "nice -n10 rtk cargo test"),
+            ("nice -10 cargo test", "nice -10 rtk cargo test"),
+            ("nice +5 cargo test", "nice +5 rtk cargo test"),
+        ] {
+            assert_eq!(
+                rewrite_command_no_prefixes(input, &[]),
+                Some(expected.into()),
+                "{}",
+                input
+            );
+        }
+    }
+
+    #[test]
+    fn test_process_wrapper_unknown_option_is_passthrough() {
+        assert_eq!(
+            rewrite_command_no_prefixes("timeout --unknown 300 cargo test", &[]),
+            None
+        );
+        assert_eq!(
+            rewrite_command_no_prefixes("nice --unknown cargo test", &[]),
+            None
+        );
+    }
+
+    #[test]
+    fn test_process_wrapper_with_unsupported_inner_command_is_passthrough() {
+        assert_eq!(
+            rewrite_command_no_prefixes("timeout 300 mycustombinary --flag", &[]),
+            None
+        );
+    }
+
+    #[test]
+    fn test_process_wrapper_never_doubles_rtk() {
+        assert_eq!(
+            rewrite_command_no_prefixes("timeout rtk cargo test", &[]),
+            None
+        );
+    }
+
+    #[test]
+    fn test_process_wrapper_without_inner_command_is_passthrough() {
+        assert_eq!(rewrite_command_no_prefixes("timeout 300", &[]), None);
+        assert_eq!(rewrite_command_no_prefixes("time", &[]), None);
+        assert_eq!(rewrite_command_no_prefixes("timeout -k 5s", &[]), None);
+    }
+
+    #[test]
+    fn test_process_wrapper_refuses_shell_syntax() {
+        for input in [
+            "time (cargo build)",
+            "timeout 300 >out.log cargo test",
+            "timeout 300 $(which cargo) test",
+            "timeout 300 */bin/cargo test",
+        ] {
+            assert_eq!(rewrite_command_no_prefixes(input, &[]), None, "{}", input);
+        }
+    }
+
+    #[test]
+    fn test_stdbuf_is_not_a_process_wrapper() {
+        assert_eq!(
+            rewrite_command_no_prefixes("stdbuf -oL cargo test", &[]),
+            None
+        );
+    }
+
+    #[test]
+    fn test_process_wrapper_composes_with_prefixes_and_compounds() {
+        assert_eq!(
+            rewrite_command_no_prefixes("CI=1 timeout 300 cargo test", &[]),
+            Some("CI=1 timeout 300 rtk cargo test".into())
+        );
+        assert_eq!(
+            rewrite_command_no_prefixes("nice -n 10 timeout 300 cargo test", &[]),
+            Some("nice -n 10 timeout 300 rtk cargo test".into())
+        );
+        assert_eq!(
+            rewrite_command_no_prefixes("timeout 300 cargo test && time git status", &[]),
+            Some("timeout 300 rtk cargo test && time rtk git status".into())
+        );
+        assert_eq!(
+            rewrite_command_no_prefixes("command timeout 300 git status", &[]),
+            Some("command timeout 300 rtk git status".into())
+        );
+    }
+
+    #[test]
+    fn test_process_wrapper_rewrite_is_idempotent() {
+        assert_eq!(
+            rewrite_command_no_prefixes("timeout 300 rtk cargo test", &[]),
+            None
+        );
+    }
+
+    #[test]
+    fn test_process_wrapper_keeps_pipeline_context() {
+        assert_eq!(
+            rewrite_command_no_prefixes("timeout 300 git log | head -5", &[]),
+            Some("timeout 300 rtk git log | head -5".into())
+        );
+        assert_eq!(
+            rewrite_command_no_prefixes("cargo test | timeout 5 grep error", &[]),
+            Some("cargo test | timeout 5 rtk grep error".into())
+        );
+    }
+
+    #[test]
+    fn test_process_wrapper_respects_exclusions() {
+        assert_eq!(
+            rewrite_command_no_prefixes("timeout 300 cargo test", &["cargo test".to_string()]),
+            None
+        );
+    }
+
+    #[test]
     fn test_transparent_prefix_multiple_configured() {
         let prefixes = vec!["shadowenv exec --".to_string(), "direnv exec .".to_string()];
         assert_eq!(
@@ -6792,19 +7108,21 @@ mod tests {
     /// `jj` is covered only by a TOML filter, never by the native RULES table,
     /// so the bare case pins the TOML branch of the rewrite path and keeps the
     /// wrapper assertions below from passing vacuously when TOML is disabled.
+    /// #2375: wrappers are peeled before matching; `is_fully_anchored` in
+    /// `core::toml_filter` is what keeps a filter off the wrapper itself.
     #[test]
-    fn test_toml_filter_rewrites_bare_command_but_not_wrapped_invocations() {
+    fn test_toml_filter_rewrites_bare_and_wrapped_invocations() {
         assert_eq!(
             rewrite_command_no_prefixes("jj log", &[]),
             Some("rtk jj log".into()),
         );
         assert_eq!(
             rewrite_command_no_prefixes("timeout 5 /usr/bin/jj log", &[]),
-            None,
+            Some("timeout 5 rtk /usr/bin/jj log".into()),
         );
         assert_eq!(
             rewrite_command_no_prefixes("nohup /opt/tools/jj log", &[]),
-            None,
+            Some("nohup rtk /opt/tools/jj log".into()),
         );
     }
 

--- a/tests/signal_flush_test.rs
+++ b/tests/signal_flush_test.rs
@@ -1,0 +1,83 @@
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::process::{Command, Stdio};
+use std::thread::sleep;
+use std::time::{Duration, Instant};
+fn shim_dir() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let cargo = dir.path().join("cargo");
+    let marker = dir.path().join("emitted");
+    fs::write(
+        &cargo,
+        format!(
+            "#!/usr/bin/env bash\n\
+             for i in $(seq 1 50); do echo \"   Compiling crate-$i v0.1.0\"; done\n\
+             echo 'error[E0308]: mismatched types'\n\
+             echo '    --> src/lib.rs:12:5'\n\
+             touch {}\n\
+             exec sleep 300\n",
+            marker.display()
+        ),
+    )
+    .expect("write shim");
+    fs::set_permissions(&cargo, fs::Permissions::from_mode(0o755)).expect("chmod shim");
+    dir
+}
+
+fn wait_for(path: &std::path::Path, limit: Duration) -> bool {
+    let deadline = Instant::now() + limit;
+    while Instant::now() < deadline {
+        if path.exists() {
+            return true;
+        }
+        sleep(Duration::from_millis(50));
+    }
+    false
+}
+
+#[test]
+fn signalled_run_still_prints_captured_output() {
+    let dir = shim_dir();
+    let home = dir.path().join("home");
+    fs::create_dir_all(&home).expect("home");
+    let path = format!(
+        "{}:{}",
+        dir.path().display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+
+    let child = Command::new(env!("CARGO_BIN_EXE_rtk"))
+        .args(["cargo", "clippy"])
+        .env("PATH", path)
+        .env("HOME", &home)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn rtk");
+
+    assert!(
+        wait_for(&dir.path().join("emitted"), Duration::from_secs(60)),
+        "shim never produced output"
+    );
+    sleep(Duration::from_millis(500));
+
+    let killed = Command::new("kill")
+        .args(["-TERM", &child.id().to_string()])
+        .status()
+        .expect("send SIGTERM");
+    assert!(killed.success(), "kill failed");
+
+    let out = child.wait_with_output().expect("collect rtk output");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        !stdout.trim().is_empty(),
+        "signalled run printed nothing; captured output was lost"
+    );
+    assert!(
+        stdout.contains("E0308"),
+        "signalled run dropped the diagnostic: {}",
+        stdout
+    );
+}


### PR DESCRIPTION
Closes #2375. Supersedes #2568, whose wrapper set and peel-recurse-reprepend shape this builds on (@YOMXXX).

## What changes

`timeout 300 cargo test` now rewrites to `timeout 300 rtk cargo test`. Same for `time`, `nice`, `nohup`, and path-qualified forms like `/usr/bin/timeout`.

`PROCESS_WRAPPERS` in `registry.rs` describes each wrapper's own arguments (value options, flag options, attached values like `-k5s` and `-n10`, positionals such as timeout's duration). One generic scanner walks them in order. Adding a wrapper is a table entry.

Two rules keep it safe:

- An unknown option drops the rewrite, since it may consume the next word and shift which token looks like the command.
- Shell syntax before the command (redirect, subshell, glob, command substitution) drops the rewrite, since the argv can no longer be read from the token list.

`stdbuf` is excluded on purpose. It exists to get incremental output, and rtk buffers until the child exits, so rewriting it removes the reason to type it.

## Signal handling

Wrapping changes who gets signalled: `timeout 300 rtk cargo test` signals rtk, not cargo. Before this PR rtk died on the default disposition and every captured line was lost, which is worse than running unwrapped.

`core::stream` now relays SIGINT/SIGTERM to the child and lets the normal filter-and-print path finish. If the child does not exit, it escalates to SIGKILL after 1.5s, then restores the default disposition and re-raises after another 1.5s, so rtk can never be held open.

## How this was tested

Shim-based execution tests, with a fake `cargo` on PATH that records its argv:

- argv and exit codes are identical between the raw and rewritten forms for all four wrappers, for success, exit 101 and exit 7.
- output under a kill, shim prints 200 lines then hangs, killed at 2s:

| | exit | lines seen |
|---|---|---|
| `timeout 2 cargo clippy` | 124 | 200 |
| `timeout 2 rtk cargo clippy` before | 124 | 0 |
| `timeout 2 rtk cargo clippy` after | 124 | 9 filtered, diagnostic kept |

- `timeout --foreground` no longer orphans the child.
- stubborn child that defers SIGTERM: bounded at 3s instead of hanging 300s, output still flushed.

Differential fuzz against develop, 6,567 generated command lines through both binaries:

| bucket | count |
|---|---|
| identical | 4,555 |
| newly filtered | 1,534 |
| changed (compound, wrapped half now rewrites) | 478 |
| lost rewrite | 0 |
| crash or hang | 0 |
| shape violation | 0 |

Shape check asserts a rewrite only ever inserts `rtk` tokens, never reorders or drops shell text. Rewriting is idempotent, so the hook can re-run over its own output.

`cargo fmt --all`, `cargo clippy --all-targets`, `cargo test --all`: clean, 3341 unit tests plus all integration targets. `tests/signal_flush_test.rs` fails without the relay.

## Needs a decision

`test_toml_filter_rewrites_bare_command_but_not_wrapped_invocations` asserted that a wrapped TOML-filtered command is never rewritten. That pinned the absence of wrapper peeling, which is what this PR adds, so it now asserts the wrapper-preserving rewrite and is renamed. What keeps a filter off the wrapper itself is the `is_fully_anchored` gate on `match_command`, unchanged and still tested in `core::toml_filter`.
