### PR TITLE
refactor(hooks): consolidate the hook decision behind one shared decide

### DIFF
--- a/src/core/tracking.rs
+++ b/src/core/tracking.rs
@@ -1499,7 +1499,7 @@ pub(crate) fn get_db_path() -> Result<PathBuf> {
     // `config::cached_config`), not a fresh `Config::load()`: this runs inside
     // `Tracker::new()`, which `log_hook_decision` now calls on every single
     // PreToolUse hook invocation — `hook_rewrite_params()` (called earlier in the
-    // same hook invocation, via `get_rewritten`) already reads config too, so
+    // same hook invocation, via `hooks::decision::decide`) already reads config too, so
     // without caching that's two full disk-read-plus-TOML-parse round trips per
     // Bash tool call instead of one.
     if let Some(db_path) = crate::core::config::cached_config()

--- a/src/discover/mod.rs
+++ b/src/discover/mod.rs
@@ -172,7 +172,7 @@ fn estimate_hook_coverage(permission_cmd: &str, rewrite_cmd: &str, ctx: &Coverag
 
 /// Pure core of `estimate_hook_coverage`, taking the permission verdict directly so
 /// it's testable without depending on real config files. Mirrors the real hook's own
-/// decision order (`hooks::hook_cmd::decide_from_verdict`): a `Deny`-rule match or an
+/// decision order (`hooks::decision::decide`): a `Deny`-rule match or an
 /// unattestable construct means the hook would never have rewritten this, regardless
 /// of registry support. See `estimate_hook_coverage` for why `permission_cmd` and
 /// `rewrite_cmd` can differ.

--- a/src/hooks/README.md
+++ b/src/hooks/README.md
@@ -11,7 +11,8 @@ Owns: `rtk init` installation flows (6 agents via `AgentTarget` enum, now includ
 Does **not** own: the deployed hook scripts themselves (that's `hooks/`), the rewrite pattern registry (that's `discover/`), or command filtering (that's `cmds/`).
 
 Boundary notes:
-- `rewrite_cmd.rs` is a thin CLI bridge — it exists to serve hooks (hooks call `rtk rewrite` as a subprocess) and delegates entirely to `discover/registry`.
+- `decision.rs` is the single place RTK decides what a hook should do with a command — deny, defer, rewrite-and-allow, or rewrite-and-ask. All three entry points route through it: the in-process `rtk hook <agent>` hosts (`hook_cmd.rs`), the `rtk rewrite` subprocess path (`rewrite_cmd.rs`), and the `rtk hook check` diagnostic (`main.rs`). Add a gate there, not in a caller.
+- `rewrite_cmd.rs` is a thin CLI bridge — it exists to serve hooks (hooks call `rtk rewrite` as a subprocess) and renders `decision.rs`'s verdict as the exit codes those delegates branch on.
 - `trust.rs` gates project-local TOML filter execution. It lives here because the trust workflow is tied to hook-installed filter discovery, not to the core filter engine.
 
 ## Purpose

--- a/src/hooks/decision.rs
+++ b/src/hooks/decision.rs
@@ -1,0 +1,257 @@
+//! The single place RTK decides what a hook should do with a command.
+//!
+//! Two entry points ask the same question — may this command be rewritten,
+//! and may the rewrite be auto-allowed?
+//!
+//! | Entry point | Verdict source | Identity rewrite |
+//! |---|---|---|
+//! | `rtk hook <agent>` (`hook_cmd`) | `check_command_for(cmd, host)` | suppressed |
+//! | `rtk rewrite` (`rewrite_cmd`, run as a subprocess by the shell/TS/Python delegates) | `check_command` (always `Host::Claude`) | reported |
+//!
+//! [`decide`] is the shared answer. What legitimately differs between callers
+//! stays outside it: the verdict is passed in rather than looked up, so each
+//! host consults its own permission rules and tests stay independent of the
+//! machine's settings (#3146); and the no-op-rewrite policy lives in
+//! [`decide_for_agent`], which every hook shares and the CLI does not.
+
+use super::permissions::PermissionVerdict;
+use crate::discover::registry::rewrite_command;
+
+/// What a hook should do with a command.
+///
+/// `rewrite_cmd` renders these as the exit codes its delegates branch on
+/// (`AllowRewrite` → 0, `AskRewrite` → 3, `Deny` → 2, `Defer` → 1); the
+/// in-process hosts render them as their own JSON response shapes.
+#[derive(Debug, PartialEq)]
+pub(crate) enum HookDecision {
+    /// Rewrite, and the host may auto-allow it — an explicit user allow rule matched.
+    AllowRewrite(String),
+    /// Rewrite, but leave approval to the host's own prompt.
+    AskRewrite(String),
+    /// Say nothing; let the host handle the command untouched.
+    Defer,
+    /// A deny rule matched — stay out of the way of the host's native deny.
+    Deny,
+}
+
+/// Decide what to do with `cmd`, given a permission verdict for it.
+///
+/// The gate order is load-bearing:
+///
+/// 1. **Deny wins outright.** Checked before anything else so a denied command
+///    is never even considered for rewriting.
+/// 2. **Unattestable constructs are refused.** Command substitution and
+///    file-target redirects can't be decomposed into segments the permission
+///    gate can check individually, so a rewrite could smuggle an unchecked
+///    command past an allow rule. `check_command_with_rules` already forces
+///    such a command to `Ask`; refusing to rewrite it at all is the stronger
+///    guarantee. Heredocs reach the same outcome, though most of them stop at
+///    this gate only because a `<<` operand reads as a file target; what
+///    actually refuses them is `rewrite_command`'s own `has_heredoc`, which
+///    catches the forms this gate lets past (see #3980).
+/// 3. **Otherwise rewrite if a rule matches**, and auto-allow only on an
+///    explicit `Allow`. Every other verdict — including `Default`, where no
+///    rule matched at all — yields `AskRewrite`. `Default` must never reach
+///    `AllowRewrite`: that would auto-approve every rewritable command on a
+///    machine with no permission rules configured (#1155).
+///
+/// An identity rewrite (`cmd` was already RTK-prefixed) is reported here as a
+/// normal rewrite. Callers that want it suppressed apply [`suppress_identity`].
+pub(crate) fn decide(cmd: &str, verdict: PermissionVerdict) -> HookDecision {
+    let (excluded, transparent_prefixes) = crate::core::config::hook_rewrite_params();
+    decide_with_params(cmd, verdict, &excluded, &transparent_prefixes)
+}
+
+/// [`decide`] with the rewrite parameters supplied by the caller, mirroring
+/// [`check_command_with_rules`](super::permissions::check_command_with_rules).
+///
+/// `hook_rewrite_params` reads the user's `config.toml`, so a test calling
+/// [`decide`] changes answer with the developer's own `exclude_commands` and
+/// `transparent_prefixes` — an `exclude_commands = ["git"]` on the machine
+/// turns an expected rewrite into a defer, and the test fails there and only
+/// there. Taking the parameters keeps the decision under test independent of
+/// the host configuration, the same way the verdict is passed in rather than
+/// looked up (#3146).
+pub(crate) fn decide_with_params(
+    cmd: &str,
+    verdict: PermissionVerdict,
+    excluded: &[String],
+    transparent_prefixes: &[String],
+) -> HookDecision {
+    if verdict == PermissionVerdict::Deny {
+        return HookDecision::Deny;
+    }
+
+    if crate::discover::lexer::contains_unattestable_construct(cmd) {
+        return HookDecision::Defer;
+    }
+
+    match rewrite_command(cmd, excluded, transparent_prefixes) {
+        Some(rewritten) if verdict == PermissionVerdict::Allow => {
+            HookDecision::AllowRewrite(rewritten)
+        }
+        Some(rewritten) => HookDecision::AskRewrite(rewritten),
+        None => HookDecision::Defer,
+    }
+}
+
+/// [`decide`], plus the no-op suppression every agent applies.
+///
+/// This is the composition every *hook* wants, as opposed to [`decide`] alone,
+/// which is what the `rtk rewrite` CLI renders. Every hook entry point goes
+/// through here so they cannot drift apart.
+pub(crate) fn decide_for_agent(cmd: &str, verdict: PermissionVerdict) -> HookDecision {
+    suppress_identity(cmd, decide(cmd, verdict))
+}
+
+/// Turn a rewrite that changed nothing into a [`HookDecision::Defer`].
+///
+/// A command that is already RTK-prefixed rewrites to itself, and a hook that
+/// reports that is asking its host to apply an edit with no effect. What that
+/// costs is per host: Copilot IDE renders a rewrite as a deny-with-suggestion,
+/// so it refuses the command and tells the user to re-run the very thing they
+/// ran; Cursor raises a permission prompt for it. The plugins that shell out to
+/// `rtk rewrite` reach the same outcome in their own code --
+/// `hooks/opencode/rtk.ts`, `hooks/pi/rtk.ts` (shared with omp),
+/// `hooks/hermes/rtk-rewrite/__init__.py` and `openclaw/index.ts` all gate on
+/// `rewritten != command`.
+///
+/// `Defer` is not uniformly neutral, though: Gemini renders it as `ask_user`,
+/// so there suppression trades a no-op rewrite for a confirmation prompt even
+/// when that host's own allow rule covers the command.
+///
+/// The comparison is byte-exact while `rewrite_command` returns a trimmed,
+/// continuation-collapsed string, so a command differing only in leading or
+/// trailing whitespace is not suppressed.
+///
+/// `rtk rewrite` itself reports the no-op as a normal rewrite, exit 0 or 3 with
+/// the command unchanged on stdout. It answers "what is the RTK form of this
+/// command", and for an already-prefixed one that form is itself; whether that
+/// counts as a change is the caller's question, which is why those plugins
+/// compare. `decision_consistency` in `tests/hook_decision_protocol_test.rs`
+/// pins the difference.
+pub(crate) fn suppress_identity(cmd: &str, decision: HookDecision) -> HookDecision {
+    match decision {
+        HookDecision::AllowRewrite(ref rewritten) | HookDecision::AskRewrite(ref rewritten)
+            if rewritten == cmd =>
+        {
+            HookDecision::Defer
+        }
+        other => other,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A rewritable command with no rule matching it is an ask-rewrite, never
+    /// an allow-rewrite (#1155).
+    #[test]
+    fn default_verdict_asks_rather_than_allows() {
+        assert!(matches!(
+            decide_with_params("git status", PermissionVerdict::Default, &[], &[]),
+            HookDecision::AskRewrite(_)
+        ));
+    }
+
+    #[test]
+    fn explicit_allow_permits_the_rewrite() {
+        assert!(matches!(
+            decide_with_params("git status", PermissionVerdict::Allow, &[], &[]),
+            HookDecision::AllowRewrite(_)
+        ));
+    }
+
+    #[test]
+    fn deny_wins_before_anything_else() {
+        assert_eq!(
+            decide_with_params("git status", PermissionVerdict::Deny, &[], &[]),
+            HookDecision::Deny
+        );
+    }
+
+    #[test]
+    fn command_without_an_rtk_equivalent_defers() {
+        assert_eq!(
+            decide_with_params("htop", PermissionVerdict::Default, &[], &[]),
+            HookDecision::Defer
+        );
+    }
+
+    /// Refused whatever the verdict: the permission gate can't decompose these
+    /// into segments it can check, so a rewrite could carry an unchecked
+    /// command past an allow rule.
+    #[test]
+    fn unattestable_constructs_defer() {
+        for cmd in [
+            "git status `rm -rf /tmp/x`",
+            "git status $(rm -rf /tmp/x)",
+            "git log --pretty=\"$(rm -rf /tmp/x)\"",
+            "git log > /tmp/out.txt",
+        ] {
+            assert_eq!(
+                decide_with_params(cmd, PermissionVerdict::Default, &[], &[]),
+                HookDecision::Defer,
+                "cmd: {cmd}"
+            );
+        }
+    }
+
+    /// A file-descriptor dup is not a file target — the rewrite still happens.
+    #[test]
+    fn fd_dup_redirect_still_rewrites() {
+        assert!(matches!(
+            decide_with_params("git status 2>&1", PermissionVerdict::Default, &[], &[]),
+            HookDecision::AskRewrite(_)
+        ));
+    }
+
+    #[test]
+    fn heredoc_defers() {
+        assert_eq!(
+            decide_with_params(
+                "cat <<'EOF'\nhello\nEOF",
+                PermissionVerdict::Default,
+                &[],
+                &[]
+            ),
+            HookDecision::Defer
+        );
+    }
+
+    /// `decide` itself reports a no-op rewrite as a normal one; only
+    /// `suppress_identity` turns it into a defer. `rtk rewrite` depends on the
+    /// former, the in-process hosts on the latter.
+    #[test]
+    fn identity_rewrite_is_reported_and_only_suppressed_on_request() {
+        let cmd = "rtk git status";
+        let decided = decide_with_params(cmd, PermissionVerdict::Default, &[], &[]);
+        assert_eq!(decided, HookDecision::AskRewrite(cmd.to_string()));
+        assert_eq!(suppress_identity(cmd, decided), HookDecision::Defer);
+    }
+
+    /// Suppression only fires on an actual no-op — a real rewrite is untouched.
+    #[test]
+    fn suppress_identity_leaves_a_real_rewrite_alone() {
+        let decided = decide_with_params("git status", PermissionVerdict::Allow, &[], &[]);
+        assert_eq!(
+            suppress_identity("git status", decided),
+            HookDecision::AllowRewrite("rtk git status".to_string())
+        );
+    }
+
+    /// Suppression only ever collapses a rewrite: a decision that carries no
+    /// rewritten command passes through untouched, so it can never mask a deny.
+    #[test]
+    fn suppress_identity_passes_deny_and_defer_through() {
+        assert_eq!(
+            suppress_identity("x", HookDecision::Deny),
+            HookDecision::Deny
+        );
+        assert_eq!(
+            suppress_identity("x", HookDecision::Defer),
+            HookDecision::Defer
+        );
+    }
+}

--- a/src/hooks/decision.rs
+++ b/src/hooks/decision.rs
@@ -1,12 +1,13 @@
 //! The single place RTK decides what a hook should do with a command.
 //!
-//! Two entry points ask the same question — may this command be rewritten,
+//! Three entry points ask the same question — may this command be rewritten,
 //! and may the rewrite be auto-allowed?
 //!
 //! | Entry point | Verdict source | Identity rewrite |
 //! |---|---|---|
 //! | `rtk hook <agent>` (`hook_cmd`) | `check_command_for(cmd, host)` | suppressed |
 //! | `rtk rewrite` (`rewrite_cmd`, run as a subprocess by the shell/TS/Python delegates) | `check_command` (always `Host::Claude`) | reported |
+//! | `rtk hook check` (`main.rs`) | whatever the named `--agent` consults, via [`AgentPath`] | suppressed |
 //!
 //! [`decide`] is the shared answer. What legitimately differs between callers
 //! stays outside it: the verdict is passed in rather than looked up, so each
@@ -14,7 +15,7 @@
 //! machine's settings (#3146); and the no-op-rewrite policy lives in
 //! [`decide_for_agent`], which every hook shares and the CLI does not.
 
-use super::permissions::PermissionVerdict;
+use super::permissions::{check_command_for, Host, PermissionVerdict};
 use crate::discover::registry::rewrite_command;
 
 /// What a hook should do with a command.
@@ -141,6 +142,109 @@ pub(crate) fn suppress_identity(cmd: &str, decision: HookDecision) -> HookDecisi
     }
 }
 
+/// How the hook RTK installs for a given `--agent` actually reaches a decision.
+///
+/// `rtk init` supports more agents than [`Host`] has variants, because they
+/// differ in *whose* permission rules their hook consults — not all of them
+/// consult any. A diagnostic that ignores that reports the wrong hook's answer.
+///
+/// They do not differ on a rewrite that changed nothing: every agent discards
+/// it. The in-process hosts do so in `hook_cmd`; the ones that shell out to
+/// `rtk rewrite` do so in their own plugin, because `rtk rewrite` reports the
+/// no-op rather than suppressing it (see [`suppress_identity`]).
+pub(crate) enum AgentPath {
+    /// `rtk hook <agent>` — decides in this process, against the host's own
+    /// permission rules.
+    InProcess(Host),
+    /// A plugin or shell script that shells out to `rtk rewrite`. That entry
+    /// point has no way to be told which host is asking, so it always reads
+    /// Claude Code's rules.
+    ViaRewrite,
+    /// A rules-file install — RTK ships instructions telling the agent to
+    /// prefix commands itself. There is no hook and no permission surface, so
+    /// only the rewrite rules apply.
+    RulesOnly,
+}
+
+impl AgentPath {
+    /// The path for an `--agent` value, reporting the accepted values on stderr
+    /// when there is no such install target.
+    ///
+    /// Every [`crate::AgentTarget`] must resolve, plus the targets installed by
+    /// a flag rather than an enum variant — `rtk init --copilot`, `--gemini`,
+    /// `--codex`, `--opencode`, and OpenClaw's own installer — pinned by
+    /// `agent_path_covers_every_install_target`.
+    // Reached only from `rtk hook check`, never from a hook's own stream.
+    #[allow(clippy::print_stderr)]
+    pub(crate) fn from_agent(agent: &str) -> Option<Self> {
+        let path = Self::lookup(agent);
+        if path.is_none() {
+            eprintln!(
+                "Unknown agent: {} (expected one of: {})",
+                agent,
+                Self::AGENTS.join(", ")
+            );
+        }
+        path
+    }
+
+    /// The mapping itself, so tests can exercise it without writing to stderr.
+    fn lookup(agent: &str) -> Option<Self> {
+        match agent {
+            // `copilot` reads Claude Code's settings rather than a Copilot file
+            // (see `hook_cmd`'s `vscode_response` and `copilot_cli_response`).
+            "antigravity" | "cline" | "codex" | "kilocode" | "kimi" | "windsurf" => {
+                Some(Self::RulesOnly)
+            }
+            "claude" | "copilot" => Some(Self::InProcess(Host::Claude)),
+            "cursor" => Some(Self::InProcess(Host::Cursor)),
+            "droid" => Some(Self::InProcess(Host::Droid)),
+            "gemini" => Some(Self::InProcess(Host::Gemini)),
+            "hermes" | "omp" | "openclaw" | "opencode" | "pi" => Some(Self::ViaRewrite),
+            "vibe" => Some(Self::InProcess(Host::Vibe)),
+            _ => None,
+        }
+    }
+
+    /// The `--agent` values [`AgentPath::lookup`] accepts.
+    const AGENTS: &'static [&'static str] = &[
+        "antigravity",
+        "claude",
+        "cline",
+        "codex",
+        "copilot",
+        "cursor",
+        "droid",
+        "gemini",
+        "hermes",
+        "kilocode",
+        "kimi",
+        "omp",
+        "openclaw",
+        "opencode",
+        "pi",
+        "vibe",
+        "windsurf",
+    ];
+
+    /// The verdict this agent's hook would judge `cmd` against.
+    fn verdict(&self, cmd: &str) -> PermissionVerdict {
+        match self {
+            Self::InProcess(host) => check_command_for(cmd, *host),
+            // `rtk rewrite` always reads Claude Code's rules.
+            Self::ViaRewrite => check_command_for(cmd, Host::Claude),
+            // No hook, so no rules to consult.
+            Self::RulesOnly => PermissionVerdict::Default,
+        }
+    }
+
+    /// What this agent's hook would do with `cmd` — the same answer it gives at
+    /// runtime, including discarding a rewrite that changed nothing.
+    pub(crate) fn decide(&self, cmd: &str) -> HookDecision {
+        decide_for_agent(cmd, self.verdict(cmd))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -252,6 +356,65 @@ mod tests {
         assert_eq!(
             suppress_identity("x", HookDecision::Defer),
             HookDecision::Defer
+        );
+    }
+
+    /// Every install target `rtk` supports must resolve, or `rtk hook check`
+    /// rejects an agent the user really installed. Derived from `AgentTarget`
+    /// so a new variant fails here instead of silently going unanswerable.
+    #[test]
+    fn agent_path_covers_every_install_target() {
+        use clap::ValueEnum;
+
+        for variant in crate::AgentTarget::value_variants() {
+            let name = variant
+                .to_possible_value()
+                .expect("AgentTarget variant is not skipped")
+                .get_name()
+                .to_string();
+            assert!(
+                AgentPath::lookup(&name).is_some(),
+                "unmapped AgentTarget: {name}"
+            );
+            assert!(
+                AgentPath::AGENTS.contains(&name.as_str()),
+                "AgentTarget missing from the error message: {name}"
+            );
+        }
+
+        // Install targets reached by a flag rather than an `AgentTarget`
+        // variant, so the loop above cannot see them.
+        for name in ["codex", "copilot", "gemini", "openclaw", "opencode"] {
+            assert!(AgentPath::lookup(name).is_some(), "unmapped: {name}");
+            assert!(AgentPath::AGENTS.contains(&name), "not listed: {name}");
+        }
+    }
+
+    /// Everything advertised in the error message must actually resolve.
+    #[test]
+    fn every_listed_agent_resolves() {
+        for name in AgentPath::AGENTS {
+            assert!(
+                AgentPath::lookup(name).is_some(),
+                "listed but unmapped: {name}"
+            );
+        }
+    }
+
+    #[test]
+    fn agent_path_rejects_the_unknown() {
+        assert!(AgentPath::lookup("nope").is_none());
+        assert!(AgentPath::lookup("").is_none());
+        assert!(AgentPath::lookup("Claude").is_none());
+    }
+
+    /// A rules-file agent has no hook and no permission rules, so its answer
+    /// must not depend on any host's settings.
+    #[test]
+    fn rules_only_agent_uses_the_default_verdict() {
+        assert_eq!(
+            AgentPath::RulesOnly.verdict("git status"),
+            PermissionVerdict::Default
         );
     }
 }

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -4,6 +4,7 @@
 //! corrupts the JSON protocol (Claude Code bug #4669 silently disables the hook).
 
 use super::constants::PRE_TOOL_USE_KEY;
+use super::decision::{self, HookDecision};
 use super::permissions::{self, PermissionVerdict};
 use anyhow::{Context, Result};
 use serde_json::{json, Value};
@@ -11,7 +12,6 @@ use std::io::{self, Read, Write};
 
 use crate::core::tracking::HookOutcome;
 use crate::core::utils::strip_leading_bom;
-use crate::discover::registry::{has_heredoc, rewrite_command};
 
 const STDIN_CAP: usize = 1_048_576; // 1 MiB
 
@@ -233,42 +233,14 @@ fn heal_legacy_hook_file(path: &std::path::Path) -> bool {
         .is_ok()
 }
 
-fn get_rewritten(cmd: &str) -> Option<String> {
-    if has_heredoc(cmd) {
-        return None;
-    }
-
-    let (excluded, transparent_prefixes) = crate::core::config::hook_rewrite_params();
-
-    let rewritten = rewrite_command(cmd, &excluded, &transparent_prefixes)?;
-
-    if rewritten == cmd {
-        return None;
-    }
-
-    Some(rewritten)
-}
-
-enum HookDecision {
-    AllowRewrite(String),
-    AskRewrite(String),
-    Defer,
-    Deny,
-}
-
+/// The decision every hook applies -- [`decision::decide_for_agent`] -- plus the
+/// recall bookkeeping the hook path performs for any command it does not deny.
 fn decide_from_verdict(cmd: &str, verdict: PermissionVerdict) -> HookDecision {
     if verdict == PermissionVerdict::Deny {
         return HookDecision::Deny;
     }
     crate::hooks::rewrite_cmd::track_tee_read(cmd);
-    if crate::discover::lexer::contains_unattestable_construct(cmd) {
-        return HookDecision::Defer;
-    }
-    match get_rewritten(cmd) {
-        Some(r) if verdict == PermissionVerdict::Allow => HookDecision::AllowRewrite(r),
-        Some(r) => HookDecision::AskRewrite(r),
-        None => HookDecision::Defer,
-    }
+    decision::decide_for_agent(cmd, verdict)
 }
 
 fn decide_hook_action(cmd: &str, host: permissions::Host) -> HookDecision {
@@ -1006,6 +978,7 @@ fn run_droid_inner_with_rules(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::hooks::permissions::PermissionVerdict;
 
     fn rewrite_command_no_prefixes(cmd: &str, excluded: &[String]) -> Option<String> {
         crate::discover::registry::rewrite_command(cmd, excluded, &[])
@@ -1117,26 +1090,6 @@ mod tests {
     #[test]
     fn test_detect_unknown_is_passthrough() {
         assert!(matches!(detect_format(&json!({})), HookFormat::PassThrough));
-    }
-
-    #[test]
-    fn test_get_rewritten_supported() {
-        assert!(get_rewritten("git status").is_some());
-    }
-
-    #[test]
-    fn test_get_rewritten_unsupported() {
-        assert!(get_rewritten("htop").is_none());
-    }
-
-    #[test]
-    fn test_get_rewritten_already_rtk() {
-        assert!(get_rewritten("rtk git status").is_none());
-    }
-
-    #[test]
-    fn test_get_rewritten_heredoc() {
-        assert!(get_rewritten("cat <<'EOF'\nhello\nEOF").is_none());
     }
 
     // --- VS Code Copilot Chat / Copilot CLI (PascalCase) handler ---
@@ -2025,11 +1978,6 @@ mod tests {
         assert_eq!(
             check_command_with_rules("cargo test", &deny, &[], &[]),
             PermissionVerdict::Deny
-        );
-        // Denied commands must not be rewritten — Gemini handler checks deny before rewrite
-        assert!(
-            get_rewritten("cargo test").is_some(),
-            "cargo test should be rewritable when not denied"
         );
     }
 

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -1,6 +1,10 @@
 //! Hook installation and lifecycle management for AI coding agents.
 
 pub mod constants;
+// Shares `hook_cmd`'s constraint: it runs inside the hook, where stray output
+// corrupts the JSON protocol.
+#[deny(clippy::print_stdout, clippy::print_stderr)]
+pub mod decision;
 pub mod hook_audit_cmd;
 pub mod hook_check;
 #[deny(clippy::print_stdout, clippy::print_stderr)]

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -2,7 +2,8 @@
 
 pub mod constants;
 // Shares `hook_cmd`'s constraint: it runs inside the hook, where stray output
-// corrupts the JSON protocol.
+// corrupts the JSON protocol. `from_agent` is the one exception and carries its
+// own allow -- it is reached only from the `rtk hook check` CLI.
 #[deny(clippy::print_stdout, clippy::print_stderr)]
 pub mod decision;
 pub mod hook_audit_cmd;

--- a/src/hooks/rewrite_cmd.rs
+++ b/src/hooks/rewrite_cmd.rs
@@ -1,20 +1,9 @@
 //! Translates a raw shell command into its RTK-optimized equivalent.
 
-use super::permissions::{check_command, PermissionVerdict};
-use crate::discover::registry;
+use super::decision::{self, HookDecision};
+use super::permissions::check_command;
 use std::io::Write;
 
-/// Run the `rtk rewrite` command.
-///
-/// Prints the RTK-rewritten command to stdout and exits with a code that tells
-/// the caller how to handle permissions:
-///
-/// | Exit | Stdout   | Meaning                                                      |
-/// |------|----------|--------------------------------------------------------------|
-/// | 0    | rewritten| Rewrite allowed — hook may auto-allow the rewritten command. |
-/// | 1    | (none)   | No RTK equivalent — hook passes through unchanged.           |
-/// | 2    | (none)   | Deny rule matched — hook defers to Claude Code native deny.  |
-/// | 3    | rewritten| Ask rule matched — hook rewrites but lets Claude Code prompt.|
 const TEE_READERS: &[&str] = &[
     "cat", "tail", "head", "less", "more", "bat", "grep", "rg", "sed", "awk",
 ];
@@ -71,74 +60,50 @@ pub(crate) fn track_tee_read(cmd: &str) {
     }
 }
 
+/// Run the `rtk rewrite` command.
+///
+/// Prints the RTK-rewritten command to stdout and exits with a code that tells
+/// the caller how to handle permissions:
+///
+/// | Exit | Stdout   | Meaning                                                      |
+/// |------|----------|--------------------------------------------------------------|
+/// | 0    | rewritten| Rewrite allowed — hook may auto-allow the rewritten command. |
+/// | 1    | (none)   | No RTK equivalent — hook passes through unchanged.           |
+/// | 2    | (none)   | Deny rule matched — hook defers to Claude Code native deny.  |
+/// | 3    | rewritten| Ask rule matched — hook rewrites but lets Claude Code prompt.|
+///
+/// The decision itself is [`decision::decide`], shared with the in-process
+/// `rtk hook <agent>` path; this function is only its exit-code rendering.
 pub fn run(cmd: &str) -> anyhow::Result<()> {
-    let (excluded, transparent_prefixes) = crate::core::config::hook_rewrite_params();
-
-    let outcome = evaluate(cmd, &excluded, &transparent_prefixes);
-    if !matches!(outcome, RewriteOutcome::Deny) {
+    // `rtk rewrite` is a subprocess entry point with no way to be told which
+    // host is asking, so every delegate that shells out to it -- hermes, omp,
+    // opencode, openclaw, pi -- is judged against `~/.claude`'s rules. The
+    // in-process `rtk hook <agent>` path is host-parameterized instead
+    // (`permissions::Host`).
+    let decided = decision::decide(cmd, check_command(cmd));
+    if !matches!(decided, HookDecision::Deny) {
         track_tee_read(cmd);
     }
-    match outcome {
-        RewriteOutcome::Allow(rewritten) => {
+    match decided {
+        HookDecision::AllowRewrite(rewritten) => {
             print!("{}", rewritten);
             let _ = std::io::stdout().flush();
             Ok(())
         }
-        RewriteOutcome::Ask(rewritten) => {
+        HookDecision::AskRewrite(rewritten) => {
             print!("{}", rewritten);
             let _ = std::io::stdout().flush();
             std::process::exit(3);
         }
-        RewriteOutcome::Deny => std::process::exit(2),
-        RewriteOutcome::Passthrough => std::process::exit(1),
-    }
-}
-
-#[derive(Debug, PartialEq)]
-enum RewriteOutcome {
-    Allow(String),
-    Passthrough,
-    Deny,
-    Ask(String),
-}
-
-fn evaluate(cmd: &str, excluded: &[String], transparent_prefixes: &[String]) -> RewriteOutcome {
-    evaluate_with_verdict(cmd, check_command(cmd), excluded, transparent_prefixes)
-}
-
-/// Decision logic for [`evaluate`] with the permission verdict supplied by the
-/// caller, mirroring [`check_command_with_rules`](super::permissions::check_command_with_rules).
-///
-/// `check_command` reads the machine's Claude Code settings files, so tests that
-/// call [`evaluate`] directly would change verdict with the developer's local
-/// `settings.local.json`. Taking the verdict as a parameter keeps the rewrite
-/// logic under test independent of the host configuration (#3146).
-fn evaluate_with_verdict(
-    cmd: &str,
-    verdict: PermissionVerdict,
-    excluded: &[String],
-    transparent_prefixes: &[String],
-) -> RewriteOutcome {
-    if verdict == PermissionVerdict::Deny {
-        return RewriteOutcome::Deny;
-    }
-
-    if crate::discover::lexer::contains_unattestable_construct(cmd) {
-        return RewriteOutcome::Passthrough;
-    }
-
-    match registry::rewrite_command(cmd, excluded, transparent_prefixes) {
-        Some(rewritten) => match verdict {
-            PermissionVerdict::Allow => RewriteOutcome::Allow(rewritten),
-            _ => RewriteOutcome::Ask(rewritten),
-        },
-        None => RewriteOutcome::Passthrough,
+        HookDecision::Deny => std::process::exit(2),
+        HookDecision::Defer => std::process::exit(1),
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::discover::registry;
 
     #[test]
     fn test_tee_read_slug_detects_tail_hint_command() {
@@ -221,106 +186,6 @@ mod tests {
             rewrite_command_no_prefixes("rtk git status"),
             Some("rtk git status".into())
         );
-    }
-
-    /// The verdict still drives the outcome: an allow rule yields `Allow`.
-    /// Pinning both directions keeps the mapping covered without depending
-    /// on which rules the developer happens to have configured.
-    #[test]
-    fn test_allow_verdict_yields_allow() {
-        assert!(matches!(
-            evaluate_with_verdict("git status", PermissionVerdict::Allow, &[], &[]),
-            RewriteOutcome::Allow(_)
-        ));
-    }
-
-    #[test]
-    fn test_deny_verdict_yields_deny() {
-        assert_eq!(
-            evaluate_with_verdict("git status", PermissionVerdict::Deny, &[], &[]),
-            RewriteOutcome::Deny
-        );
-    }
-
-    /// Commands with an unattestable construct are always a passthrough,
-    /// regardless of permission verdict.
-    ///
-    /// The verdict is pinned to `Default` rather than going through `evaluate`,
-    /// which reads the developer's own `.claude/settings.local.json`: a
-    /// `Bash(git *)` allow rule turns the expected `Ask` into `Allow` and these
-    /// tests fail on that machine only (#3146). Pinning the verdict keeps the
-    /// assertions about the rewrite logic and nothing about the host.
-    mod unattestable_passthrough {
-        use super::super::{evaluate_with_verdict, RewriteOutcome};
-        use crate::hooks::permissions::PermissionVerdict;
-
-        #[test]
-        fn test_backtick_substitution_passthrough() {
-            assert_eq!(
-                evaluate_with_verdict(
-                    "git status `rm -rf /tmp/x`",
-                    PermissionVerdict::Default,
-                    &[],
-                    &[]
-                ),
-                RewriteOutcome::Passthrough
-            );
-        }
-
-        #[test]
-        fn test_dollar_substitution_passthrough() {
-            assert_eq!(
-                evaluate_with_verdict(
-                    "git status $(rm -rf /tmp/x)",
-                    PermissionVerdict::Default,
-                    &[],
-                    &[]
-                ),
-                RewriteOutcome::Passthrough
-            );
-        }
-
-        #[test]
-        fn test_double_quoted_substitution_passthrough() {
-            assert_eq!(
-                evaluate_with_verdict(
-                    "git log --pretty=\"$(rm -rf /tmp/x)\"",
-                    PermissionVerdict::Default,
-                    &[],
-                    &[]
-                ),
-                RewriteOutcome::Passthrough
-            );
-        }
-
-        #[test]
-        fn test_file_redirect_passthrough() {
-            assert_eq!(
-                evaluate_with_verdict(
-                    "git log > /tmp/out.txt",
-                    PermissionVerdict::Default,
-                    &[],
-                    &[]
-                ),
-                RewriteOutcome::Passthrough
-            );
-        }
-
-        #[test]
-        fn test_fd_dup_redirect_still_rewrites() {
-            assert!(matches!(
-                evaluate_with_verdict("git status 2>&1", PermissionVerdict::Default, &[], &[]),
-                RewriteOutcome::Ask(_)
-            ));
-        }
-
-        #[test]
-        fn test_plain_command_still_rewrites() {
-            assert!(matches!(
-                evaluate_with_verdict("git status", PermissionVerdict::Default, &[], &[]),
-                RewriteOutcome::Ask(_)
-            ));
-        }
     }
 
     /// SECURITY: Verify the exit code protocol for permission verdicts.

--- a/src/main.rs
+++ b/src/main.rs
@@ -2788,16 +2788,32 @@ fn run_cli() -> Result<i32> {
                 hooks::hook_cmd::run_vibe()?;
                 0
             }
-            HookCommands::Check { agent: _, command } => {
-                use crate::discover::registry::rewrite_command;
+            HookCommands::Check { agent, command } => {
+                // Answers the same question the hooks answer, through the same
+                // decision (`hooks::decision`) — not just "does a rewrite rule
+                // match?". Checking the rule alone reported a rewrite for
+                // command substitutions, file redirects and heredocs that both
+                // hook paths refuse to touch, which is the opposite of what a
+                // diagnostic is for.
+                use crate::hooks::decision::{AgentPath, HookDecision};
                 let raw = command.join(" ");
-                let (excluded, transparent_prefixes) = crate::core::config::hook_rewrite_params();
-                match rewrite_command(&raw, &excluded, &transparent_prefixes) {
-                    Some(rewritten) => {
+                // Answer for the agent that was asked about. Agents differ both
+                // in whose permission rules their hook reads and in how it
+                // decides -- see `AgentPath` -- so one hard-coded answer would
+                // misdescribe the very hook being diagnosed.
+                let Some(path) = AgentPath::from_agent(&agent) else {
+                    return Ok(2);
+                };
+                match path.decide(&raw) {
+                    HookDecision::AllowRewrite(rewritten) | HookDecision::AskRewrite(rewritten) => {
                         println!("{}", rewritten);
                         0
                     }
-                    None => {
+                    HookDecision::Deny => {
+                        eprintln!("Denied by a permission rule: {}", raw);
+                        1
+                    }
+                    HookDecision::Defer => {
                         eprintln!("No rewrite for: {}", raw);
                         1
                     }

--- a/tests/hook_decision_protocol_test.rs
+++ b/tests/hook_decision_protocol_test.rs
@@ -1,0 +1,467 @@
+//! Characterization of the two hook decision entry points, end to end.
+//!
+//! `rtk rewrite`'s exit-code protocol is a public contract consumed entirely
+//! outside this crate — `hooks/claude/rtk-rewrite.sh`, `hooks/cursor/rtk-rewrite.sh`,
+//! `hooks/pi/rtk.ts`, `hooks/hermes/rtk-rewrite/__init__.py`, `hooks/opencode/rtk.ts`
+//! and `openclaw/index.ts` all branch on it — yet no Rust test ever ran `run()`.
+//! `rewrite_cmd`'s own `exit_code_protocol` module asserts against a locally
+//! re-implemented `expected_exit_code()` table, so the real mapping could change
+//! without a single failure, including the #1155 invariant that a `Default`
+//! verdict must exit 3 and never 0.
+//!
+//! These tests spawn the real binary in a sandboxed HOME/CLAUDE_CONFIG_DIR and
+//! pin the actual `(exit code, stdout)` pairs. They exist to make the decision-flow
+//! consolidation provably behavior-preserving: they must keep passing, unmodified,
+//! across that refactor.
+
+use std::path::PathBuf;
+use std::process::Command;
+use tempfile::TempDir;
+
+/// An isolated machine: no developer settings, no user rtk config, no real HOME.
+struct Sandbox {
+    _root: TempDir,
+    home: PathBuf,
+    claude_home: PathBuf,
+    project: PathBuf,
+}
+
+impl Sandbox {
+    /// Build a sandbox whose project-level `.claude/settings.json` carries
+    /// exactly the given rules, and nothing else anywhere.
+    fn with_rules(deny: &[&str], ask: &[&str], allow: &[&str]) -> Self {
+        let root = TempDir::new().expect("tempdir");
+        let home = root.path().join("home");
+        let claude_home = root.path().join("claude-home");
+        let project = root.path().join("project");
+        std::fs::create_dir_all(home.join(".config")).expect("mkdir home config");
+        std::fs::create_dir_all(&claude_home).expect("mkdir claude home");
+        std::fs::create_dir_all(project.join(".claude")).expect("mkdir project claude");
+        // A tee artefact plus an existing recall store: the recall path only
+        // writes to a store that already exists.
+        let tee = root.path().join("tee");
+        std::fs::create_dir_all(&tee).expect("mkdir tee");
+        std::fs::write(tee.join("1755590000_cargo-test.log"), "boom\n").expect("write tee log");
+        std::fs::write(root.path().join("recall.db"), b"").expect("seed recall store");
+
+        let quote = |rules: &[&str]| {
+            rules
+                .iter()
+                .map(|r| format!("\"Bash({r})\""))
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+        let settings = format!(
+            r#"{{"permissions": {{"deny": [{}], "ask": [{}], "allow": [{}]}}}}"#,
+            quote(deny),
+            quote(ask),
+            quote(allow)
+        );
+        std::fs::write(project.join(".claude/settings.json"), settings).expect("write settings");
+
+        let quote = |rules: &[&str]| {
+            rules
+                .iter()
+                .map(|r| format!("\"Bash({r})\""))
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+        let settings = format!(
+            r#"{{"permissions": {{"deny": [{}], "ask": [{}], "allow": [{}]}}}}"#,
+            quote(deny),
+            quote(ask),
+            quote(allow)
+        );
+        std::fs::write(project.join(".claude/settings.json"), settings).expect("write settings");
+
+        Self {
+            _root: root,
+            home,
+            claude_home,
+            project,
+        }
+    }
+
+    /// A sandbox with no permission rules at all — every command lands on the
+    /// `Default` verdict.
+    fn bare() -> Self {
+        Self::with_rules(&[], &[], &[])
+    }
+
+    fn run(&self, args: &[&str]) -> (i32, String, String) {
+        let out = Command::new(env!("CARGO_BIN_EXE_rtk"))
+            .args(args)
+            .current_dir(&self.project)
+            .env("HOME", &self.home)
+            .env("XDG_CONFIG_HOME", self.home.join(".config"))
+            .env("CLAUDE_CONFIG_DIR", &self.claude_home)
+            .env("RTK_DB_PATH", self.project.join("rtk.db"))
+            .env("RTK_TEE_DIR", self.tee_dir())
+            .env("RTK_RECALL_DB", self.recall_db())
+            .env("LC_ALL", "C")
+            .output()
+            .expect("spawn rtk");
+        (
+            out.status.code().expect("exit code"),
+            String::from_utf8_lossy(&out.stdout).into_owned(),
+            String::from_utf8_lossy(&out.stderr).into_owned(),
+        )
+    }
+
+    fn tee_dir(&self) -> PathBuf {
+        self._root.path().join("tee")
+    }
+
+    fn recall_db(&self) -> PathBuf {
+        self._root.path().join("recall.db")
+    }
+
+    fn tee_log(&self) -> String {
+        self.tee_dir()
+            .join("1755590000_cargo-test.log")
+            .to_string_lossy()
+            .into_owned()
+    }
+
+    /// Whether anything was written to the recall store. It is seeded empty, and
+    /// the schema is only created when a recall is actually recorded.
+    fn recorded_a_recall(&self) -> bool {
+        std::fs::metadata(self.recall_db())
+            .map(|m| m.len() > 0)
+            .unwrap_or(false)
+    }
+
+    fn rewrite(&self, cmd: &str) -> (i32, String) {
+        let (code, stdout, _) = self.run(&["rewrite", cmd]);
+        (code, stdout)
+    }
+}
+
+impl Sandbox {
+    /// Feed a Claude PreToolUse payload to the in-process hook and return stdout.
+    fn hook_claude(&self, cmd: &str) -> String {
+        use std::io::Write;
+        use std::process::Stdio;
+        let payload = serde_json::json!({
+            "tool_name": "Bash",
+            "tool_input": { "command": cmd },
+        })
+        .to_string();
+        let mut child = Command::new(env!("CARGO_BIN_EXE_rtk"))
+            .args(["hook", "claude"])
+            .current_dir(&self.project)
+            .env("HOME", &self.home)
+            .env("XDG_CONFIG_HOME", self.home.join(".config"))
+            .env("CLAUDE_CONFIG_DIR", &self.claude_home)
+            .env("RTK_DB_PATH", self.project.join("rtk.db"))
+            .env("RTK_TEE_DIR", self.tee_dir())
+            .env("RTK_RECALL_DB", self.recall_db())
+            .env("LC_ALL", "C")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn rtk hook claude");
+        child
+            .stdin
+            .take()
+            .expect("stdin")
+            .write_all(payload.as_bytes())
+            .expect("write payload");
+        let out = child.wait_with_output().expect("wait rtk");
+        String::from_utf8_lossy(&out.stdout).into_owned()
+    }
+
+    /// The command the in-process hook would substitute, or `None` when it defers.
+    fn hook_claude_rewrite(&self, cmd: &str) -> Option<String> {
+        let stdout = self.hook_claude(cmd);
+        if stdout.trim().is_empty() {
+            return None;
+        }
+        let v: serde_json::Value = serde_json::from_str(&stdout).expect("hook emitted valid JSON");
+        v.pointer("/hookSpecificOutput/updatedInput/command")
+            .and_then(|c| c.as_str())
+            .map(str::to_owned)
+    }
+}
+
+/// `rtk rewrite`'s four documented exit codes, against real permission rules.
+///
+/// The table in `rewrite_cmd`'s doc comment is the contract every delegate
+/// branches on; this is the only place it is checked end to end.
+mod rewrite_exit_codes {
+    use super::Sandbox;
+
+    #[test]
+    fn allow_rule_exits_zero_with_the_rewrite() {
+        let sb = Sandbox::with_rules(&[], &[], &["git status"]);
+        assert_eq!(sb.rewrite("git status"), (0, "rtk git status".into()));
+    }
+
+    #[test]
+    fn ask_rule_exits_three_with_the_rewrite() {
+        let sb = Sandbox::with_rules(&[], &["git status"], &[]);
+        assert_eq!(sb.rewrite("git status"), (3, "rtk git status".into()));
+    }
+
+    #[test]
+    fn deny_rule_exits_two_and_says_nothing() {
+        let sb = Sandbox::with_rules(&["git status"], &[], &[]);
+        assert_eq!(sb.rewrite("git status"), (2, String::new()));
+    }
+
+    /// A deny rule matching *any* segment denies the whole chain (#1213).
+    #[test]
+    fn deny_rule_on_one_segment_denies_the_compound() {
+        let sb = Sandbox::with_rules(&["rm -rf *"], &[], &[]);
+        assert_eq!(
+            sb.rewrite("git status && rm -rf /tmp/x"),
+            (2, String::new())
+        );
+    }
+
+    #[test]
+    fn unknown_command_exits_one_and_says_nothing() {
+        let sb = Sandbox::bare();
+        assert_eq!(sb.rewrite("htop"), (1, String::new()));
+    }
+
+    /// SECURITY (#1155): with no rule matching, the verdict is `Default`, and
+    /// `Default` must exit 3 (ask) — never 0. Exit 0 tells the hook it may
+    /// auto-allow, so mapping `Default` there would auto-approve every
+    /// rewritable command on a machine with no permission rules at all.
+    #[test]
+    fn default_verdict_exits_three_never_zero() {
+        let sb = Sandbox::bare();
+        let (code, stdout) = sb.rewrite("git status");
+        assert_eq!(code, 3, "Default verdict must exit 3 (ask), not 0 (allow)");
+        assert_eq!(stdout, "rtk git status");
+    }
+
+    #[test]
+    fn compound_command_rewrites_every_segment() {
+        let sb = Sandbox::bare();
+        assert_eq!(
+            sb.rewrite("git status && cargo test"),
+            (3, "rtk git status && rtk cargo test".into())
+        );
+    }
+
+    /// A file-descriptor dup is not a file target, so the rewrite still happens.
+    #[test]
+    fn fd_dup_redirect_still_rewrites() {
+        let sb = Sandbox::bare();
+        assert_eq!(
+            sb.rewrite("git status 2>&1"),
+            (3, "rtk git status 2>&1".into())
+        );
+    }
+
+    /// Constructs the permission gate cannot decompose are never rewritten,
+    /// so a hidden command can't ride along inside an approved rewrite.
+    #[test]
+    fn unattestable_constructs_pass_through() {
+        let sb = Sandbox::bare();
+        for cmd in [
+            "git status $(rm -rf /tmp/x)",
+            "git status `rm -rf /tmp/x`",
+            "git log > /tmp/out.txt",
+        ] {
+            assert_eq!(sb.rewrite(cmd), (1, String::new()), "cmd: {cmd}");
+        }
+    }
+
+    #[test]
+    fn heredoc_passes_through() {
+        let sb = Sandbox::bare();
+        assert_eq!(sb.rewrite("cat <<EOF"), (1, String::new()));
+        assert_eq!(sb.rewrite("git status <<EOF"), (1, String::new()));
+    }
+}
+
+/// Reading back a tee artefact records a recall, and a denied command does not.
+///
+/// Both entry points perform that bookkeeping themselves rather than through the
+/// shared decision, because the `rtk hook check` diagnostic must not write
+/// counters that `rtk gain` reports. Two hand-written copies of one rule is
+/// exactly what drifts, and nothing else asserts it.
+mod recall_tracking {
+    use super::Sandbox;
+
+    #[test]
+    fn rewrite_records_a_tee_read_unless_denied() {
+        let sb = Sandbox::bare();
+        assert!(!sb.recorded_a_recall(), "store starts empty");
+        sb.rewrite(&format!("tail -n +52 {}", sb.tee_log()));
+        assert!(
+            sb.recorded_a_recall(),
+            "reading a tee artefact records a recall"
+        );
+
+        let denied = Sandbox::with_rules(&["tail *"], &[], &[]);
+        let (code, _) = denied.rewrite(&format!("tail -n +52 {}", denied.tee_log()));
+        assert_eq!(code, 2, "the deny rule must match, or this proves nothing");
+        assert!(
+            !denied.recorded_a_recall(),
+            "a denied command must not record a recall"
+        );
+    }
+
+    #[test]
+    fn hook_records_a_tee_read_unless_denied() {
+        let sb = Sandbox::bare();
+        sb.hook_claude(&format!("tail -n +52 {}", sb.tee_log()));
+        assert!(sb.recorded_a_recall(), "the hook path records a recall too");
+
+        let denied = Sandbox::with_rules(&["tail *"], &[], &[]);
+        denied.hook_claude(&format!("tail -n +52 {}", denied.tee_log()));
+        assert!(
+            !denied.recorded_a_recall(),
+            "a denied command must not record a recall"
+        );
+    }
+
+    /// A command that reads nothing from the tee directory records nothing.
+    #[test]
+    fn unrelated_command_records_nothing() {
+        let sb = Sandbox::bare();
+        sb.rewrite("git status");
+        assert!(!sb.recorded_a_recall());
+    }
+}
+
+/// The two decision paths, side by side on one corpus.
+///
+/// `rtk rewrite` (subprocess path) and `rtk hook claude` (in-process path)
+/// answer the same question through two independently written flows. These
+/// tests pin what each one does today, together, so a consolidation that
+/// changes either is caught here rather than by a user.
+///
+/// Modelled on `registry.rs`'s `segmenter_consistency` module (#3704).
+mod decision_consistency {
+    use super::Sandbox;
+
+    /// Everything the two paths already agree on: the rewrite is identical
+    /// where one happens, and both stay silent where it doesn't.
+    #[test]
+    fn both_paths_agree_on_the_corpus() {
+        let sb = Sandbox::bare();
+        let cases: [(&str, Option<&str>); 9] = [
+            ("git status", Some("rtk git status")),
+            (
+                "git status && cargo test",
+                Some("rtk git status && rtk cargo test"),
+            ),
+            ("git status 2>&1", Some("rtk git status 2>&1")),
+            ("git log | head", Some("rtk git log | head")),
+            ("htop", None),
+            ("git status $(rm -rf /tmp/x)", None),
+            ("git status `rm -rf /tmp/x`", None),
+            ("git log > /tmp/out.txt", None),
+            ("cat <<EOF", None),
+        ];
+
+        for (cmd, expected) in cases {
+            let (code, stdout) = sb.rewrite(cmd);
+            let via_rewrite = match code {
+                0 | 3 => Some(stdout),
+                _ => None,
+            };
+            let via_hook = sb.hook_claude_rewrite(cmd);
+            assert_eq!(
+                via_rewrite.as_deref(),
+                expected,
+                "rtk rewrite disagreed with the pinned corpus for: {cmd}"
+            );
+            assert_eq!(
+                via_hook.as_deref(),
+                expected,
+                "rtk hook claude disagreed with the pinned corpus for: {cmd}"
+            );
+        }
+    }
+
+    /// The one place the two paths genuinely disagree, pinned deliberately.
+    ///
+    /// For a command that is already RTK-prefixed the rewrite is a no-op.
+    /// `hook_cmd::get_rewritten` suppresses it (`rewritten == cmd` → `None` →
+    /// defer); `rewrite_cmd` has no such check and reports it as a normal
+    /// rewrite, so `rtk rewrite` exits 3 with the command unchanged on stdout.
+    ///
+    /// This is accidental rather than designed, and it has one observable
+    /// consequence: `hooks/claude/rtk-rewrite.sh` guards for an identical
+    /// rewrite in its exit-0 branch but *not* in its exit-3 branch, so Claude
+    /// Code prompts the user for a command RTK did not touch. Every other
+    /// delegate gates on `rewritten != command` and is unaffected.
+    ///
+    /// Pinned here, not fixed here — resolving it is a deliberate behavior
+    /// change and its own decision.
+    #[test]
+    fn identity_rewrite_is_where_the_paths_diverge() {
+        let sb = Sandbox::bare();
+
+        // Subprocess path: reported as an ask-rewrite, output identical to input.
+        assert_eq!(
+            sb.rewrite("rtk git status"),
+            (3, "rtk git status".into()),
+            "rtk rewrite reports the no-op rewrite"
+        );
+
+        // In-process path: nothing to say.
+        assert_eq!(
+            sb.hook_claude_rewrite("rtk git status"),
+            None,
+            "rtk hook claude defers on the no-op rewrite"
+        );
+    }
+}
+
+/// `rtk hook check` as it behaves today: a raw rewrite-rule probe.
+///
+/// It calls `registry::rewrite_command` directly, with no permission verdict
+/// and none of the gates the hooks apply, so it answers a different question
+/// than the hooks it is meant to diagnose — it reports a rewrite for commands
+/// both hook paths refuse to touch.
+///
+/// Pinned before that is changed, so the fix shows up as an explicit diff.
+mod hook_check_current_behavior {
+    use super::Sandbox;
+
+    #[test]
+    fn reports_the_rewrite_for_a_plain_command() {
+        let sb = Sandbox::bare();
+        let (code, stdout, _) = sb.run(&["hook", "check", "git status"]);
+        assert_eq!((code, stdout.trim()), (0, "rtk git status"));
+    }
+
+    #[test]
+    fn exits_one_for_an_unknown_command() {
+        let sb = Sandbox::bare();
+        let (code, stdout, _) = sb.run(&["hook", "check", "htop"]);
+        assert_eq!((code, stdout.trim()), (1, ""));
+    }
+
+    /// The drift: both hook paths defer on these, `hook check` claims a rewrite.
+    #[test]
+    fn claims_rewrites_the_hooks_would_never_apply() {
+        let sb = Sandbox::bare();
+
+        let (code, stdout, _) = sb.run(&["hook", "check", "git status $(rm -rf /tmp/x)"]);
+        assert_eq!(
+            (code, stdout.trim()),
+            (0, "rtk git status $(rm -rf /tmp/x)"),
+            "today: a command substitution is reported as rewritable"
+        );
+        assert_eq!(sb.hook_claude_rewrite("git status $(rm -rf /tmp/x)"), None);
+        assert_eq!(sb.rewrite("git status $(rm -rf /tmp/x)").0, 1);
+
+        let (code, stdout, _) = sb.run(&["hook", "check", "git log > /tmp/out.txt"]);
+        assert_eq!(
+            (code, stdout.trim()),
+            (0, "rtk git log > /tmp/out.txt"),
+            "today: a file redirect is reported as rewritable"
+        );
+        assert_eq!(sb.hook_claude_rewrite("git log > /tmp/out.txt"), None);
+        assert_eq!(sb.rewrite("git log > /tmp/out.txt").0, 1);
+    }
+}

--- a/tests/hook_decision_protocol_test.rs
+++ b/tests/hook_decision_protocol_test.rs
@@ -1,18 +1,13 @@
-//! Characterization of the two hook decision entry points, end to end.
+//! End-to-end coverage of the hook decision entry points.
 //!
 //! `rtk rewrite`'s exit-code protocol is a public contract consumed entirely
-//! outside this crate — `hooks/claude/rtk-rewrite.sh`, `hooks/cursor/rtk-rewrite.sh`,
-//! `hooks/pi/rtk.ts`, `hooks/hermes/rtk-rewrite/__init__.py`, `hooks/opencode/rtk.ts`
-//! and `openclaw/index.ts` all branch on it — yet no Rust test ever ran `run()`.
-//! `rewrite_cmd`'s own `exit_code_protocol` module asserts against a locally
-//! re-implemented `expected_exit_code()` table, so the real mapping could change
-//! without a single failure, including the #1155 invariant that a `Default`
-//! verdict must exit 3 and never 0.
-//!
-//! These tests spawn the real binary in a sandboxed HOME/CLAUDE_CONFIG_DIR and
-//! pin the actual `(exit code, stdout)` pairs. They exist to make the decision-flow
-//! consolidation provably behavior-preserving: they must keep passing, unmodified,
-//! across that refactor.
+//! outside this crate -- `hooks/hermes/rtk-rewrite/__init__.py`,
+//! `hooks/opencode/rtk.ts`, `hooks/pi/rtk.ts` and `openclaw/index.ts` all
+//! branch on it -- and `rewrite_cmd`'s in-module `exit_code_protocol` asserts
+//! against a hand-copied `expected_exit_code()` table without ever calling
+//! `run()`. These tests spawn the real binary in a sandboxed
+//! HOME/CLAUDE_CONFIG_DIR and pin the actual `(exit code, stdout)` pairs,
+//! including the #1155 invariant that a `Default` verdict exits 3 and never 0.
 
 use std::path::PathBuf;
 use std::process::Command;
@@ -59,21 +54,6 @@ impl Sandbox {
         );
         std::fs::write(project.join(".claude/settings.json"), settings).expect("write settings");
 
-        let quote = |rules: &[&str]| {
-            rules
-                .iter()
-                .map(|r| format!("\"Bash({r})\""))
-                .collect::<Vec<_>>()
-                .join(", ")
-        };
-        let settings = format!(
-            r#"{{"permissions": {{"deny": [{}], "ask": [{}], "allow": [{}]}}}}"#,
-            quote(deny),
-            quote(ask),
-            quote(allow)
-        );
-        std::fs::write(project.join(".claude/settings.json"), settings).expect("write settings");
-
         Self {
             _root: root,
             home,
@@ -101,10 +81,17 @@ impl Sandbox {
             .env("LC_ALL", "C")
             .output()
             .expect("spawn rtk");
+        let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+        // A crash produces empty stdout too, which would let every "expect no
+        // output" assertion below pass vacuously.
+        assert!(
+            !stderr.contains("panicked"),
+            "rtk panicked on {args:?}: {stderr}"
+        );
         (
             out.status.code().expect("exit code"),
             String::from_utf8_lossy(&out.stdout).into_owned(),
-            String::from_utf8_lossy(&out.stderr).into_owned(),
+            stderr,
         )
     }
 
@@ -159,7 +146,7 @@ impl Sandbox {
             .env("LC_ALL", "C")
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
-            .stderr(Stdio::null())
+            .stderr(Stdio::piped())
             .spawn()
             .expect("spawn rtk hook claude");
         child
@@ -169,6 +156,15 @@ impl Sandbox {
             .write_all(payload.as_bytes())
             .expect("write payload");
         let out = child.wait_with_output().expect("wait rtk");
+        // The hook protocol requires exit 0 whatever it decides; without this a
+        // crash is indistinguishable from a deliberate defer, and every
+        // `assert_eq!(..., None)` below would pass vacuously.
+        assert_eq!(
+            out.status.code(),
+            Some(0),
+            "rtk hook claude exited non-zero for {cmd:?}: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
         String::from_utf8_lossy(&out.stdout).into_owned()
     }
 
@@ -333,11 +329,10 @@ mod recall_tracking {
 /// The two decision paths, side by side on one corpus.
 ///
 /// `rtk rewrite` (subprocess path) and `rtk hook claude` (in-process path)
-/// answer the same question through two independently written flows. These
-/// tests pin what each one does today, together, so a consolidation that
-/// changes either is caught here rather than by a user.
+/// answer the same question for the same command. Asserting both against one
+/// corpus keeps a change to either from silently moving them apart.
 ///
-/// Modelled on `registry.rs`'s `segmenter_consistency` module (#3704).
+/// Follows the shape of `registry.rs`'s `segmenter_consistency` module.
 mod decision_consistency {
     use super::Sandbox;
 
@@ -381,21 +376,12 @@ mod decision_consistency {
         }
     }
 
-    /// The one place the two paths genuinely disagree, pinned deliberately.
+    /// The one place the two paths differ.
     ///
-    /// For a command that is already RTK-prefixed the rewrite is a no-op.
-    /// `hook_cmd::get_rewritten` suppresses it (`rewritten == cmd` → `None` →
-    /// defer); `rewrite_cmd` has no such check and reports it as a normal
-    /// rewrite, so `rtk rewrite` exits 3 with the command unchanged on stdout.
-    ///
-    /// This is accidental rather than designed, and it has one observable
-    /// consequence: `hooks/claude/rtk-rewrite.sh` guards for an identical
-    /// rewrite in its exit-0 branch but *not* in its exit-3 branch, so Claude
-    /// Code prompts the user for a command RTK did not touch. Every other
-    /// delegate gates on `rewritten != command` and is unaffected.
-    ///
-    /// Pinned here, not fixed here — resolving it is a deliberate behavior
-    /// change and its own decision.
+    /// A command that is already RTK-prefixed rewrites to itself. Every hook
+    /// discards that; `rtk rewrite` reports it, exiting 3 with the command
+    /// unchanged on stdout. The plugins that shell out to it gate on
+    /// `rewritten != command` for exactly this reason.
     #[test]
     fn identity_rewrite_is_where_the_paths_diverge() {
         let sb = Sandbox::bare();
@@ -416,15 +402,12 @@ mod decision_consistency {
     }
 }
 
-/// `rtk hook check` as it behaves today: a raw rewrite-rule probe.
+/// `rtk hook check` answers the same question the hooks answer.
 ///
-/// It calls `registry::rewrite_command` directly, with no permission verdict
-/// and none of the gates the hooks apply, so it answers a different question
-/// than the hooks it is meant to diagnose — it reports a rewrite for commands
-/// both hook paths refuse to touch.
-///
-/// Pinned before that is changed, so the fix shows up as an explicit diff.
-mod hook_check_current_behavior {
+/// A diagnostic that reported a rewrite the hooks refuse to apply would be
+/// worse than none, so it routes through the shared decision and is pinned
+/// here against the hooks themselves.
+mod hook_check {
     use super::Sandbox;
 
     #[test]
@@ -441,27 +424,109 @@ mod hook_check_current_behavior {
         assert_eq!((code, stdout.trim()), (1, ""));
     }
 
-    /// The drift: both hook paths defer on these, `hook check` claims a rewrite.
+    /// Both hook paths refuse these, so the diagnostic must refuse them too.
     #[test]
-    fn claims_rewrites_the_hooks_would_never_apply() {
+    fn agrees_with_the_hooks_on_what_is_never_rewritten() {
         let sb = Sandbox::bare();
 
-        let (code, stdout, _) = sb.run(&["hook", "check", "git status $(rm -rf /tmp/x)"]);
-        assert_eq!(
-            (code, stdout.trim()),
-            (0, "rtk git status $(rm -rf /tmp/x)"),
-            "today: a command substitution is reported as rewritable"
-        );
-        assert_eq!(sb.hook_claude_rewrite("git status $(rm -rf /tmp/x)"), None);
-        assert_eq!(sb.rewrite("git status $(rm -rf /tmp/x)").0, 1);
+        for cmd in [
+            "git status $(rm -rf /tmp/x)",
+            "git log > /tmp/out.txt",
+            "cat <<EOF",
+        ] {
+            let (code, stdout, _) = sb.run(&["hook", "check", cmd]);
+            assert_eq!((code, stdout.trim()), (1, ""), "hook check on: {cmd}");
+            assert_eq!(sb.hook_claude_rewrite(cmd), None, "hook claude on: {cmd}");
+            assert_eq!(sb.rewrite(cmd).0, 1, "rtk rewrite on: {cmd}");
+        }
+    }
 
-        let (code, stdout, _) = sb.run(&["hook", "check", "git log > /tmp/out.txt"]);
+    /// An already-RTK-prefixed command rewrites to itself, and no agent applies
+    /// that: the in-process hosts discard it in `hook_cmd`, and the ones whose
+    /// plugin shells out to `rtk rewrite` discard it themselves. Only the bare
+    /// `rtk rewrite` CLI reports it -- see `decision_consistency`.
+    #[test]
+    fn no_agent_applies_a_rewrite_that_changed_nothing() {
+        let sb = Sandbox::bare();
+
+        for agent in ["claude", "pi", "kimi"] {
+            let (code, stdout, _) = sb.run(&["hook", "check", "--agent", agent, "rtk git status"]);
+            assert_eq!((code, stdout.trim()), (1, ""), "agent: {agent}");
+        }
+        assert_eq!(sb.hook_claude_rewrite("rtk git status"), None);
+
+        // The CLI itself still reports it, which is what the delegates guard against.
+        assert_eq!(sb.rewrite("rtk git status"), (3, "rtk git status".into()));
+    }
+
+    /// Every install target answers; only a genuine typo is rejected.
+    #[test]
+    fn answers_for_every_supported_agent() {
+        let sb = Sandbox::bare();
+        for agent in [
+            "claude",
+            "copilot",
+            "cursor",
+            "gemini",
+            "droid",
+            "vibe",
+            "opencode",
+            "openclaw",
+            "pi",
+            "omp",
+            "hermes",
+            "codex",
+            "windsurf",
+            "cline",
+            "kilocode",
+            "antigravity",
+            "kimi",
+        ] {
+            let (code, stdout, _) = sb.run(&["hook", "check", "--agent", agent, "git status"]);
+            assert_eq!(
+                (code, stdout.trim()),
+                (0, "rtk git status"),
+                "agent: {agent}"
+            );
+        }
+    }
+
+    /// `--agent` selects whose rules are consulted. Hosts read different
+    /// settings files, so answering with Claude's verdict for another agent
+    /// would misdescribe the very hook being diagnosed: here a Claude deny rule
+    /// must not deny for Gemini, which has no rules of its own in this sandbox.
+    #[test]
+    fn agent_flag_selects_the_hosts_own_rules() {
+        let sb = Sandbox::with_rules(&["git status"], &[], &[]);
+
+        let (code, stdout, _) = sb.run(&["hook", "check", "--agent", "claude", "git status"]);
+        assert_eq!((code, stdout.trim()), (1, ""), "claude denies");
+
+        let (code, stdout, _) = sb.run(&["hook", "check", "--agent", "gemini", "git status"]);
         assert_eq!(
             (code, stdout.trim()),
-            (0, "rtk git log > /tmp/out.txt"),
-            "today: a file redirect is reported as rewritable"
+            (0, "rtk git status"),
+            "gemini has no deny rule here, so the rewrite stands"
         );
-        assert_eq!(sb.hook_claude_rewrite("git log > /tmp/out.txt"), None);
-        assert_eq!(sb.rewrite("git log > /tmp/out.txt").0, 1);
+    }
+
+    #[test]
+    fn unknown_agent_is_rejected_rather_than_answered_for_claude() {
+        let sb = Sandbox::bare();
+        let (code, stdout, stderr) = sb.run(&["hook", "check", "--agent", "nope", "git status"]);
+        assert_eq!((code, stdout.trim()), (2, ""));
+        assert!(stderr.contains("Unknown agent: nope"), "stderr: {stderr}");
+    }
+
+    /// A denied command is not rewritten, and says so distinctly.
+    #[test]
+    fn reports_a_deny_rule_separately_from_no_rewrite() {
+        let sb = Sandbox::with_rules(&["git status"], &[], &[]);
+        let (code, stdout, stderr) = sb.run(&["hook", "check", "git status"]);
+        assert_eq!((code, stdout.trim()), (1, ""));
+        assert!(
+            stderr.contains("Denied by a permission rule"),
+            "stderr: {stderr}"
+        );
     }
 }


### PR DESCRIPTION
Follow-up to #3704, which consolidated raw-command lexing and closed with:

> `hooks/rewrite_cmd.rs` vs `hooks/hook_cmd.rs` decision-flow duplication — real, but a separate follow-up at a different level.

## `rtk rewrite`'s behaviour is unchanged — deliberately

The obvious generalisation is to make `rtk rewrite` behave like the hooks and defer on a rewrite that changes nothing. **This PR does not do that**, and the divergence is kept on purpose:

| | already-`rtk` command |
|---|---|
| `rtk hook <agent>` | defers — a hook speaks an edit protocol, and an edit to the same string is meaningless |
| `rtk rewrite` | reports it (exit 0/3, command unchanged on stdout) |

That is the documented contract from #241, which created `rtk rewrite`: *"Handle already-rtk commands (exit 0, identical output)"*, still pinned by `test_run_already_rtk_returns_some`. The CLI answers *"what is the RTK form of this command"*; for an already-prefixed command that form is itself, and whether that counts as a change is the caller's question. Every delegate already asks it — `hooks/opencode/rtk.ts`, `hooks/pi/rtk.ts` (shared with omp), `hooks/hermes/rtk-rewrite/__init__.py` and `openclaw/index.ts` all gate on `rewritten != command`.

So `suppress_identity` is applied by `decide_for_agent`, which the hooks share, and not by `decide`, which the CLI renders. The exit-code protocol is untouched.

## What changed

`rtk hook <agent>` and `rtk rewrite` carried two independently written copies of the same four steps over two isomorphic enums (`HookDecision`, `RewriteOutcome`), so a fix to the gate order or a new construct to refuse had to be made twice.

- **`src/hooks/decision.rs`** — one `decide`, taking the permission verdict and the rewrite parameters rather than looking them up, so each host consults its own rules and tests stay independent of the developer's machine (#3146). `decide_for_agent` adds the no-op suppression every hook applies.
- **`rewrite_cmd::run`** is reduced to exit-code rendering; `hook_cmd`'s eight response builders are untouched.
- **`rtk hook check`** now routes through the same decision (the one intended behaviour change, below).

## Related issues

- Closes #3936 — `rtk hook check` disagrees with `rtk hook claude` on commands containing a file redirect. Fixed here; all six shapes in that report now agree, and `2>&1` still rewrites on both.
- **#3476** — `hook check` does not expose the actual host permission decision. Partially addressed: the diagnostic now consults the host's real rules instead of ignoring them, but it still collapses allow and ask into one answer. The remaining half is a follow-up, commented on that issue.

## `rtk hook check` — the one behaviour change

It called `registry::rewrite_command` directly, with no verdict and none of the gates, so it reported a rewrite for command substitutions, file redirects and heredocs that both hook paths refuse — the diagnostic disagreed with the thing it exists to diagnose, in the direction that matters.

Consulting rules makes the answer host-dependent, so `--agent` stops being discarded. `AgentPath` records what actually differs: the six agents deciding in-process use their own host's rules, the five whose plugin shells out to `rtk rewrite` get Claude's, and the six installing only a rules file have none. All 17 install targets resolve; only a typo is rejected.

On develop the diagnostic consults no rules and ignores `--agent`, so it contradicts every host. Under a Claude deny rule for `git status` it prints `rtk git status`, while `rtk hook claude` refuses the command outright.

## Verification

- `cargo fmt --all` · `cargo clippy --all-targets` clean · `cargo test --all` green; each commit builds and tests independently.
- A characterization commit lands **first**, pinning the real `(exit code, stdout)` pairs end-to-end — `rtk rewrite`'s exit codes had no Rust test at all, only a hand-copied table in `exit_code_protocol` that never called `run()`. Those tests pass **unmodified** across the refactor.
- Differential-tested against the base binary across an adversarial corpus (CRLF, NBSP, ZWSP, RTL override, 50 KB command, 200-segment chain, heredocs, substitutions): byte-identical on every path except `rtk hook check`.
- Property-fuzzed with a throwaway harness driving the built binary — not part of the diff, so it is not re-runnable by CI or a reviewer; the invariants it covers are the ones asserted in the committed tests. Across ~6k generated cases: exit codes stay in range, stdout appears exactly for the two rewrite outcomes, a deny rule is always enforced, rewriting is idempotent, no hook ever emits `updatedInput` identical to its input, and — the one that matters — a rewrite is never auto-allowed unless an allow rule covers every segment (#1155, #1213).
- Out-of-crate suites unchanged from their pre-refactor baselines: `hooks/claude/test-rtk-rewrite.sh` 58/66, hermes 18 passed, `scripts/test-all.sh` 105/13/5.
- After rebasing onto the recall feature (#3258 line), `track_tee_read` is called under exactly upstream's conditions on both paths — verified by differential-testing the recall store against the upstream binary. `rtk hook check` deliberately does not record, matching upstream.

## Not in scope

- Making `rtk rewrite` defer on the identity case (above).
- `rewrite_cmd` judges every subprocess-path agent by Claude's rules, since `rtk rewrite` cannot be told who is asking.
- `hook_cmd`'s tests read the developer's `config.toml` (26) and `~/.claude` rules (5); pre-existing, same count on the base commit, and fixing it means giving all six hosts the injection seam only three have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

