### PR TITLE
feat(hook): add native Google Antigravity lifecycle hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,7 +421,7 @@ RTK supports 17 AI coding tools. Each integration rewrites shell commands to `rt
 | **Hermes** | `rtk init --agent hermes` | Python plugin adapter (terminal command mutation via `rtk rewrite`) |
 | **Mistral Vibe** | `rtk init -g --agent vibe` | `pre_tool` hook (hooks.toml) |
 | **Kilo Code** | `rtk init --agent kilocode` | .kilocode/rules/rtk-rules.md (project-scoped) |
-| **Google Antigravity** | `rtk init --agent antigravity` | .agents/rules/antigravity-rtk-rules.md (project-scoped) |
+| **Google Antigravity** | `rtk init --agent antigravity` (or `-g`) | `PreToolUse` hook in `.agents/hooks.json` / `~/.gemini/config/hooks.json` (matcher `run_command`) |
 | **Kimi AI** | `rtk init --agent kimi` | AGENTS.md (project-scoped) |
 | **Factory Droid** | `rtk init -g --agent droid` (or per-project) | PreToolUse hook in `~/.factory/hooks.json` (matcher `Execute`) |
 

--- a/docs/guide/getting-started/configuration.md
+++ b/docs/guide/getting-started/configuration.md
@@ -80,8 +80,8 @@ level = "high"
 
 Re-run `rtk init -g` (or your agent's init command) to rewrite the file.
 
-Agents without a hook (Codex CLI, Cline, Windsurf, Kilo Code, Antigravity, Kimi) always get `full`,
-since the agent must type `rtk` itself. `rtk init` prints a note when it does this.
+Agents whose awareness ships as a rules file (Codex CLI, Cline, Windsurf, Kilo Code, Antigravity,
+Kimi) always get `full`, since the rules file has to stand on its own. `rtk init` prints a note when it does this.
 
 ## Environment variables
 

--- a/docs/guide/getting-started/supported-agents.md
+++ b/docs/guide/getting-started/supported-agents.md
@@ -43,7 +43,7 @@ Agent runs "cargo test"
 | Windsurf | Rules file (prompt-level) | N/A |
 | Codex CLI | AGENTS.md instructions | N/A |
 | Kilo Code | Rules file (prompt-level) | N/A |
-| Google Antigravity | Rules file (prompt-level) | N/A |
+| Google Antigravity | Shell hook (`PreToolUse`, matcher `run_command`) | Yes |
 | Mistral Vibe | Rust binary (`pre_tool`) | Yes |
 
 Agents that rewrite transparently receive the awareness file selected by `awareness.level` in
@@ -225,10 +225,18 @@ Kilo Code reads `.kilocode/rules/` as custom instructions. RTK adds guidance tel
 ### Google Antigravity
 
 ```bash
-rtk init --agent antigravity    # creates .agents/rules/antigravity-rtk-rules.md in current project
+rtk init --agent antigravity       # workspace: .agents/hooks.json
+rtk init -g --agent antigravity    # global:    ~/.gemini/config/hooks.json
 ```
 
-Antigravity reads `.agents/rules/` as custom instructions. RTK adds guidance telling Antigravity to prefer `rtk <cmd>` over raw commands.
+Antigravity dispatches a `PreToolUse` lifecycle event before every `run_command` step, and RTK's
+handler answers with the rewritten command, so interception does not depend on the model
+remembering anything. The awareness rules file is still installed alongside it as a fallback for
+sessions where the hook is disabled.
+
+Antigravity checks its `permissions` rules **after** the hook rewrites a command, so an existing
+`command(git status)` allow-rule stops matching once RTK prefixes it — add a `command(rtk git
+status)` twin. `rtk init` prints this reminder after installing.
 
 ### Mistral Vibe
 
@@ -261,7 +269,7 @@ Strips only RTK's `[[hooks]]` block and the `~/.vibe/prompts/rtk.md` file. Any o
 | **Plugin** | TypeScript, JavaScript, or Python in agent's plugin system | Transparent, in-place mutation when the agent allows it |
 | **Rules file** | Prompt-level instructions | Guidance only — agent is told to prefer `rtk <cmd>` |
 
-Rules file integrations (Cline, Windsurf, Codex, Kilo Code, Antigravity) rely on the model following instructions. Full hook integrations (Claude Code, Cursor, Gemini) are guaranteed — the command is rewritten before the agent sees it. Plugin integrations (OpenCode, Pi) use in-place mutation via the agent's TypeScript extension API.
+Rules file integrations (Cline, Windsurf, Codex, Kilo Code) rely on the model following instructions. Full hook integrations (Claude Code, Cursor, Gemini) are guaranteed — the command is rewritten before the agent sees it. Plugin integrations (OpenCode, Pi) use in-place mutation via the agent's TypeScript extension API.
 
 ## Windows support
 

--- a/hooks/antigravity/README.md
+++ b/hooks/antigravity/README.md
@@ -4,6 +4,69 @@
 
 ## Specifics
 
-- Prompt-level guidance only (no programmatic hook) -- relies on Antigravity reading custom instructions
-- Installs `../rtk-awareness-full.md` (shared, agent-neutral): the instruction to prefix every shell command with `rtk`, plus meta commands. No hook, so the `full` level is always used regardless of `awareness.level`
-- Installed to `.agents/rules/antigravity-rtk-rules.md` (project-local) by `rtk init --agent antigravity`
+- Native programmatic hook: Antigravity dispatches a `PreToolUse` lifecycle event and lets the handler rewrite the tool call, so RTK intercepts commands instead of asking the model to prefix them
+- Installed by `rtk init --agent antigravity` (workspace) or `rtk init -g --agent antigravity` (global)
+- Also installs `../rtk-awareness-full.md` to `rules/antigravity-rtk-rules.md` as a second layer for sessions where the hook is disabled
+
+## Customization roots
+
+Antigravity discovers customizations from a *customization root*, and both roots hold the same layout (`hooks.json`, `rules/`, `skills/`):
+
+| Scope | Root |
+| :--- | :--- |
+| Workspace | `<workspace>/.agents/` |
+| Global | `~/.gemini/config/` |
+
+## `hooks.json`
+
+Each top-level key is a **hook name**; Antigravity merges the handlers of every named hook for a given event. RTK owns the `rtk` key and leaves all others untouched:
+
+```json
+{
+  "rtk": {
+    "PreToolUse": [
+      {
+        "matcher": "run_command",
+        "hooks": [
+          { "type": "command", "command": "rtk hook antigravity", "timeout": 10 }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## Wire contract
+
+`rtk hook antigravity` reads the payload on stdin and answers on stdout. Keys are camelCase (protojson).
+
+**stdin**
+
+```json
+{
+  "toolCall": { "name": "run_command", "args": { "CommandLine": "git status" } },
+  "stepIdx": 12,
+  "conversationId": "…",
+  "workspacePaths": ["/path/to/workspace"]
+}
+```
+
+**stdout**
+
+| case | response |
+| :--- | :--- |
+| rewrite | `{"decision":"allow","overwrite":{"CommandLine":"rtk git status"}}` |
+| deny | `{"decision":"deny","reason":"Blocked by RTK permission rule"}` |
+| defer to the host's approval flow | `{"decision":"ask"}` |
+
+`overwrite` is a shallow, top-level merge into the tool call's arguments, and the merged call is what actually executes and gets recorded. `decision` is required on every response; the accepted values are `allow`, `deny`, `ask` and `force_ask`.
+
+The contract ships inside the `agy` binary. To read it first-hand:
+
+```bash
+strings $(which agy) | sed -n '/Lifecycle Hooks/,/PostInvocation Contract/p'
+```
+
+## Gotcha: permissions are checked after the rewrite
+
+Antigravity evaluates `permissions.allow` against the **modified** tool call, so an existing rule for a bare command stops matching once RTK prefixes it. `command(git status)` alone is no longer enough — it needs `command(rtk git status)` too. Interactively this surfaces as an unexpected approval prompt; in headless or CI runs the tool call is denied outright. `rtk init --agent antigravity` prints this warning after installing.

--- a/src/hooks/constants.rs
+++ b/src/hooks/constants.rs
@@ -16,6 +16,20 @@ pub const CURSOR_HOOK_COMMAND: &str = "rtk hook cursor";
 pub const DROID_HOOK_COMMAND: &str = "rtk hook droid";
 /// Native Rust hook command for Mistral Vibe.
 pub const VIBE_HOOK_COMMAND: &str = "rtk hook vibe";
+/// Native Rust hook command for Google Antigravity.
+pub const ANTIGRAVITY_HOOK_COMMAND: &str = "rtk hook antigravity";
+/// Antigravity's shell tool, and therefore the `matcher` its `PreToolUse`
+/// handlers key off. Tool names are the step type lowercased with the
+/// `CORTEX_STEP_TYPE_` prefix removed.
+pub const ANTIGRAVITY_SHELL_TOOL: &str = "run_command";
+/// Top-level namespace RTK claims inside a shared `hooks.json`. Antigravity
+/// merges the named hooks of every entry, so anything under a different key
+/// (a user's own linter, another tool's install) must survive untouched.
+pub const ANTIGRAVITY_HOOK_NAME: &str = "rtk";
+/// Antigravity's global customization root, relative to `~/.gemini`.
+pub const ANTIGRAVITY_GLOBAL_SUBDIR: &str = "config";
+/// Antigravity's workspace customization root.
+pub const AGENTS_DIR: &str = ".agents";
 
 pub const CONFIG_DIR: &str = ".config";
 pub const OPENCODE_SUBDIR: &str = "opencode";

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -3,7 +3,7 @@
 //! Uses `writeln!(stdout, ...)` instead of `println!` — accidental stdout/stderr
 //! corrupts the JSON protocol (Claude Code bug #4669 silently disables the hook).
 
-use super::constants::PRE_TOOL_USE_KEY;
+use super::constants::{ANTIGRAVITY_SHELL_TOOL, PRE_TOOL_USE_KEY};
 use super::permissions::{self, PermissionVerdict};
 use anyhow::{Context, Result};
 use serde_json::{json, Value};
@@ -467,6 +467,121 @@ fn run_gemini_inner_impl(
         }
         HookDecision::Defer => gemini_json("ask_user", None),
     })
+}
+
+// ── Antigravity hook ──────────────────────────────────────────
+
+/// Run the Google Antigravity CLI (`agy`) `PreToolUse` hook.
+///
+/// Antigravity hook contract (shipped inside the `agy` binary; reproduce with
+/// `strings $(which agy) | sed -n '/Lifecycle Hooks/,/PostInvocation Contract/p'`):
+/// - stdin: `{"toolCall": {"name": "run_command", "args": {"CommandLine": "…"}}, …}`
+///   — protojson, so every key is camelCase.
+/// - Rewrite: `{"decision":"allow","overwrite":{"CommandLine":"…"}}`. `overwrite` is a
+///   shallow, top-level merge into the tool call's arguments, and the merged call is
+///   what actually executes and gets recorded.
+/// - Deny: `{"decision":"deny","reason":"…"}`.
+/// - `decision` is required on every response; the accepted values are `allow`,
+///   `deny`, `ask` and `force_ask`.
+pub fn run_antigravity() -> Result<()> {
+    let input = read_stdin_limited()?;
+    let output = run_antigravity_inner(&input).context("Failed to parse hook input as JSON")?;
+    let _ = writeln!(io::stdout(), "{output}");
+    Ok(())
+}
+
+/// Parse the Antigravity `PreToolUse` stdin payload, decide, and render the
+/// response JSON — no stdin/stdout I/O. Used by `run_antigravity` itself (not
+/// just tests), so a regression here fails for real rather than only in a
+/// duplicate test copy. Mirrors `run_gemini_inner`.
+fn run_antigravity_inner(input: &str) -> serde_json::Result<String> {
+    run_antigravity_inner_impl(input, |cmd| {
+        decide_hook_action(cmd, permissions::Host::Antigravity)
+    })
+}
+
+/// Same parse/render path as `run_antigravity_inner`, but with the permission
+/// decision driven by explicit rule slices instead of whatever settings file
+/// happens to sit at HOME — lets tests exercise the real BOM-stripping/parsing
+/// logic without depending on (or being broken by) the machine they run on.
+#[cfg(test)]
+fn run_antigravity_inner_with_rules(
+    input: &str,
+    deny: &[String],
+    ask: &[String],
+    allow: &[String],
+) -> serde_json::Result<String> {
+    run_antigravity_inner_impl(input, |cmd| {
+        decide_from_verdict(
+            cmd,
+            permissions::check_command_with_rules(cmd, deny, ask, allow),
+        )
+    })
+}
+
+fn run_antigravity_inner_impl(
+    input: &str,
+    decide: impl Fn(&str) -> HookDecision,
+) -> serde_json::Result<String> {
+    let input = strip_leading_bom(input);
+    let json: Value = serde_json::from_str(input)?;
+
+    let tool_name = json
+        .pointer("/toolCall/name")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    if tool_name != ANTIGRAVITY_SHELL_TOOL {
+        return Ok(antigravity_json("allow", None));
+    }
+
+    let cmd = json
+        .pointer("/toolCall/args/CommandLine")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    if cmd.is_empty() {
+        return Ok(antigravity_json("allow", None));
+    }
+
+    Ok(match decide(cmd) {
+        HookDecision::Deny => {
+            r#"{"decision":"deny","reason":"Blocked by RTK permission rule"}"#.to_string()
+        }
+        HookDecision::AllowRewrite(ref rewritten) => {
+            audit_log("rewrite", cmd, rewritten);
+            antigravity_json("allow", Some(rewritten))
+        }
+        // Everything RTK does not actively deny answers `allow`, meaning "RTK
+        // has no objection" — NOT "skip the approval prompt".
+        //
+        // Antigravity applies its own `permissions` rules to the tool call
+        // *after* this hook runs, and it enforces them regardless of what the
+        // hook answered: a headless run whose only allow-rule was
+        // `command(git status)` was still denied while this hook returned
+        // `allow`, because the rule no longer matched the rewritten
+        // `rtk git status`. So `allow` cannot widen the permissions the user
+        // granted, while `ask` would add an approval gate that did not exist
+        // before RTK was installed — every rewritten command would prompt
+        // interactively and hard-fail in headless/CI.
+        //
+        // This is where Antigravity parts ways with `run_gemini_inner_impl`,
+        // whose `ask_user` is the host's *default* path rather than an extra
+        // gate.
+        HookDecision::AskRewrite(ref rewritten) => {
+            audit_log("rewrite", cmd, rewritten);
+            antigravity_json("allow", Some(rewritten))
+        }
+        HookDecision::Defer => antigravity_json("allow", None),
+    })
+}
+
+/// Render an Antigravity `PreToolUse` response. The rewrite rides in a
+/// top-level `overwrite` object rather than Gemini's `hookSpecificOutput`.
+fn antigravity_json(decision: &str, rewrite: Option<&str>) -> String {
+    let mut output = serde_json::json!({ "decision": decision });
+    if let Some(cmd) = rewrite {
+        output["overwrite"] = serde_json::json!({ "CommandLine": cmd });
+    }
+    output.to_string()
 }
 
 // ── Vibe hook ─────────────────────────────────────────────────
@@ -2207,6 +2322,137 @@ mod tests {
         ))
         .unwrap();
         assert_eq!(v["decision"], "deny");
+    }
+
+    // --- Google Antigravity hook ---
+
+    fn antigravity_input(tool: &str, cmd: &str) -> String {
+        json!({
+            "toolCall": { "name": tool, "args": { "CommandLine": cmd } },
+            "stepIdx": 12,
+            "conversationId": "ec33ebf9-0cba-4100-8142-c61503f6c587",
+            "workspacePaths": ["/tmp/workspace"],
+            "modelName": "auto"
+        })
+        .to_string()
+    }
+
+    fn antigravity_render(cmd: &str, deny: &[String], ask: &[String], allow: &[String]) -> String {
+        run_antigravity_inner_with_rules(
+            &antigravity_input(ANTIGRAVITY_SHELL_TOOL, cmd),
+            deny,
+            ask,
+            allow,
+        )
+        .expect("well-formed payload must parse")
+    }
+
+    #[test]
+    fn test_antigravity_allow_emits_overwrite() {
+        // The rewrite rides in a top-level `overwrite`, not Gemini's
+        // `hookSpecificOutput` — Antigravity shallow-merges it into the tool
+        // call's args, and the merged call is what actually runs.
+        let v: Value =
+            serde_json::from_str(&antigravity_render("git status", &[], &[], &all_allowed()))
+                .unwrap();
+        assert_eq!(v["decision"], "allow");
+        assert_eq!(v["overwrite"]["CommandLine"], "rtk git status");
+    }
+
+    #[test]
+    fn test_antigravity_ignores_other_tools() {
+        let input = json!({
+            "toolCall": { "name": "view_file", "args": { "AbsolutePath": "/tmp/x" } }
+        })
+        .to_string();
+        let out = run_antigravity_inner_with_rules(&input, &[], &[], &all_allowed()).unwrap();
+        let v: Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["decision"], "allow");
+        assert!(v.get("overwrite").is_none());
+    }
+
+    #[test]
+    fn test_antigravity_empty_command_line() {
+        let input = json!({
+            "toolCall": { "name": ANTIGRAVITY_SHELL_TOOL, "args": {} }
+        })
+        .to_string();
+        let out = run_antigravity_inner_with_rules(&input, &[], &[], &all_allowed()).unwrap();
+        let v: Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["decision"], "allow");
+        assert!(v.get("overwrite").is_none());
+    }
+
+    #[test]
+    fn test_antigravity_rewrite_is_idempotent() {
+        // The hook runs again on its own output whenever a session replays a
+        // step; a second prefix would produce `rtk rtk git status`.
+        let v: Value = serde_json::from_str(&antigravity_render(
+            "rtk git status",
+            &[],
+            &[],
+            &all_allowed(),
+        ))
+        .unwrap();
+        let rewritten = v["overwrite"]["CommandLine"].as_str().unwrap_or("");
+        assert!(
+            !rewritten.starts_with("rtk rtk"),
+            "double-prefixed command: {rewritten}"
+        );
+    }
+
+    #[test]
+    fn test_antigravity_deny_carries_reason() {
+        // Antigravity surfaces `reason` to the user; a bare deny reads as an
+        // unexplained block.
+        let v: Value = serde_json::from_str(&antigravity_render(
+            "rm -rf /tmp/x",
+            &["rm -rf".to_string()],
+            &[],
+            &[],
+        ))
+        .unwrap();
+        assert_eq!(v["decision"], "deny");
+        assert!(!v["reason"].as_str().unwrap_or("").is_empty());
+    }
+
+    #[test]
+    fn test_antigravity_never_adds_an_approval_gate() {
+        // With no RTK rules at all — the state every Antigravity user starts in,
+        // since `Host::Antigravity` defers permissions to the host — the hook
+        // must still answer `allow`. Answering `ask` here would prompt on every
+        // single rewritten command interactively and hard-fail headless runs.
+        let v: Value =
+            serde_json::from_str(&antigravity_render("git status", &[], &[], &[])).unwrap();
+        assert_eq!(v["decision"], "allow");
+        assert_eq!(v["overwrite"]["CommandLine"], "rtk git status");
+
+        // Same for a command RTK has no rewrite for.
+        let v: Value = serde_json::from_str(&antigravity_render("echo hi", &[], &[], &[])).unwrap();
+        assert_eq!(v["decision"], "allow");
+        assert!(v.get("overwrite").is_none());
+    }
+
+    #[test]
+    fn test_antigravity_strips_utf8_bom() {
+        let with_bom = format!(
+            "\u{feff}{}",
+            antigravity_input(ANTIGRAVITY_SHELL_TOOL, "git status")
+        );
+        let out = run_antigravity_inner_with_rules(&with_bom, &[], &[], &all_allowed())
+            .expect("BOM-prefixed payload must parse");
+        let v: Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["overwrite"]["CommandLine"], "rtk git status");
+    }
+
+    #[test]
+    fn test_antigravity_inner_preserves_serde_diagnostic() {
+        let err = run_antigravity_inner("not valid json {{{").unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("line") && msg.contains("column"),
+            "expected serde_json's own parse diagnostic, got: {msg}"
+        );
     }
 
     // --- Factory Droid hook ---

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -14,14 +14,15 @@ use crate::hooks::constants::{
 };
 
 use super::constants::{
-    BEFORE_TOOL_KEY, CLAUDE_DIR, CLAUDE_HOOK_COMMAND, CODEX_DIR, CURSOR_HOOK_COMMAND, DROID_DIR,
-    DROID_EXECUTE_MATCHER, DROID_HOME_ENV, DROID_HOOKS_FILE, DROID_HOOKS_SUBDIR,
-    DROID_HOOK_COMMAND, DROID_SETTINGS_FILE, GEMINI_HOOK_FILE, HERMES_DIR, HERMES_PLUGINS_SUBDIR,
-    HERMES_PLUGIN_INIT_FILE, HERMES_PLUGIN_MANIFEST_FILE, HERMES_PLUGIN_NAME, HOOKS_JSON,
-    HOOKS_SUBDIR, OMP_DIR, OMP_LOCAL_DIR, PI_AGENT_STATE_FILE, PI_CODING_AGENT_DIR_ENV, PI_DIR,
-    PI_EXTENSIONS_SUBDIR, PI_LOCAL_DIR, PI_PLUGIN_FILE, PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE,
-    SETTINGS_JSON, VIBE_BASH_MATCH, VIBE_DIR, VIBE_HOOKS_FILE, VIBE_HOOK_COMMAND, VIBE_HOOK_NAME,
-    VIBE_PROMPTS_SUBDIR, VIBE_PROMPT_FILE,
+    AGENTS_DIR, ANTIGRAVITY_GLOBAL_SUBDIR, ANTIGRAVITY_HOOK_COMMAND, ANTIGRAVITY_HOOK_NAME,
+    ANTIGRAVITY_SHELL_TOOL, BEFORE_TOOL_KEY, CLAUDE_DIR, CLAUDE_HOOK_COMMAND, CODEX_DIR,
+    CURSOR_HOOK_COMMAND, DROID_DIR, DROID_EXECUTE_MATCHER, DROID_HOME_ENV, DROID_HOOKS_FILE,
+    DROID_HOOKS_SUBDIR, DROID_HOOK_COMMAND, DROID_SETTINGS_FILE, GEMINI_HOOK_FILE, HERMES_DIR,
+    HERMES_PLUGINS_SUBDIR, HERMES_PLUGIN_INIT_FILE, HERMES_PLUGIN_MANIFEST_FILE,
+    HERMES_PLUGIN_NAME, HOOKS_JSON, HOOKS_SUBDIR, OMP_DIR, OMP_LOCAL_DIR, PI_AGENT_STATE_FILE,
+    PI_CODING_AGENT_DIR_ENV, PI_DIR, PI_EXTENSIONS_SUBDIR, PI_LOCAL_DIR, PI_PLUGIN_FILE,
+    PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE, SETTINGS_JSON, VIBE_BASH_MATCH, VIBE_DIR, VIBE_HOOKS_FILE,
+    VIBE_HOOK_COMMAND, VIBE_HOOK_NAME, VIBE_PROMPTS_SUBDIR, VIBE_PROMPT_FILE,
 };
 use super::integrity;
 use super::is_claude_hook_command;
@@ -2040,23 +2041,41 @@ fn run_kilocode_mode_at(base_dir: &Path, ctx: InitContext) -> Result<()> {
 
 // ─── Google Antigravity support ───────────────────────────────
 
-pub fn run_antigravity_mode(ctx: InitContext) -> Result<()> {
-    run_antigravity_mode_at(&std::env::current_dir()?, ctx)
+/// `rtk init [-g] --agent antigravity`.
+///
+/// Antigravity discovers customizations from a *customization root*: `.agents/`
+/// inside the workspace, or `~/.gemini/config/` globally. Both roots hold the
+/// same layout (`hooks.json`, `rules/`, `skills/`), so scope selection is only a
+/// question of which root to hand to `run_antigravity_mode_in_root`.
+pub fn run_antigravity_mode_with_scope(global: bool, ctx: InitContext) -> Result<()> {
+    if global {
+        let root = resolve_gemini_dir()?.join(ANTIGRAVITY_GLOBAL_SUBDIR);
+        run_antigravity_mode_in_root(&root, true, ctx)
+    } else {
+        run_antigravity_mode_at(&std::env::current_dir()?, ctx)
+    }
 }
 
 fn run_antigravity_mode_at(base_dir: &Path, ctx: InitContext) -> Result<()> {
+    run_antigravity_mode_in_root(&base_dir.join(AGENTS_DIR), false, ctx)
+}
+
+fn run_antigravity_mode_in_root(root: &Path, global: bool, ctx: InitContext) -> Result<()> {
     let InitContext {
         verbose, dry_run, ..
     } = ctx;
-    // Antigravity reads .agents/rules/ from the project root (workspace-scoped)
-    let target_dir = base_dir.join(".agents/rules");
+    let scope = if global { "global" } else { "workspace" };
+    let hooks_path = root.join(HOOKS_JSON);
+    let hook_installed = patch_antigravity_hooks_json(&hooks_path, ctx)?;
+
+    let target_dir = root.join("rules");
     let rules_path = target_dir.join("antigravity-rtk-rules.md");
 
     let existing = fs::read_to_string(&rules_path).unwrap_or_default();
     if existing.contains("RTK") || existing.contains("rtk") {
         if !dry_run {
-            println!("\nRTK already configured for Antigravity in this project.\n");
-            println!("  Rules: .agents/rules/antigravity-rtk-rules.md (already present)");
+            println!("\nRTK already configured for Antigravity ({scope}).\n");
+            println!("  Rules: {} (already present)", rules_path.display());
         }
     } else {
         let new_content = if existing.trim().is_empty() {
@@ -2073,27 +2092,148 @@ fn run_antigravity_mode_at(base_dir: &Path, ctx: InitContext) -> Result<()> {
                 println!("[dry-run] content:\n{}", new_content);
             }
         } else {
-            fs::create_dir_all(&target_dir).context("Failed to create .agents/rules directory")?;
+            fs::create_dir_all(&target_dir).with_context(|| {
+                format!("Failed to create rules directory {}", target_dir.display())
+            })?;
             fs::write(&rules_path, &new_content)
-                .context("Failed to write .agents/rules/antigravity-rtk-rules.md")?;
+                .with_context(|| format!("Failed to write {}", rules_path.display()))?;
 
             if verbose > 0 {
-                eprintln!("Wrote .agents/rules/antigravity-rtk-rules.md");
+                eprintln!("Wrote {}", rules_path.display());
             }
 
-            println!("\nRTK configured for Google Antigravity.\n");
-            println!("  Rules: .agents/rules/antigravity-rtk-rules.md (installed)");
+            println!("\nRTK configured for Google Antigravity ({scope}).\n");
+            println!("  Rules: {} (installed)", rules_path.display());
         }
     }
-    print_rules_only_awareness_note("Antigravity", ctx);
+    if hook_installed {
+        println!("  Hook:  {} (installed)", hooks_path.display());
+    } else {
+        println!("  Hook:  {} (already present)", hooks_path.display());
+    }
     if dry_run {
         print_dry_run_footer();
     } else {
-        println!("  Antigravity will now use rtk commands for token savings.");
-        println!("  Test with: git status\n");
+        println!("\n  Restart Antigravity. Test with: git status");
+        // Antigravity evaluates `permissions.allow` against the *rewritten* tool
+        // call, so a rule the user wrote for the bare command stops matching the
+        // moment RTK prefixes it. Silence here turns into a surprise approval
+        // prompt interactively, and a hard denial in headless/CI runs.
+        println!(
+            "\n  Note: Antigravity checks permissions AFTER this hook rewrites a command.\n  \
+             Existing `command(<cmd>)` allow-rules need an `rtk `-prefixed twin,\n  \
+             e.g. `command(git status)` also needs `command(rtk git status)`.\n"
+        );
     }
 
     Ok(())
+}
+
+/// Install RTK's `PreToolUse` handler into an Antigravity `hooks.json`.
+///
+/// The file is a map of *hook name* → event config, and Antigravity merges the
+/// handlers of every named hook for a given event. RTK therefore owns exactly
+/// one top-level key and must leave every other key — a user's linter, another
+/// tool's install — byte-identical.
+///
+/// Returns `true` when the file was written, `false` when RTK's entry was
+/// already there (idempotent re-run).
+fn patch_antigravity_hooks_json(path: &Path, ctx: InitContext) -> Result<bool> {
+    let InitContext {
+        verbose, dry_run, ..
+    } = ctx;
+
+    let mut root = if path.exists() {
+        let content = fs::read_to_string(path)
+            .with_context(|| format!("Failed to read {}", path.display()))?;
+        let content = strip_leading_bom(&content);
+        if content.trim().is_empty() {
+            serde_json::json!({})
+        } else {
+            from_json_str(content)
+                .with_context(|| format!("Failed to parse {} as JSON", path.display()))?
+        }
+    } else {
+        serde_json::json!({})
+    };
+
+    if antigravity_hook_already_present(&root) {
+        if verbose > 0 {
+            eprintln!("Antigravity hooks.json: RTK hook already present");
+        }
+        return Ok(false);
+    }
+
+    let obj = root
+        .as_object_mut()
+        .with_context(|| format!("{} is not a JSON object", path.display()))?;
+    obj.insert(ANTIGRAVITY_HOOK_NAME.to_string(), antigravity_hook_entry());
+
+    let serialized =
+        serde_json::to_string_pretty(&root).context("Failed to serialize hooks.json")?;
+
+    if dry_run {
+        println!(
+            "[dry-run] would patch Antigravity hooks.json: {}",
+            path.display()
+        );
+        if verbose > 0 {
+            println!("[dry-run] content:\n{}", serialized);
+        }
+        return Ok(true);
+    }
+
+    if path.exists() {
+        let backup_path = path.with_extension("json.bak");
+        fs::copy(path, &backup_path)
+            .with_context(|| format!("Failed to backup to {}", backup_path.display()))?;
+        if verbose > 0 {
+            eprintln!("Backup: {}", backup_path.display());
+        }
+    } else if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create {}", parent.display()))?;
+    }
+
+    atomic_write(path, &serialized)?;
+
+    Ok(true)
+}
+
+/// RTK's entry in an Antigravity `hooks.json`.
+fn antigravity_hook_entry() -> serde_json::Value {
+    serde_json::json!({
+        PRE_TOOL_USE_KEY: [
+            {
+                "matcher": ANTIGRAVITY_SHELL_TOOL,
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": ANTIGRAVITY_HOOK_COMMAND,
+                        "timeout": 10
+                    }
+                ]
+            }
+        ]
+    })
+}
+
+/// True when some handler under RTK's namespace already runs `rtk hook antigravity`.
+/// Keyed on the command rather than the namespace so a stale entry written by an
+/// older RTK (or hand-edited by the user) is replaced instead of skipped.
+fn antigravity_hook_already_present(root: &serde_json::Value) -> bool {
+    root.get(ANTIGRAVITY_HOOK_NAME)
+        .and_then(|entry| entry.get(PRE_TOOL_USE_KEY))
+        .and_then(|events| events.as_array())
+        .map(|events| {
+            events
+                .iter()
+                .filter_map(|group| group.get("hooks")?.as_array())
+                .flatten()
+                .filter_map(|handler| handler.get("command")?.as_str())
+                .any(|command| command == ANTIGRAVITY_HOOK_COMMAND)
+        })
+        .unwrap_or(false)
 }
 
 // ─── Hermes support ────────────────────────────────────────────
@@ -6662,6 +6802,60 @@ mod tests {
         run_antigravity_mode_at(temp.path(), InitContext::default()).unwrap();
         let second = fs::read_to_string(&path).unwrap();
         assert_eq!(first, second, "Idempotent: content should not change");
+    }
+
+    #[test]
+    fn test_antigravity_mode_installs_hook() {
+        let temp = TempDir::new().unwrap();
+        run_antigravity_mode_at(temp.path(), InitContext::default()).unwrap();
+
+        let hooks_path = temp.path().join(".agents/hooks.json");
+        assert!(hooks_path.exists(), "hooks.json should be created");
+        let root: serde_json::Value =
+            from_json_str(&fs::read_to_string(&hooks_path).unwrap()).unwrap();
+        let handler = &root["rtk"]["PreToolUse"][0];
+        assert_eq!(handler["matcher"], "run_command");
+        assert_eq!(handler["hooks"][0]["command"], "rtk hook antigravity");
+    }
+
+    #[test]
+    fn test_antigravity_hook_preserves_foreign_namespaces() {
+        // Antigravity merges the handlers of every named hook, so an install
+        // that clobbers a user's own entry silently disables their tooling.
+        let temp = TempDir::new().unwrap();
+        let agents_dir = temp.path().join(".agents");
+        fs::create_dir_all(&agents_dir).unwrap();
+        let hooks_path = agents_dir.join("hooks.json");
+        fs::write(
+            &hooks_path,
+            r#"{"lint-checker":{"PostToolUse":[{"matcher":"run_command","hooks":[{"command":"./lint.sh"}]}]}}"#,
+        )
+        .unwrap();
+
+        run_antigravity_mode_at(temp.path(), InitContext::default()).unwrap();
+
+        let root: serde_json::Value =
+            from_json_str(&fs::read_to_string(&hooks_path).unwrap()).unwrap();
+        assert_eq!(
+            root["lint-checker"]["PostToolUse"][0]["hooks"][0]["command"], "./lint.sh",
+            "foreign hook namespace must survive untouched"
+        );
+        assert_eq!(
+            root["rtk"]["PreToolUse"][0]["hooks"][0]["command"],
+            "rtk hook antigravity"
+        );
+    }
+
+    #[test]
+    fn test_antigravity_hook_install_is_idempotent() {
+        let temp = TempDir::new().unwrap();
+        run_antigravity_mode_at(temp.path(), InitContext::default()).unwrap();
+        let hooks_path = temp.path().join(".agents/hooks.json");
+        let first = fs::read_to_string(&hooks_path).unwrap();
+
+        run_antigravity_mode_at(temp.path(), InitContext::default()).unwrap();
+        let second = fs::read_to_string(&hooks_path).unwrap();
+        assert_eq!(first, second, "re-running init must not duplicate handlers");
     }
 
     #[test]

--- a/src/hooks/permissions.rs
+++ b/src/hooks/permissions.rs
@@ -38,6 +38,7 @@ pub enum Host {
     Gemini,
     Droid,
     Vibe,
+    Antigravity,
 }
 
 pub fn check_command_for(cmd: &str, host: Host) -> PermissionVerdict {
@@ -58,6 +59,12 @@ pub(crate) fn load_rules_for(host: Host) -> (Vec<String>, Vec<String>, Vec<Strin
         Host::Gemini => load_gemini_rules(),
         Host::Droid => load_droid_rules(),
         Host::Vibe => (Vec::new(), Vec::new(), Vec::new()),
+        // Antigravity keeps its own `permissions.allow` list in
+        // `~/.gemini/antigravity-cli/settings.json`, but it evaluates that list
+        // against the *rewritten* tool call (see `hooks/antigravity/README.md`),
+        // so mirroring the rules here would only ever double-check what the host
+        // is about to check itself. Defer to the host, like `Host::Vibe`.
+        Host::Antigravity => (Vec::new(), Vec::new(), Vec::new()),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -963,6 +963,8 @@ enum HookCommands {
     Droid,
     /// Process Mistral Vibe CLI pre_tool hook (reads JSON from stdin)
     Vibe,
+    /// Process Google Antigravity PreToolUse hook (reads JSON from stdin)
+    Antigravity,
     /// Check how a command would be rewritten by the hook engine (dry-run)
     Check {
         /// Target agent
@@ -2322,12 +2324,10 @@ fn run_cli() -> Result<i32> {
                 }
                 hooks::init::run_kilocode_mode(ctx)?;
             } else if agent == Some(AgentTarget::Antigravity) {
-                if global {
-                    anyhow::bail!(
-                        "Antigravity is project-scoped. Use: rtk init --agent antigravity"
-                    );
-                }
-                hooks::init::run_antigravity_mode(ctx)?;
+                // Antigravity reads a workspace customization root (`.agents/`)
+                // *and* a global one (`~/.gemini/config/`), so `-g` is meaningful
+                // here and installs the hook once for every workspace.
+                hooks::init::run_antigravity_mode_with_scope(global, ctx)?;
             } else if agent == Some(AgentTarget::Kimi) {
                 if global {
                     anyhow::bail!("Kimi AI is project-scoped. Use: rtk init --agent kimi");
@@ -2786,6 +2786,10 @@ fn run_cli() -> Result<i32> {
             }
             HookCommands::Vibe => {
                 hooks::hook_cmd::run_vibe()?;
+                0
+            }
+            HookCommands::Antigravity => {
+                hooks::hook_cmd::run_antigravity()?;
                 0
             }
             HookCommands::Check { agent: _, command } => {


### PR DESCRIPTION
## Summary

- `hooks/antigravity/README.md` and `src/hooks/init.rs` state that Antigravity has no programmatic hook, so `rtk init --agent antigravity` only writes a Markdown rule asking the model to type `rtk` itself. Antigravity does have one — this PR adds it.
- New `rtk hook antigravity`: reads the `PreToolUse` payload, answers with `overwrite.CommandLine`, which Antigravity shallow-merges into the tool call before it executes.
- `rtk init [-g] --agent antigravity` now installs a real `hooks.json` into the workspace root (`.agents/`) or the global one (`~/.gemini/config/`), merging into any existing file. `-g` was previously rejected with "Antigravity is project-scoped".

## Why I opened this

I use Antigravity CLI daily for cheap agentic work and wanted RTK's savings there. Nothing was being intercepted, so I went looking and found the assumption in your source rather than a bug.

Antigravity ships its own hook documentation inside the `agy` binary. It is reproducible on any machine with Antigravity installed:

```bash
strings $(which agy) | sed -n '/Lifecycle Hooks/,/PostInvocation Contract/p'
```

Relevant excerpts (verified on `agy` 1.1.27, macOS arm64):

> "Hooks are configured in a single `hooks.json` file placed in your customization root directory (e.g., `.agents/hooks.json`)."

> `PreToolUse` | Before a tool step executes. | Matcher target: Tool name (e.g., `run_command`).

> **`overwrite`** (object, optional): Key-value pairs merged into the tool call's arguments before it runs… **The modified tool call is what actually executes and is recorded.**

Two changelog entries in the same binary confirm both roots: one fixes `/hooks` writing to `~/.gemini/antigravity-cli/hooks.json` "instead of the shared `~/.gemini/config/hooks.json`", another fixes workspace-local hooks in `<workspace>/.agents/hooks.json` not loading after trusting a folder.

## Evidence it works end-to-end

Not just unit tests — a real headless session that was never told about RTK:

```bash
agy --print "Run exactly one shell command: git status. Report its output."
rtk gain --history     # → a new `rtk git status` row
```

The model typed `git status`; the hook rewrote it.

## Two judgment calls I'd like your read on

**1. Everything not denied answers `allow`.** `Host::Antigravity` carries no rules of its own (like `Host::Vibe`), so every command lands on `Defer`/`AskRewrite`. Mirroring `run_gemini_inner_impl`'s `ask_user` looked right, but the built binary then answered `{"decision":"ask"}` to `git status` — that adds an approval prompt that did not exist before RTK was installed, and hard-fails headless runs.

`allow` cannot widen permissions here, and that is measured rather than assumed: the headless run above was **denied** while the hook answered `allow`, because Antigravity re-checks its own `permissions` rules against the rewritten call afterwards. So `allow` reads as "RTK has no objection", not "skip the prompt". Happy to move this behind a config toggle if you'd rather.

**2. The post-rewrite permission check is a real user-facing gotcha.** Because Antigravity evaluates `permissions.allow` against the modified tool call, an existing `command(git status)` rule stops matching the moment RTK prefixes the command — a surprise prompt interactively, a hard denial in CI. `PreToolUse` output does support `permissionOverrides`, which would paper over it, but emitting that unconditionally means RTK auto-granting permission for commands the user never approved. I chose not to: `rtk init` prints a warning and the README documents it. Your call if you'd prefer the override.

## Scope

Feature + its own docs only. Two things I deliberately left out, happy to send separately:

- `src/hooks/hook_check.rs::status()` only inspects Claude Code, so `rtk gain` warns "No hook installed" at any user whose agent is Antigravity, Gemini, Cursor or Droid. Independent defect, cross-cutting fix, wrong to bundle here.
- `hooks/codex/README.md` carries the same "no programmatic hook" claim, and `codex features list` reports `hooks stable true` with a `PreToolUse` schema that already matches what `rtk hook claude` emits (`hookSpecificOutput` + `updatedInput`). Worth its own PR.

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets -- -D warnings && cargo test` — clean; 3406 tests pass, 13 of them new
- [x] Manual testing: `rtk hook antigravity` against real payloads — rewrite, passthrough for non-rewritable commands, non-`run_command` tools ignored, idempotent on already-prefixed input, UTF-8 BOM tolerated
- [x] `rtk init --agent antigravity` writes a valid `.agents/hooks.json`; a pre-existing foreign hook namespace in that file survives (covered by `test_antigravity_hook_preserves_foreign_namespaces`)
- [x] Re-running `init` does not duplicate handlers
- [x] Live confirmation in Antigravity CLI 1.1.27 as shown above
