### PR TITLE
fix(diff): make stdin raw fallback byte-exact (#3924)

### DIFF
--- a/src/cmds/git/diff_cmd.rs
+++ b/src/cmds/git/diff_cmd.rs
@@ -470,15 +470,13 @@ pub fn run_stdin(_verbose: u8) -> Result<()> {
             );
         }
         None => {
-            // Structural fallback: the caller's exact bytes (plus println!
-            // parity — a terminating newline when the input lacked one).
+            // Structural fallback: emit the caller's exact input bytes,
+            // byte-for-byte. condense_stdin's None contract is "exact input
+            // bytes", and RTK never adds bytes a native pipe would not produce.
             use std::io::Write;
             let mut out = io::stdout();
             out.write_all(&bytes)
                 .context("Failed to write raw diff to stdout")?;
-            if !bytes.is_empty() && !bytes.ends_with(b"\n") {
-                writeln!(out).context("Failed to write raw diff to stdout")?;
-            }
             let raw = String::from_utf8_lossy(&bytes);
             timer.track("diff (stdin)", "rtk diff (stdin)", &raw, &raw);
         }

--- a/tests/diff_stdin_byte_accuracy_test.rs
+++ b/tests/diff_stdin_byte_accuracy_test.rs
@@ -1,0 +1,68 @@
+//! Byte-exactness of `rtk diff -`'s structural fallback.
+//!
+//! When the piped stream is not a parseable diff, `rtk diff -` falls back to
+//! emitting the input bytes verbatim. That fallback is documented as
+//! byte-exact (condense_stdin's `None` contract), so it must not append a
+//! newline the native pipe would not produce.
+
+use std::io::Write;
+use std::process::{Command, Output, Stdio};
+
+fn rtk_diff_stdin(input: &[u8]) -> Output {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_rtk"))
+        .env("LC_ALL", "C")
+        .args(["diff", "-"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn rtk diff");
+    child
+        .stdin
+        .take()
+        .expect("stdin")
+        .write_all(input)
+        .expect("write stdin");
+    child.wait_with_output().expect("wait for rtk diff")
+}
+
+#[test]
+fn fallback_is_byte_exact_when_input_has_no_trailing_newline() {
+    let input: &[u8] = b"not a diff at all";
+    let out = rtk_diff_stdin(input);
+
+    assert!(
+        out.status.success(),
+        "raw fallback must succeed:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_eq!(
+        out.stdout, input,
+        "fallback must emit the exact input bytes with no trailing newline"
+    );
+}
+
+#[test]
+fn fallback_round_trips_input_with_trailing_newline() {
+    let input: &[u8] = b"not a diff at all\n";
+    let out = rtk_diff_stdin(input);
+
+    assert!(out.status.success());
+    assert_eq!(
+        out.stdout, input,
+        "newline-terminated input must round-trip byte-for-byte"
+    );
+}
+
+#[test]
+fn fallback_preserves_non_utf8_bytes() {
+    // 0xFF is not valid UTF-8; the raw fallback must not try to re-encode it.
+    let input: &[u8] = &[b'a', b'b', 0xFF, b'\n'];
+    let out = rtk_diff_stdin(input);
+
+    assert!(out.status.success());
+    assert_eq!(
+        out.stdout, input,
+        "non-UTF-8 bytes must pass through untouched"
+    );
+}


### PR DESCRIPTION
Closes #3924

## Problem

\tk diff -\'s structural fallback appends a trailing newline when the piped input has none, violating the documented contract that the raw fallback emits the caller's exact input bytes (\condense_stdin\ returns \None\ → caller emits input bytes verbatim).

Repro:
\\\
printf 'not a diff at all' | rtk diff - | wc -c   # 18 (input was 17)
\\\

Input that already ends with \\n\ round-trips byte-exact, so the bug only affects unterminated streams — exactly the truncated captures / dead producers most likely to hit the fallback.

## Fix

Drop the \writeln!\ in \un_stdin\ so the fallback emits the exact input bytes with no additions. This follows the issue's \yte-exact\ option, matches the doc contract in \condense_stdin\, and aligns with RTK's 'never adds bytes a native pipe would not produce' / byte-fidelity philosophy for unfiltered passthrough.

## Tests

New process-level test \	ests/diff_stdin_byte_accuracy_test.rs\ (as the issue requests — a unit test can't reach the write path):

- unterminated input round-trips byte-for-byte
- newline-terminated input round-trips byte-for-byte
- non-UTF-8 bytes pass through untouched (byte fidelity for the raw branch)

Verified the byte-exact test fails on \develop\ (appends \\n\) and passes with this change. \cargo clippy --all-targets\ and \cargo fmt --check\ are clean; all diff-related tests pass (233 unit + 5 integration + 3 new).