### PR TITLE
fix(cli): hand --help/-h to the wrapped tool on every forwarding subcommand

### DIFF
--- a/src/analytics/ccusage.rs
+++ b/src/analytics/ccusage.rs
@@ -103,6 +103,8 @@ fn build_command() -> Option<Command> {
 
     // Fallback: try npx
     eprintln!("[info] ccusage not installed globally, fetching via npx...");
+    // Stays on `.status()`: `core::stream::exec_capture` shows a `--help`
+    // request verbatim and exits the process (see `runner::requests_help`).
     let npx_check = resolved_command("npx")
         .arg("--yes")
         .arg("ccusage")

--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -33,6 +33,57 @@ pub enum GitCommand {
     Worktree,
 }
 
+impl GitCommand {
+    /// The git subcommand this arm runs, as the user would type it.
+    fn name(&self) -> &'static str {
+        match self {
+            GitCommand::Diff => "diff",
+            GitCommand::Log => "log",
+            GitCommand::Status => "status",
+            GitCommand::Show => "show",
+            GitCommand::Add => "add",
+            GitCommand::Commit => "commit",
+            GitCommand::Checkout => "checkout",
+            GitCommand::Push => "push",
+            GitCommand::Pull => "pull",
+            GitCommand::Branch => "branch",
+            GitCommand::Fetch => "fetch",
+            GitCommand::Stash { .. } => "stash",
+            GitCommand::Worktree => "worktree",
+        }
+    }
+
+    /// Everything the user typed after the subcommand, in order. `Stash`
+    /// parses its first operand into its own positional, so it is put back
+    /// in front of `args`: `restore_double_dash` measures the user region by
+    /// length, and a `--` before that operand (`git stash -- -h`) would
+    /// otherwise be lost.
+    fn user_args(&self, args: &[String]) -> Vec<String> {
+        match self {
+            GitCommand::Stash {
+                subcommand: Some(sub),
+            } => std::iter::once(sub.clone())
+                .chain(args.iter().cloned())
+                .collect(),
+            _ => args.to_vec(),
+        }
+    }
+}
+
+/// `-h` or `--help` before any `--` asks git for the subcommand's usage. git
+/// prints it on stdout with exit 129 (or opens the manual), and every filter
+/// here reads stdout as the subcommand's normal output: `git worktree -h`
+/// listed worktrees, `git show -h` printed nothing. Such a call is not a
+/// filtering job, so it runs through the passthrough unchanged.
+///
+/// Callers pass the args with clap's stripped `--` restored
+/// (`args_utils::restore_double_dash`): `git log -- -h` names a pathspec.
+fn requests_help(args: &[String]) -> bool {
+    args.iter()
+        .take_while(|arg| *arg != "--")
+        .any(|arg| arg == "-h" || arg == "--help")
+}
+
 /// Create a git Command with global options (e.g. -C, -c, --git-dir, --work-tree)
 /// prepended before any subcommand arguments.
 fn git_cmd(global_args: &[String]) -> Command {
@@ -90,6 +141,13 @@ pub fn run(
     verbose: u8,
     global_args: &[String],
 ) -> Result<i32> {
+    let user_args = args_utils::restore_double_dash(&cmd.user_args(args));
+    if requests_help(&user_args) {
+        let raw: Vec<OsString> = std::iter::once(OsString::from(cmd.name()))
+            .chain(user_args.iter().map(OsString::from))
+            .collect();
+        return run_passthrough(&raw, global_args, verbose);
+    }
     match cmd {
         GitCommand::Diff => run_diff(args, max_lines, verbose, global_args),
         GitCommand::Log => run_log(args, max_lines, verbose, global_args),
@@ -2656,6 +2714,48 @@ pub fn run_passthrough(args: &[OsString], global_args: &[String], verbose: u8) -
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_requests_help_before_double_dash_only() {
+        let a = |v: &[&str]| v.iter().map(|s| s.to_string()).collect::<Vec<_>>();
+        assert!(requests_help(&a(&["-h"])));
+        assert!(requests_help(&a(&["--oneline", "--help"])));
+        assert!(!requests_help(&a(&[])));
+        assert!(!requests_help(&a(&["--oneline", "-5"])));
+        // After `--` it is a pathspec, not a request for usage.
+        assert!(!requests_help(&a(&["--", "-h"])));
+        assert!(!requests_help(&a(&["--", "--help"])));
+    }
+
+    #[test]
+    fn test_stash_operand_rejoins_the_user_region_before_restoring_double_dash() {
+        let a = |v: &[&str]| v.iter().map(|s| s.to_string()).collect::<Vec<_>>();
+        // `rtk git stash -- -h`: clap put `-h` in `subcommand`, args is empty.
+        let cmd = GitCommand::Stash {
+            subcommand: Some("-h".to_string()),
+        };
+        let raw = a(&["rtk", "git", "stash", "--", "-h"]);
+        let restored = args_utils::restore_double_dash_with_raw(&cmd.user_args(&[]), &raw);
+        assert_eq!(restored, a(&["--", "-h"]));
+        assert!(!requests_help(&restored), "`-- -h` is an operand, not help");
+        // Without the operand the region is one short and the `--` is lost.
+        assert_eq!(
+            args_utils::restore_double_dash_with_raw(&[], &raw),
+            a(&["-h"])
+        );
+        // `rtk git stash list -h` still asks for usage.
+        let cmd = GitCommand::Stash {
+            subcommand: Some("list".to_string()),
+        };
+        assert!(requests_help(&cmd.user_args(&a(&["-h"]))));
+    }
+
+    #[test]
+    fn test_git_command_names_match_the_subcommand() {
+        assert_eq!(GitCommand::Log.name(), "log");
+        assert_eq!(GitCommand::Stash { subcommand: None }.name(), "stash");
+        assert_eq!(GitCommand::Worktree.name(), "worktree");
+    }
 
     #[test]
     fn test_git_cmd_no_global_args() {

--- a/src/cmds/system/find_cmd.rs
+++ b/src/cmds/system/find_cmd.rs
@@ -143,7 +143,17 @@ fn parse_subset(paths: &[String], expr: &[String]) -> Option<FindArgs> {
 /// token starting with `-`, `!` or a parenthesis, exactly like find.
 /// RTK syntax: `find <pattern> [path] [-m max] [-t type]` — used when the first
 /// token contains `*` or `?`, or is not an existing directory.
+/// GNU find spells its usage request `-help` or `--help` (`-h` is not a
+/// find flag). The compress path reads find's output as an inventory, which
+/// once rendered the usage text as `1F 1D:`; usage runs verbatim.
+fn requests_help(args: &[String]) -> bool {
+    args.iter().any(|arg| arg == "-help" || arg == "--help")
+}
+
 fn dispatch(original: &[String]) -> Result<Dispatch> {
+    if requests_help(original) {
+        return Ok(Dispatch::Verbatim(original.to_vec()));
+    }
     let (args, max, file_type) = peel_trailing_rtk_flags(original);
     let legacy = !args.is_empty()
         && !is_expression_token(&args[0])
@@ -748,6 +758,22 @@ mod tests {
     /// Convert string slices to Vec<String> for test convenience.
     fn args(values: &[&str]) -> Vec<String> {
         values.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn help_request_dispatches_verbatim() {
+        for flag in ["--help", "-help"] {
+            match dispatch(&args(&[flag])).expect("dispatch") {
+                Dispatch::Verbatim(a) => assert_eq!(a, args(&[flag])),
+                _ => panic!("find {flag} must run verbatim"),
+            }
+        }
+        match dispatch(&args(&[".", "-name", "*.rs", "--help"])).expect("dispatch") {
+            Dispatch::Verbatim(a) => assert_eq!(a, args(&[".", "-name", "*.rs", "--help"])),
+            _ => panic!("--help anywhere in a find argv is a usage request"),
+        }
+        // `-h` is not a find flag and must not be mistaken for one.
+        assert!(!requests_help(&args(&["-h"])));
     }
 
     fn parse_find_args(a: &[String]) -> Result<FindArgs> {

--- a/src/core/runner.rs
+++ b/src/core/runner.rs
@@ -2,6 +2,7 @@
 
 use anyhow::{Context, Result};
 use regex::Regex;
+use std::ffi::OsStr;
 use std::process::Command;
 use std::sync::LazyLock;
 
@@ -159,6 +160,44 @@ where
     Ok(exit_code)
 }
 
+/// Tools that define `-h` as something other than help: `psql -h host`,
+/// `ls`/`tree -h` (human sizes), `grep -h` (no filename). Everywhere else a
+/// bare `-h` is the usage request it is for cargo, go, dotnet, git, rg, …
+const DASH_H_IS_NOT_HELP: &[&str] = &["psql", "ls", "tree", "grep"];
+
+/// `--help` (or `-h`, unless the tool defines it) before any `--` asks the
+/// tool for its usage. A filter models the tool's normal output, so it reads
+/// that usage as an empty run: `cargo build --help` summarised as "0 crates
+/// compiled", `cargo test --help` as nothing. Usage is not a filtering job; it
+/// goes through the passthrough verbatim.
+///
+/// A Node tool that is not on PATH runs through its package runner
+/// (`utils::tool_exec`): `pnpm exec -- <tool>`, `yarn exec -- <tool>`,
+/// `npx [--no-install] -- <tool>`. That `--` is rtk's own and is skipped; the
+/// tool's argv starts after it.
+///
+/// The flag is read by position only: `git log --grep -h` runs verbatim
+/// (correct output, no filtering), since the tool, not rtk, knows which
+/// options take a value.
+pub fn requests_help(cmd: &Command) -> bool {
+    let stem = std::path::Path::new(cmd.get_program())
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or_default();
+    let dash_h_is_help = !DASH_H_IS_NOT_HELP.contains(&stem);
+    let args: Vec<&OsStr> = cmd.get_args().collect();
+    let runner_prefix = match (stem, args.as_slice()) {
+        ("pnpm" | "yarn", [exec, sep, ..]) if *exec == "exec" && *sep == "--" => 2,
+        ("npx", [flag, sep, ..]) if *flag == "--no-install" && *sep == "--" => 2,
+        ("npx", [sep, ..]) if *sep == "--" => 1,
+        _ => 0,
+    };
+    args[runner_prefix..]
+        .iter()
+        .take_while(|arg| **arg != "--")
+        .any(|arg| *arg == "--help" || (dash_h_is_help && *arg == "-h"))
+}
+
 pub fn run(
     mut cmd: Command,
     tool_name: &str,
@@ -166,6 +205,11 @@ pub fn run(
     mode: RunMode<'_>,
     opts: RunOptions<'_>,
 ) -> Result<i32> {
+    let mode = if requests_help(&cmd) {
+        RunMode::Passthrough
+    } else {
+        mode
+    };
     let timer = tracking::TimedExecution::start();
     let cmd_label = format!("{} {}", tool_name, args_display);
 
@@ -891,6 +935,86 @@ fn is_bun_count_line(trimmed: &str) -> bool {
 #[cfg(test)]
 mod err_test_runner_tests {
     use super::*;
+
+    #[test]
+    fn test_requests_help_reads_only_the_tools_own_flags() {
+        let build = |args: &[&str]| {
+            let mut c = Command::new("tool");
+            c.args(args);
+            c
+        };
+        assert!(requests_help(&build(&["--help"])));
+        assert!(requests_help(&build(&["build", "--release", "--help"])));
+        assert!(!requests_help(&build(&[])));
+        assert!(!requests_help(&build(&["build", "--release"])));
+        // `--help` after `--` is an operand.
+        assert!(!requests_help(&build(&["--", "--help"])));
+    }
+
+    #[test]
+    fn test_requests_help_skips_rtks_own_package_runner_prefix() {
+        let build = |program: &str, args: &[&str]| {
+            // nosemgrep: dynamic-command-execution
+            let mut c = Command::new(program);
+            c.args(args);
+            c
+        };
+        // The `--` after the runner is rtk's (utils::tool_exec), not the user's.
+        assert!(requests_help(&build(
+            "npx",
+            &["--no-install", "--", "eslint", "-f", "json", "--help", "."]
+        )));
+        assert!(requests_help(&build(
+            "npx",
+            &["--", "playwright", "test", "-h"]
+        )));
+        assert!(requests_help(&build(
+            "pnpm.cmd",
+            &["exec", "--", "vitest", "run", "--help"]
+        )));
+        assert!(requests_help(&build(
+            "yarn",
+            &["exec", "--", "jest", "--help"]
+        )));
+        // The user's own `--` after the tool still ends the scan.
+        assert!(!requests_help(&build(
+            "pnpm",
+            &["exec", "--", "vitest", "run", "--", "--help"]
+        )));
+        assert!(!requests_help(&build(
+            "npx",
+            &["--", "eslint", "-f", "json", "."]
+        )));
+        // `pnpm --help` itself, and `pnpm run -- --help`, are not the runner prefix.
+        assert!(requests_help(&build("pnpm", &["--help"])));
+        assert!(!requests_help(&build("pnpm", &["run", "--", "--help"])));
+    }
+
+    #[test]
+    fn test_requests_help_dash_h_belongs_to_the_tools_that_define_it() {
+        let build = |program: &str, args: &[&str]| {
+            // nosemgrep: dynamic-command-execution
+            let mut c = Command::new(program);
+            c.args(args);
+            c
+        };
+        // cargo, go, dotnet, …: `-h` is help.
+        assert!(requests_help(&build("cargo", &["build", "-h"])));
+        assert!(requests_help(&build("/usr/bin/go", &["-h"])));
+        // psql host, ls human sizes, grep no-filename: `-h` is theirs.
+        assert!(!requests_help(&build(
+            "psql",
+            &["-h", "localhost", "-c", "select 1"]
+        )));
+        assert!(!requests_help(&build("C:\\tools\\ls.exe", &["-lh"])));
+        assert!(!requests_help(&build("ls", &["-h"])));
+        assert!(!requests_help(&build("tree", &["-h", "-L", "2"])));
+        assert!(!requests_help(&build("grep", &["-h", "pattern", "a", "b"])));
+        // ripgrep's no-filename flag is `-I`; its `-h` is short help.
+        assert!(requests_help(&build("rg.exe", &["-h"])));
+        // …but `--help` is help for them too.
+        assert!(requests_help(&build("psql", &["--help"])));
+    }
 
     #[test]
     fn test_filter_errors() {

--- a/src/core/stream.rs
+++ b/src/core/stream.rs
@@ -569,12 +569,19 @@ impl CaptureResult {
     }
 }
 
+/// Run `cmd` with stdin closed and capture what it wrote.
+///
+/// A `--help`/`-h` request (see [`crate::core::runner::requests_help`]) is
+/// not captured: the usage is shown as the tool prints it and the process
+/// exits with the tool's code, because no caller here can read usage as the
+/// output it filters. Internal probes must not pass those flags.
 pub fn exec_capture(cmd: &mut Command) -> Result<CaptureResult> {
     cmd.stdin(Stdio::null());
     capture(cmd)
 }
 
-/// Like [`exec_capture`] but inherits stdin so a wrapped engine can read a piped stdin.
+/// Like [`exec_capture`] but inherits stdin so a wrapped engine can read a
+/// piped stdin. Same `--help` contract.
 pub fn exec_capture_stdin(cmd: &mut Command) -> Result<CaptureResult> {
     cmd.stdin(Stdio::inherit());
     capture(cmd)
@@ -589,6 +596,19 @@ pub fn exec_capture_stdin(cmd: &mut Command) -> Result<CaptureResult> {
 /// used as the label so no call site has to pass one.
 fn capture(cmd: &mut Command) -> Result<CaptureResult> {
     let program = cmd.get_program().to_string_lossy().into_owned();
+    // `--help` asks the tool for its usage, and no caller here can read usage
+    // as the output it filters (see `runner::requests_help`). The usage is
+    // shown as the tool prints it and the process ends with the tool's code:
+    // there is no captured output to hand back, and formatting an empty
+    // capture would append a false summary under it.
+    if super::runner::requests_help(cmd) {
+        let status = cmd
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit())
+            .status()
+            .with_context(|| format!("Failed to execute {program}"))?;
+        std::process::exit(super::utils::exit_code_from_status(&status, &program));
+    }
     let output = cmd.output().context("Failed to execute command")?;
     let exit_code = super::utils::exit_code_from_output(&output, &program);
     Ok(CaptureResult {

--- a/src/main.rs
+++ b/src/main.rs
@@ -135,6 +135,8 @@ enum Commands {
     },
 
     /// Git commands with compact output
+    // `--help` belongs to the tool: see forward_help_to_wrapped_tools.
+    #[command(disable_help_flag = true, disable_help_subcommand = true)]
     Git {
         /// Change to directory before executing (like git -C <path>, can be repeated)
         #[arg(short = 'C', action = clap::ArgAction::Append)]
@@ -214,6 +216,8 @@ enum Commands {
     },
 
     /// pnpm commands with ultra-compact output
+    // `--help` belongs to the tool: see forward_help_to_wrapped_tools.
+    #[command(disable_help_flag = true, disable_help_subcommand = true)]
     Pnpm {
         /// pnpm filter arguments (can be repeated: --filter @app1 --filter @app2)
         #[arg(long, short = 'F')]
@@ -285,24 +289,32 @@ enum Commands {
     },
 
     /// .NET commands with compact output (build/test/restore/format)
+    // `--help` belongs to the tool: see forward_help_to_wrapped_tools.
+    #[command(disable_help_flag = true, disable_help_subcommand = true)]
     Dotnet {
         #[command(subcommand)]
         command: DotnetCommands,
     },
 
     /// Docker commands with compact output
+    // `--help` belongs to the tool: see forward_help_to_wrapped_tools.
+    #[command(disable_help_flag = true, disable_help_subcommand = true)]
     Docker {
         #[command(subcommand)]
         command: DockerCommands,
     },
 
     /// Kubectl commands with compact output
+    // `--help` belongs to the tool: see forward_help_to_wrapped_tools.
+    #[command(disable_help_flag = true, disable_help_subcommand = true)]
     Kubectl {
         #[command(subcommand)]
         command: KubectlCommands,
     },
 
     /// OpenShift CLI (oc) commands with compact output
+    // `--help` belongs to the tool: see forward_help_to_wrapped_tools.
+    #[command(disable_help_flag = true, disable_help_subcommand = true)]
     Oc {
         #[command(subcommand)]
         command: OcCommands,
@@ -528,6 +540,8 @@ enum Commands {
     },
 
     /// Prisma commands with compact output (no ASCII art)
+    // `--help` belongs to the tool: see forward_help_to_wrapped_tools.
+    #[command(disable_help_flag = true, disable_help_subcommand = true)]
     Prisma {
         #[command(subcommand)]
         command: PrismaCommands,
@@ -576,6 +590,8 @@ enum Commands {
     },
 
     /// Cargo commands with compact output
+    // `--help` belongs to the tool: see forward_help_to_wrapped_tools.
+    #[command(disable_help_flag = true, disable_help_subcommand = true)]
     Cargo {
         #[command(subcommand)]
         command: CargoCommands,
@@ -596,6 +612,8 @@ enum Commands {
     },
 
     /// Bun runtime commands with compact output
+    // `--help` belongs to the tool: see forward_help_to_wrapped_tools.
+    #[command(disable_help_flag = true, disable_help_subcommand = true)]
     Bun {
         #[command(subcommand)]
         command: BunCommands,
@@ -839,24 +857,32 @@ enum Commands {
     },
 
     /// Deno runtime commands with compact output
+    // `--help` belongs to the tool: see forward_help_to_wrapped_tools.
+    #[command(disable_help_flag = true, disable_help_subcommand = true)]
     Deno {
         #[command(subcommand)]
         command: DenoCommands,
     },
 
     /// Go commands with compact output
+    // `--help` belongs to the tool: see forward_help_to_wrapped_tools.
+    #[command(disable_help_flag = true, disable_help_subcommand = true)]
     Go {
         #[command(subcommand)]
         command: GoCommands,
     },
 
     /// SBT (Scala Build Tool) commands with compact output
+    // `--help` belongs to the tool: see forward_help_to_wrapped_tools.
+    #[command(disable_help_flag = true, disable_help_subcommand = true)]
     Sbt {
         #[command(subcommand)]
         command: SbtCommands,
     },
 
     /// Graphite (gt) stacked PR commands with compact output
+    // `--help` belongs to the tool: see forward_help_to_wrapped_tools.
+    #[command(disable_help_flag = true, disable_help_subcommand = true)]
     Gt {
         #[command(subcommand)]
         command: GtCommands,
@@ -1081,6 +1107,8 @@ enum DockerCommands {
     /// Show container logs (deduplicated)
     Logs { container: String },
     /// Docker Compose commands with compact output
+    // `--help` belongs to the tool: see forward_help_to_wrapped_tools.
+    #[command(disable_help_flag = true, disable_help_subcommand = true)]
     Compose {
         #[command(subcommand)]
         command: ComposeCommands,
@@ -1194,6 +1222,8 @@ enum PrismaCommands {
         args: Vec<String>,
     },
     /// Manage migrations
+    // `--help` belongs to the tool: see forward_help_to_wrapped_tools.
+    #[command(disable_help_flag = true, disable_help_subcommand = true)]
     Migrate {
         #[command(subcommand)]
         command: PrismaMigrateCommands,
@@ -1384,6 +1414,8 @@ enum BunCommands {
         args: Vec<String>,
     },
     /// Package manager commands (pm ls, etc.)
+    // `--help` belongs to the tool: see forward_help_to_wrapped_tools.
+    #[command(disable_help_flag = true, disable_help_subcommand = true)]
     Pm {
         #[command(subcommand)]
         command: BunPmCommands,
@@ -1798,11 +1830,85 @@ fn is_native_test_expression(command: &[String]) -> bool {
     }
 }
 
+/// Hand `--help`/`-h` to the wrapped tool instead of clap, recursively.
+///
+/// A subcommand that carries a trailing-var-arg positional (`rtk tsc <args>`)
+/// forwards every other flag to the tool; clap's auto help was the one it
+/// kept, so `rtk tsc --help` printed rtk's one-line stub instead of running
+/// tsc, and through the hook that is what `tsc --help` came back as.
+///
+/// The exact exemption is [`keeps_clap_help`]: rtk's own entry points
+/// (`RTK_META_COMMANDS`, plus `RTK_OWN_RUNNERS`: `err`, `test`, `summary`, `format`),
+/// and everything beneath them (`rtk hook check <args>`), keep clap's help
+/// even when they take a trailing command, because there is no tool to hand
+/// it to. Subcommands with nothing to forward (`gain`, `init`, …) are
+/// untouched by construction.
+///
+/// Parents whose passthrough is an `external_subcommand` arm (`rtk git <any>`)
+/// cannot be told apart here: clap records that arm only while building, after
+/// this pass. Those parents carry `#[command(disable_help_flag = true,
+/// disable_help_subcommand = true)]` on the variant: the flag setting is
+/// global in clap, so it also reaches their children that forward nothing
+/// (`rtk docker logs --help` runs docker), and the subcommand setting keeps
+/// clap's `help` subcommand from claiming `rtk git help log` — `help` then
+/// reaches the tool through the external arm, or fails the parse and runs the
+/// raw tool. The attributes are load-bearing for the whole subtree, not only
+/// the parent. `test_every_wrapped_tool_subcommand_forwards_help` builds the
+/// command to hold both groups to the same contract.
+fn forward_help_to_wrapped_tools(cmd: clap::Command) -> clap::Command {
+    forward_help_below(cmd, 0, false)
+}
+
+/// rtk subcommands that take a trailing command but run it themselves —
+/// through `sh -c` (`err`, `test`, `summary`) or a detected formatter
+/// (`format`) — so there is no one tool to receive `--help`. A new rtk-own
+/// runner with a trailing command must be added here, or `--help` on it
+/// falls through to a tool that does not exist.
+const RTK_OWN_RUNNERS: &[&str] = &["err", "test", "summary", "format"];
+
+/// A top-level subcommand that is rtk's own: `--help` on it means rtk's help.
+fn keeps_clap_help(name: &str) -> bool {
+    core::constants::RTK_META_COMMANDS.contains(&name) || RTK_OWN_RUNNERS.contains(&name)
+}
+
+/// `depth` 1 is a direct child of `rtk`: the rtk-owned names are only rtk's
+/// own there (`rtk run` is, `rtk bun run` is bun's). `under_meta` carries
+/// that verdict down to the meta command's own subcommands.
+fn forward_help_below(cmd: clap::Command, depth: usize, under_meta: bool) -> clap::Command {
+    let meta = under_meta || (depth == 1 && keeps_clap_help(cmd.get_name()));
+    let forwards = cmd.get_positionals().any(|a| a.is_trailing_var_arg_set()) && !meta;
+    let cmd = if forwards {
+        cmd.disable_help_flag(true)
+    } else {
+        cmd
+    };
+    cmd.mut_subcommands(|sub| forward_help_below(sub, depth + 1, meta))
+}
+
+/// The clap command `main` parses with: the derived `Cli` after
+/// [`forward_help_to_wrapped_tools`].
+fn cli_command() -> clap::Command {
+    forward_help_to_wrapped_tools(<Cli as clap::CommandFactory>::command())
+}
+
+/// Parse argv the way `main` does. `Cli::try_parse_from` is the derived
+/// parser *before* [`forward_help_to_wrapped_tools`], so a test about
+/// `--help`/`-h` on a wrapped tool must go through this or it tests a parser
+/// `main` never runs.
+fn parse_cli<I, T>(args: I) -> Result<Cli, clap::Error>
+where
+    I: IntoIterator<Item = T>,
+    T: Into<OsString> + Clone,
+{
+    let matches = cli_command().try_get_matches_from(args)?;
+    <Cli as clap::FromArgMatches>::from_arg_matches(&matches)
+}
+
 fn run_cli() -> Result<i32> {
     // Fire-and-forget telemetry ping (1/day, non-blocking)
     core::telemetry::maybe_ping();
 
-    let cli = match Cli::try_parse_from(std::env::args_os()) {
+    let cli = match parse_cli(std::env::args_os()) {
         Ok(cli) => cli,
         Err(e) => {
             if matches!(e.kind(), ErrorKind::DisplayHelp | ErrorKind::DisplayVersion) {
@@ -3073,6 +3179,176 @@ mod tests {
     use clap::Parser;
     use std::cell::Cell;
 
+    // --- `--help` on wrapped tools reaches the tool (#165) ---
+
+    #[test]
+    fn test_parse_cli_forwards_help_to_wrapped_tool() {
+        // Through the hook the user typed `tsc --help`; rtk's one-line stub
+        // is not what they asked for.
+        for flag in ["--help", "-h"] {
+            let cli = parse_cli(["rtk", "tsc", flag])
+                .unwrap_or_else(|e| panic!("`rtk tsc {flag}` must parse, clap claimed it: {e}"));
+            match cli.command {
+                Commands::Tsc { args } => assert_eq!(args, vec![flag.to_string()]),
+                _ => panic!("expected Tsc"),
+            }
+        }
+    }
+
+    #[test]
+    fn test_parse_cli_forwards_help_alongside_rtk_options() {
+        // A wrapped tool that also parses rtk-only long options keeps them
+        // and still hands `--help` to the tool.
+        let cli = parse_cli(["rtk", "grep", "--max-len", "40", "--help"]).unwrap();
+        match cli.command {
+            Commands::Grep {
+                max_len,
+                extra_args,
+                ..
+            } => {
+                assert_eq!(max_len, 40);
+                assert_eq!(extra_args, vec!["--help".to_string()]);
+            }
+            _ => panic!("expected Grep"),
+        }
+    }
+
+    #[test]
+    fn test_parse_cli_forwards_help_to_nested_wrapped_tool() {
+        let cli = parse_cli(["rtk", "git", "log", "--help"]).unwrap();
+        match cli.command {
+            Commands::Git {
+                command: GitCommands::Log { args },
+                ..
+            } => assert_eq!(args, vec!["--help".to_string()]),
+            _ => panic!("expected git log"),
+        }
+    }
+
+    #[test]
+    fn test_parse_cli_forwards_help_past_an_external_subcommand_parent() {
+        // `rtk git --help`: the parent has no trailing positional, only an
+        // external-subcommand arm. clap must not answer with rtk's stub: the
+        // flag either lands in the external arm or fails the parse, and a
+        // parse error routes `run_fallback` to the raw `git --help`.
+        match parse_cli(["rtk", "git", "--help"]) {
+            Err(e) => assert_ne!(e.kind(), ErrorKind::DisplayHelp),
+            Ok(Cli {
+                command:
+                    Commands::Git {
+                        command: GitCommands::Other(args),
+                        ..
+                    },
+                ..
+            }) => assert_eq!(args, vec![OsString::from("--help")]),
+            Ok(_) => panic!("`--help` parsed as something other than git's external arm"),
+        }
+
+        // clap's `help` subcommand is rtk's stub too: `git help log` is git's.
+        let cli = parse_cli(["rtk", "git", "help", "log"]).unwrap();
+        match cli.command {
+            Commands::Git {
+                command: GitCommands::Other(args),
+                ..
+            } => assert_eq!(args, vec![OsString::from("help"), OsString::from("log")]),
+            _ => panic!("`git help log` must reach git's external arm"),
+        }
+
+        let cli = parse_cli(["rtk", "git", "bisect", "--help"]).unwrap();
+        match cli.command {
+            Commands::Git {
+                command: GitCommands::Other(args),
+                ..
+            } => assert_eq!(
+                args,
+                vec![OsString::from("bisect"), OsString::from("--help")]
+            ),
+            _ => panic!("expected git's external subcommand arm"),
+        }
+    }
+
+    #[test]
+    fn test_parse_cli_keeps_help_on_meta_commands() {
+        // Nothing to forward to: rtk's own help stays, including on the meta
+        // commands that take a trailing command of their own.
+        for argv in [
+            vec!["rtk", "--help"],
+            vec!["rtk", "gain", "--help"],
+            vec!["rtk", "proxy", "--help"],
+            vec!["rtk", "run", "--help"],
+            vec!["rtk", "rewrite", "--help"],
+            vec!["rtk", "hook", "check", "--help"],
+            // `sh -c` runners: a trailing command, no tool to forward to.
+            vec!["rtk", "err", "--help"],
+            vec!["rtk", "test", "--help"],
+            vec!["rtk", "summary", "--help"],
+            vec!["rtk", "format", "--help"],
+        ] {
+            let err = match parse_cli(argv.clone()) {
+                Err(e) => e,
+                Ok(_) => panic!("{argv:?}: help must be clap's"),
+            };
+            assert_eq!(err.kind(), ErrorKind::DisplayHelp, "{argv:?}");
+        }
+    }
+
+    #[test]
+    fn test_every_wrapped_tool_subcommand_forwards_help() {
+        // Total contract: a subcommand that forwards to a tool (trailing
+        // hyphen args or an external subcommand) must not let clap claim
+        // `--help`; a meta command or one that forwards nothing must keep it.
+        fn walk(cmd: &clap::Command, path: &str, depth: usize, under_meta: bool, seen: &mut usize) {
+            // A parent counts as forwarding when any subcommand of its own does:
+            // `rtk prisma --help` is prisma's even though `prisma` itself takes
+            // no trailing args.
+            fn forwards(cmd: &clap::Command) -> bool {
+                cmd.get_positionals().any(|a| a.is_trailing_var_arg_set())
+                    || cmd.is_allow_external_subcommands_set()
+                    || cmd.get_subcommands().any(forwards)
+            }
+            let forwards = depth > 0 && forwards(cmd);
+            let meta = under_meta || (depth == 1 && keeps_clap_help(cmd.get_name()));
+            if meta && cmd.get_name() == "help" {
+                // clap's own `help` subcommand (and its per-subcommand
+                // children) disable the flag on themselves.
+                return;
+            }
+            if forwards && !meta {
+                *seen += 1;
+                assert!(
+                    cmd.is_disable_help_flag_set(),
+                    "{path} forwards args but clap still owns --help"
+                );
+                if cmd.has_subcommands() {
+                    assert!(
+                        cmd.is_disable_help_subcommand_set(),
+                        "{path} forwards args but clap still owns `help <sub>`"
+                    );
+                }
+            } else if meta {
+                assert!(
+                    !cmd.is_disable_help_flag_set(),
+                    "{path} is rtk's own; clap must keep --help"
+                );
+            }
+            for sub in cmd.get_subcommands() {
+                walk(
+                    sub,
+                    &format!("{path} {}", sub.get_name()),
+                    depth + 1,
+                    meta,
+                    seen,
+                );
+            }
+        }
+        let mut seen = 0;
+        // Built, so the external-subcommand arms are visible to the walk.
+        let mut cmd = cli_command();
+        cmd.build();
+        walk(&cmd, "rtk", 0, false, &mut seen);
+        assert!(seen >= 100, "expected the wrapped-tool surface, saw {seen}");
+    }
+
     #[test]
     fn test_git_commit_single_message() {
         let cli = Cli::try_parse_from(["rtk", "git", "commit", "-m", "fix: typo"]).unwrap();
@@ -3608,7 +3884,7 @@ mod tests {
     #[test]
     fn test_ctest_help_and_version_passthrough_args() {
         for flag in ["--help", "--version"] {
-            let cli = Cli::try_parse_from(["rtk", "ctest", flag]).unwrap();
+            let cli = parse_cli(["rtk", "ctest", flag]).unwrap();
             match cli.command {
                 Commands::Ctest { args } => assert_eq!(args, vec![flag]),
                 _ => panic!("Expected Ctest command"),

--- a/tests/help_forwarding_test.rs
+++ b/tests/help_forwarding_test.rs
@@ -1,0 +1,196 @@
+//! A forwarded `--help`/`-h` reaches the wrapped tool and is shown as the tool
+//! prints it, through fake tools first on PATH. Windows twin:
+//! `help_forwarding_windows_test.rs`.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use std::process::{Command, Output};
+
+/// Writes an executable `name` in `dir` that runs `body`.
+fn fake_tool(dir: &Path, name: &str, body: &str) {
+    let path = dir.join(name);
+    fs::write(&path, format!("#!/bin/sh\n{}\n", body)).expect("write fake tool");
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).expect("chmod fake tool");
+}
+
+/// Runs rtk with `dir` first on PATH, so the fake tool shadows any real one.
+fn rtk_with(dir: &Path, args: &[&str]) -> Output {
+    let path = format!(
+        "{}:{}",
+        dir.display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+    Command::new(env!("CARGO_BIN_EXE_rtk"))
+        .args(args)
+        .env("PATH", path)
+        // Keep tracking off the developer's real database.
+        .env("RTK_DB_PATH", dir.join("rtk-test.db"))
+        .output()
+        .expect("run rtk")
+}
+
+/// A git that answers `-h`/`--help` before `--` with its usage on stdout and
+/// exit 129, like the real one, and otherwise echoes its argv and exits 0.
+const FAKE_GIT: &str = "for a in \"$@\"; do [ \"$a\" = \"--\" ] && break; case \"$a\" in -h|--help) echo \"usage: git $1 [<options>]\"; exit 129;; esac; done; echo \"$@\"; exit 0";
+
+/// git answers `-h` with its usage on **stdout** and exit 129. Once `rtk git
+/// log -h` / `rtk git status -h` forward the flag (they used to be clap's), the
+/// call must reach the user as git's usage — not as a filter's reading of it.
+#[test]
+fn forwarded_help_keeps_gits_stdout_usage() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    fake_tool(dir.path(), "git", FAKE_GIT);
+    for sub in ["log", "status"] {
+        let out = rtk_with(dir.path(), &["git", sub, "-h"]);
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        assert_eq!(out.status.code(), Some(129), "git {sub} -h exit");
+        assert!(
+            stdout.contains(&format!("usage: git {sub}")),
+            "git {sub} -h usage must reach stdout, got {stdout:?}"
+        );
+    }
+}
+
+/// A tool's usage is not filter input. `rtk wget --help` used to reach the
+/// wget filter, which read the usage text as a failed download; the capture
+/// helper now shows it as the tool printed it and exits with the tool's code.
+#[test]
+fn forwarded_help_on_a_captured_tool_is_shown_verbatim() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    fake_tool(
+        dir.path(),
+        "wget",
+        "echo \"Usage: wget [OPTION]... [URL]...\"; echo \"Try --help for more options.\"; exit 0",
+    );
+    let out = rtk_with(dir.path(), &["wget", "http://x/f", "--help"]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert_eq!(out.status.code(), Some(0));
+    assert!(
+        stdout.contains("Usage: wget [OPTION]"),
+        "usage must reach stdout verbatim, got {stdout:?}"
+    );
+    assert!(
+        !stdout.contains(" ok |") && !stdout.to_lowercase().contains("fail"),
+        "usage read as a completed download, got {stdout:?}"
+    );
+}
+
+/// A tool run through `runner::run` in filtered mode: its usage must not be
+/// read as a normal (empty) run. `rtk cargo build --help` used to come back as
+/// "cargo build (0 crates compiled)" under cargo's own usage text.
+#[test]
+fn forwarded_help_on_a_filtered_tool_is_shown_verbatim() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    fake_tool(
+        dir.path(),
+        "cargo",
+        "echo \"Usage: cargo build [OPTIONS]\"; echo \"  --release  Build artifacts in release mode\"; exit 0",
+    );
+    let out = rtk_with(dir.path(), &["cargo", "build", "--help"]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert_eq!(out.status.code(), Some(0));
+    assert!(
+        stdout.contains("Usage: cargo build"),
+        "usage must reach stdout verbatim, got {stdout:?}"
+    );
+    assert!(
+        !stdout.contains("crates compiled"),
+        "filter summary leaked under the usage, got {stdout:?}"
+    );
+}
+
+/// After `--`, `-h` is a pathspec. clap strips the `--` before the git filter
+/// sees the args, so the help guard must read them with it restored.
+#[test]
+fn dash_h_after_double_dash_stays_a_pathspec() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    fake_tool(dir.path(), "git", FAKE_GIT);
+    let out = rtk_with(dir.path(), &["git", "log", "--", "-h"]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "git log -- -h exit, got {stdout:?}"
+    );
+    assert!(
+        !stdout.contains("usage:"),
+        "`-- -h` is a pathspec, not a usage request, got {stdout:?}"
+    );
+}
+
+/// `-h` is a usage request for a tool that does not define it otherwise:
+/// `rtk pytest -h` must show pytest's usage, not the filter's reading of it
+/// ("Pytest: No tests collected").
+#[test]
+fn dash_h_where_the_tool_means_help_is_shown_verbatim() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    fake_tool(
+        dir.path(),
+        "pytest",
+        "echo \"usage: pytest [options] [file_or_dir] [file_or_dir] [...]\"; exit 0",
+    );
+    let out = rtk_with(dir.path(), &["pytest", "-h"]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert_eq!(out.status.code(), Some(0));
+    assert!(
+        stdout.contains("usage: pytest"),
+        "pytest's usage must reach stdout verbatim, got {stdout:?}"
+    );
+    assert!(
+        !stdout.contains("No tests collected"),
+        "usage read as an empty run, got {stdout:?}"
+    );
+}
+
+/// `-h` is the tool's own flag where the tool defines it: `psql -h host` is
+/// a connection option, so the call stays filtered instead of being shown
+/// verbatim as if it were a usage request.
+#[test]
+fn dash_h_where_the_tool_defines_it_stays_filtered() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    fake_tool(
+        dir.path(),
+        "psql",
+        "printf ' id | name\n----+------\n  1 | a\n(1 row)\n'; exit 0",
+    );
+    let out = rtk_with(dir.path(), &["psql", "-h", "localhost", "-c", "select 1"]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert_eq!(out.status.code(), Some(0));
+    assert!(
+        stdout.contains("1\ta"),
+        "table must be filtered to tab-separated rows, got {stdout:?}"
+    );
+    assert!(
+        !stdout.contains("(1 row)") && !stdout.contains("----+"),
+        "`-h host` was treated as a usage request and shown verbatim, got {stdout:?}"
+    );
+}
+
+/// A Node tool that is not on PATH runs through its package runner, and rtk
+/// puts its own `--` between the two (`npx --no-install -- playwright …`).
+/// The help guard must read past that `--`: `rtk playwright test --help` is
+/// still a usage request, not a test run for the filter to model.
+#[test]
+fn forwarded_help_through_the_package_runner_is_shown_verbatim() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    fake_tool(
+        dir.path(),
+        "npx",
+        "echo \"Usage: playwright test [options] [test-filter...]\"; exit 0",
+    );
+    let out = rtk_with(dir.path(), &["playwright", "test", "--help"]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert_eq!(out.status.code(), Some(0));
+    assert!(
+        stdout.contains("Usage: playwright test"),
+        "usage must reach stdout verbatim, got {stdout:?}"
+    );
+    assert!(
+        stderr.trim().is_empty(),
+        "usage was handed to the filter, got stderr {stderr:?}"
+    );
+}

--- a/tests/help_forwarding_windows_test.rs
+++ b/tests/help_forwarding_windows_test.rs
@@ -1,0 +1,143 @@
+//! Windows twin of the `--help` cases in `help_forwarding_test.rs` (which is
+//! `#![cfg(unix)]`): a forwarded `--help` on a captured tool is shown as the
+//! tool prints it, through a `.cmd` shim found via PATH.
+#![cfg(windows)]
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Output};
+
+fn fake_cmd_tool(dir: &Path, name: &str, body: &str) {
+    fs::write(
+        dir.join(format!("{name}.cmd")),
+        format!("@echo off\r\n{body}\r\n"),
+    )
+    .expect("write fake tool");
+}
+
+fn rtk_with(dir: &Path, args: &[&str]) -> Output {
+    let path = format!(
+        "{};{}",
+        dir.display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+    Command::new(env!("CARGO_BIN_EXE_rtk"))
+        .args(args)
+        .env("PATH", path)
+        .env("RTK_DB_PATH", dir.join("rtk-test.db"))
+        .output()
+        .expect("run rtk")
+}
+
+#[test]
+fn forwarded_help_on_a_captured_tool_is_shown_verbatim() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    fake_cmd_tool(
+        dir.path(),
+        "wget",
+        "echo Usage: wget [OPTION]... [URL]...\r\necho Try --help for more options.\r\nexit /b 0",
+    );
+    let out = rtk_with(dir.path(), &["wget", "http://x/f", "--help"]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert_eq!(out.status.code(), Some(0));
+    assert!(
+        stdout.contains("Usage: wget [OPTION]"),
+        "usage must reach stdout verbatim, got {stdout:?}"
+    );
+    assert!(
+        !stdout.contains(" ok |") && !stdout.to_lowercase().contains("fail"),
+        "usage read as a completed download, got {stdout:?}"
+    );
+}
+
+#[test]
+fn forwarded_help_exits_with_the_tools_code() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    fake_cmd_tool(dir.path(), "wget", "echo usage: wget\r\nexit /b 129");
+    let out = rtk_with(dir.path(), &["wget", "http://x/f", "--help"]);
+    assert_eq!(out.status.code(), Some(129));
+}
+
+#[test]
+fn forwarded_help_on_a_filtered_tool_is_shown_verbatim() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    fake_cmd_tool(
+        dir.path(),
+        "cargo",
+        "echo Usage: cargo build [OPTIONS]\r\necho   --release  Build artifacts in release mode\r\nexit /b 0",
+    );
+    let out = rtk_with(dir.path(), &["cargo", "build", "--help"]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert_eq!(out.status.code(), Some(0));
+    assert!(
+        stdout.contains("Usage: cargo build"),
+        "usage must reach stdout verbatim, got {stdout:?}"
+    );
+    assert!(
+        !stdout.contains("crates compiled"),
+        "filter summary leaked under the usage, got {stdout:?}"
+    );
+}
+
+#[test]
+fn dash_h_where_the_tool_means_help_is_shown_verbatim() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    fake_cmd_tool(
+        dir.path(),
+        "pytest",
+        "echo usage: pytest [options] [file_or_dir] [file_or_dir] [...]\r\nexit /b 0",
+    );
+    let out = rtk_with(dir.path(), &["pytest", "-h"]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert_eq!(out.status.code(), Some(0));
+    assert!(
+        stdout.contains("usage: pytest"),
+        "pytest's usage must reach stdout verbatim, got {stdout:?}"
+    );
+    assert!(
+        !stdout.contains("No tests collected"),
+        "usage read as an empty run, got {stdout:?}"
+    );
+}
+
+#[test]
+fn dash_h_where_the_tool_defines_it_stays_filtered() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    fake_cmd_tool(
+        dir.path(),
+        "psql",
+        "echo  id ^| name\r\necho ----+------\r\necho   1 ^| a\r\necho (1 row)\r\nexit /b 0",
+    );
+    let out = rtk_with(dir.path(), &["psql", "-h", "localhost", "-c", "select 1"]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert_eq!(out.status.code(), Some(0));
+    assert!(
+        stdout.contains("1\ta"),
+        "table must be filtered to tab-separated rows, got {stdout:?}"
+    );
+    assert!(
+        !stdout.contains("(1 row)") && !stdout.contains("----+"),
+        "`-h host` was treated as a usage request and shown verbatim, got {stdout:?}"
+    );
+}
+
+#[test]
+fn forwarded_help_through_the_package_runner_is_shown_verbatim() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    fake_cmd_tool(
+        dir.path(),
+        "npx",
+        "echo Usage: playwright test [options] [test-filter...]\r\nexit /b 0",
+    );
+    let out = rtk_with(dir.path(), &["playwright", "test", "--help"]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert_eq!(out.status.code(), Some(0));
+    assert!(
+        stdout.contains("Usage: playwright test"),
+        "usage must reach stdout verbatim, got {stdout:?}"
+    );
+    assert!(
+        stderr.trim().is_empty(),
+        "usage was handed to the filter, got stderr {stderr:?}"
+    );
+}


### PR DESCRIPTION
## Problem

clap's auto-generated `-h`/`--help` (and its auto `help` subcommand) is live on every wrapped-tool subcommand, so `rtk <tool> --help` prints rtk's one-paragraph stub for the subcommand instead of running the tool. Through the hook, a user or agent that types `tsc --help`, `cargo build --help`, `git show -h`, `npm --help` or `docker --help` gets rtk's doc line back; the tool's own help is unreachable except as `rtk <tool> -- --help`. Only `Psql` and `Ctest` had opted out per variant.

```
$ rtk tsc --help
TypeScript compiler with grouped error output

Usage: rtk tsc [OPTIONS] [ARGS]...

$ rtk cargo build --help
Build with compact output (strip Compiling lines, keep errors)

Usage: rtk cargo build [OPTIONS] [ARGS]...
```

## Fix

One rule instead of ~100 attributes. After building the derived `Cli`, `forward_help_to_wrapped_tools` walks the command tree and disables clap's help flag on every subcommand that carries a trailing-var-arg positional; `main` parses from that command (`parse_cli`). Exemptions are exact:

- rtk's own entry points keep clap's help: `RTK_META_COMMANDS` plus `err`/`test`/`summary`/`format` (they take a trailing command but run it themselves), and everything beneath them (`rtk hook check --help`).
- The 16 parents whose passthrough is an `external_subcommand` arm (`git`, `cargo`, `docker` + `compose`, `pnpm`, `dotnet`, `kubectl`, `oc`, `prisma` + `migrate`, `bun` + `pm`, `deno`, `go`, `sbt`, `gt`) are not visible to the walk before clap builds, so they carry `#[command(disable_help_flag = true, disable_help_subcommand = true)]`. Both settings propagate to the subtree; the second keeps `rtk git help log` from being rtk's stub.
- `test_every_wrapped_tool_subcommand_forwards_help` builds the command and holds both groups to one invariant (≥100 forwarding subcommands seen; a parent counts as forwarding when any child does).

A forwarded `--help` then has to reach the tool's *passthrough*, not its filter: a filter models the tool's normal output and reads usage text as an empty run (`cargo build --help` → "cargo build (0 crates compiled)", `git worktree -h` listed worktrees, `wget <url> --help` → "<url> ok | …"). Three shared guards instead of one per filter:

- `core::runner::run` flips to `RunMode::Passthrough` when `--help` (or `-h`, except for tools that define it otherwise: `psql -h host`, `ls`/`tree -h` human sizes, `grep -h` no-filename) appears before any `--`. The `npx [--no-install] --` / `pnpm exec --` / `yarn exec --` prefix rtk itself inserts for a Node tool not on PATH (`utils::tool_exec`) is skipped; the tool's argv starts after it.
- `core::stream::capture` shows the usage verbatim and exits with the tool's code (git: 129).
- `git::run` treats `-h`/`--help` before `--` as a passthrough request, with clap's stripped `--` restored (and stash's own operand rejoined first) so `git log -- -h` stays a pathspec.
- `find`'s dispatcher sends `-help`/`--help` down its existing verbatim path (GNU find has no `-h`).

## Tests

- `src/main.rs`: `parse_cli` tests for `tsc --help`/`-h`, `grep --max-len 40 --help`, nested `git log --help`, `git --help` / `git help log` / `git bisect --help` past the external arm, meta commands keeping `DisplayHelp`; the total contract walk. Two existing tests moved from `Cli::try_parse_from` to `parse_cli` so they exercise the parser `main` actually runs.
- `src/core/runner.rs`: `requests_help` reads the tool's own flags before `--`; `-h` belongs to `psql`/`ls`/`tree`/`grep` (ripgrep's `-h` is help, `-I` is no-filename); rtk's package-runner prefix is skipped and the user's own later `--` still ends the scan.
- `src/cmds/git/git.rs`: `-h`/`--help` before `--` only; stash's operand rejoins the user region before `restore_double_dash`.
- `src/cmds/system/find_cmd.rs`: `--help`/`-help` dispatch verbatim; `-h` is not a find flag.
- `tests/stderr_only_failure_test.rs` (unix) and `tests/help_forwarding_windows_test.rs` (windows, `.cmd` shims): with fake tools on PATH, `cargo build --help` (filtered runner), `wget <url> --help` (capture, exit code kept), `playwright test --help` through a fake `npx` (package-runner prefix), `pytest -h` (help), `psql -h host` (stays filtered), `git log -h`/`git status -h` (git's stdout usage, exit 129), `git log -- -h` (pathspec). Each was verified to fail with its guard reverted.

Gate: `cargo fmt --all --check`, `cargo clippy --all-targets` (zero warnings), `cargo test --all` green.

## Out of scope

- `--version` is not a twin: clap's version flag lives on the top-level `Cli` only; `rtk tsc --version` already reaches tsc.
- Whether a tool's help renders well is the tool's output; help never reaches a filter now.
- `run_stash` drops a `--` before its first operand on its own (`git stash -- x` → `git stash push x`); pre-existing and unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
