### PR TITLE
feat(hook): add native Codex CLI lifecycle hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ RTK supports 17 AI coding tools. Each integration rewrites shell commands to `rt
 | **GitHub Copilot CLI** | `rtk init -g --copilot` | PreToolUse deny-with-suggestion (CLI limitation) |
 | **Cursor** | `rtk init -g --agent cursor` | preToolUse hook (hooks.json) |
 | **Gemini CLI** | `rtk init -g --gemini` | BeforeTool hook |
-| **Codex** | `rtk init -g --codex` | AGENTS.md + RTK.md instructions |
+| **Codex** | `rtk init -g --codex` (or project-scoped) | `PreToolUse` hook in `$CODEX_HOME/hooks.json` / `.codex/hooks.json` (matcher `Bash`) |
 | **Windsurf** | `rtk init -g --agent windsurf` | .windsurfrules (project-scoped) |
 | **Cline / Roo Code** | `rtk init --agent cline` | .clinerules (project-scoped) |
 | **OpenCode** | `rtk init -g --opencode` | Plugin TS (tool.execute.before) |

--- a/docs/guide/getting-started/configuration.md
+++ b/docs/guide/getting-started/configuration.md
@@ -80,8 +80,9 @@ level = "high"
 
 Re-run `rtk init -g` (or your agent's init command) to rewrite the file.
 
-Agents without a hook (Codex CLI, Cline, Windsurf, Kilo Code, Antigravity, Kimi) always get `full`,
-since the agent must type `rtk` itself. `rtk init` prints a note when it does this.
+Agents whose awareness ships as a rules file (Cline, Windsurf, Kilo Code, Antigravity, Kimi)
+always get `full`, since the rules file has to stand on its own. Codex keeps `full` too: its
+`AGENTS.md` guidance is the fallback layer behind the hook. `rtk init` prints a note when it does this.
 
 ## Environment variables
 

--- a/docs/guide/getting-started/supported-agents.md
+++ b/docs/guide/getting-started/supported-agents.md
@@ -41,7 +41,7 @@ Agent runs "cargo test"
 | Factory Droid | Shell hook (`PreToolUse`, matcher `Execute`) | Yes |
 | Cline / Roo Code | Rules file (prompt-level) | N/A |
 | Windsurf | Rules file (prompt-level) | N/A |
-| Codex CLI | AGENTS.md instructions | N/A |
+| Codex CLI | Shell hook (`PreToolUse`, matcher `Bash`) | Yes |
 | Kilo Code | Rules file (prompt-level) | N/A |
 | Google Antigravity | Rules file (prompt-level) | N/A |
 | Mistral Vibe | Rust binary (`pre_tool`) | Yes |
@@ -210,9 +210,18 @@ rtk init --global --agent windsurf    # creates .windsurfrules in current projec
 ### Codex CLI
 
 ```bash
-rtk init --codex           # project-scoped (AGENTS.md)
-rtk init --global --codex  # user-global (~/.codex/AGENTS.md)
+rtk init --codex           # project:  .codex/hooks.json + AGENTS.md
+rtk init --global --codex  # global:   $CODEX_HOME/hooks.json + ~/.codex/AGENTS.md
 ```
+
+Codex dispatches a `PreToolUse` lifecycle event before every shell tool call, and RTK's handler
+answers with the rewritten command, so interception does not depend on the model remembering
+anything. The `AGENTS.md` guidance stays installed as a fallback for sessions where the hook is
+disabled. Verify the engine is available with `codex features list | grep hooks`.
+
+Codex reviews hook definitions before running them and skips one that has not been trusted, so
+start Codex once after installing and approve RTK's hook in the `/hooks` review — otherwise the
+integration looks installed but never fires.
 
 ### Kilo Code
 
@@ -261,7 +270,7 @@ Strips only RTK's `[[hooks]]` block and the `~/.vibe/prompts/rtk.md` file. Any o
 | **Plugin** | TypeScript, JavaScript, or Python in agent's plugin system | Transparent, in-place mutation when the agent allows it |
 | **Rules file** | Prompt-level instructions | Guidance only — agent is told to prefer `rtk <cmd>` |
 
-Rules file integrations (Cline, Windsurf, Codex, Kilo Code, Antigravity) rely on the model following instructions. Full hook integrations (Claude Code, Cursor, Gemini) are guaranteed — the command is rewritten before the agent sees it. Plugin integrations (OpenCode, Pi) use in-place mutation via the agent's TypeScript extension API.
+Rules file integrations (Cline, Windsurf, Kilo Code, Antigravity) rely on the model following instructions. Full hook integrations (Claude Code, Cursor, Gemini) are guaranteed — the command is rewritten before the agent sees it. Plugin integrations (OpenCode, Pi) use in-place mutation via the agent's TypeScript extension API.
 
 ## Windows support
 

--- a/hooks/codex/README.md
+++ b/hooks/codex/README.md
@@ -4,6 +4,67 @@
 
 ## Specifics
 
-- Prompt-level guidance via awareness document -- no programmatic hook
-- `../rtk-awareness-full.md` is written to `RTK.md` and referenced from `AGENTS.md` via `@RTK.md`. No hook, so the `full` level is always used regardless of `awareness.level`
-- Installed to `$CODEX_HOME` when set, otherwise `~/.codex/`, by `rtk init --codex`
+- Native programmatic hook: Codex dispatches a `PreToolUse` lifecycle event and honours a handler that rewrites the tool call, so RTK intercepts commands instead of asking the model to prefix them
+- Installed by `rtk init --codex` (project, `.codex/hooks.json`) or `rtk init -g --codex` (global, `$CODEX_HOME/hooks.json`, otherwise `~/.codex/hooks.json`)
+- Also installs `../rtk-awareness-full.md` to `RTK.md`, referenced from `AGENTS.md` via `@RTK.md`, as a second layer for sessions where the hook is disabled
+
+Confirm the hook engine is present on a given install with:
+
+```bash
+codex features list | grep hooks     # → hooks   stable   true
+```
+
+## `hooks.json`
+
+Codex nests every event under a single top-level `hooks` key and merges all handlers registered for an event, so RTK appends one entry and leaves the rest of the file alone:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          { "type": "command", "command": "rtk hook codex", "timeout": 10 }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## Wire contract
+
+Codex models its hooks on Claude Code's, so the payload is the same snake_case shape RTK already parses. Captured live from Codex 0.153.4:
+
+```json
+{
+  "session_id": "01a08578-…",
+  "turn_id": "01a08578-…",
+  "cwd": "/path/to/workspace",
+  "hook_event_name": "PreToolUse",
+  "permission_mode": "bypassPermissions",
+  "tool_name": "Bash",
+  "tool_input": { "command": "git status" },
+  "tool_use_id": "exec-7716f8ce-…"
+}
+```
+
+The response is where Codex diverges, and it validates strictly:
+
+| case | response |
+| :--- | :--- |
+| rewrite | `{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow","permissionDecisionReason":"RTK auto-rewrite","updatedInput":{"command":"rtk git status"}}}` |
+| deny | the same envelope with `"permissionDecision":"deny"` and a non-empty `permissionDecisionReason` |
+| no rewrite | empty stdout — Codex falls through to its native handling |
+
+Two of Codex's validation rules are why this needs its own handler rather than reusing `rtk hook claude`:
+
+- `updatedInput` is honoured only together with `permissionDecision: "allow"`; otherwise Codex rejects the response outright (*"PreToolUse hook returned updatedInput without permissionDecision:allow"*). `run_claude` omits that field on its Ask path.
+- A deny without a non-empty `permissionDecisionReason` is likewise rejected.
+
+`continue: false`, `stopReason` and `suppressOutput` are all rejected as unsupported, so the handler never emits them.
+
+## Gotcha: a new hook has to be trusted once
+
+Codex reviews hook definitions before running them and skips one that has not been trusted. After `rtk init --codex`, start Codex and approve the hook in its `/hooks` review — otherwise the integration looks installed but never fires.

--- a/src/hooks/constants.rs
+++ b/src/hooks/constants.rs
@@ -16,6 +16,13 @@ pub const CURSOR_HOOK_COMMAND: &str = "rtk hook cursor";
 pub const DROID_HOOK_COMMAND: &str = "rtk hook droid";
 /// Native Rust hook command for Mistral Vibe.
 pub const VIBE_HOOK_COMMAND: &str = "rtk hook vibe";
+/// Native Rust hook command for Codex CLI.
+pub const CODEX_HOOK_COMMAND: &str = "rtk hook codex";
+/// Codex's shell tool name, as observed in a live `PreToolUse` payload.
+pub const CODEX_SHELL_TOOL: &str = "Bash";
+/// Matcher for Codex's shell tool. Codex treats `matcher` as a regex and does
+/// NOT special-case a bare `"*"` — a hook registered with `"*"` never fires.
+pub const CODEX_SHELL_MATCHER: &str = "Bash";
 
 pub const CONFIG_DIR: &str = ".config";
 pub const OPENCODE_SUBDIR: &str = "opencode";

--- a/src/hooks/constants.rs
+++ b/src/hooks/constants.rs
@@ -18,11 +18,9 @@ pub const DROID_HOOK_COMMAND: &str = "rtk hook droid";
 pub const VIBE_HOOK_COMMAND: &str = "rtk hook vibe";
 /// Native Rust hook command for Codex CLI.
 pub const CODEX_HOOK_COMMAND: &str = "rtk hook codex";
-/// Codex's shell tool name, as observed in a live `PreToolUse` payload.
+/// Codex's shell tool, as reported by `tool_name` in a live `PreToolUse`
+/// payload, and therefore the `matcher` its handlers key off.
 pub const CODEX_SHELL_TOOL: &str = "Bash";
-/// Matcher for Codex's shell tool. Codex treats `matcher` as a regex and does
-/// NOT special-case a bare `"*"` — a hook registered with `"*"` never fires.
-pub const CODEX_SHELL_MATCHER: &str = "Bash";
 
 pub const CONFIG_DIR: &str = ".config";
 pub const OPENCODE_SUBDIR: &str = "opencode";

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -3,7 +3,7 @@
 //! Uses `writeln!(stdout, ...)` instead of `println!` — accidental stdout/stderr
 //! corrupts the JSON protocol (Claude Code bug #4669 silently disables the hook).
 
-use super::constants::PRE_TOOL_USE_KEY;
+use super::constants::{CODEX_SHELL_TOOL, PRE_TOOL_USE_KEY};
 use super::permissions::{self, PermissionVerdict};
 use anyhow::{Context, Result};
 use serde_json::{json, Value};
@@ -467,6 +467,114 @@ fn run_gemini_inner_impl(
         }
         HookDecision::Defer => gemini_json("ask_user", None),
     })
+}
+
+// ── Codex hook ────────────────────────────────────────────────
+
+/// Run the Codex CLI `PreToolUse` hook.
+///
+/// Codex models its hooks on Claude Code's — same snake_case stdin
+/// (`tool_name` / `tool_input.command`) and the same `hookSpecificOutput`
+/// envelope — but it validates the response strictly, and two of its rules bite
+/// (error strings taken from the `codex` binary):
+///
+/// - "PreToolUse hook returned updatedInput without permissionDecision:allow"
+///   — a rewrite MUST carry `permissionDecision: "allow"`. `run_claude` omits
+///   that field on its Ask path, which is why `rtk hook claude` cannot simply
+///   be pointed at Codex.
+/// - "PreToolUse hook returned permissionDecision:deny without a non-empty
+///   permissionDecisionReason" — a deny MUST carry a reason.
+///
+/// `continue: false`, `stopReason` and `suppressOutput` are rejected as
+/// unsupported, so this handler never emits them.
+///
+/// Live payload captured from Codex 0.153.4 for `git status`:
+/// ```json
+/// {"tool_name":"Bash","tool_input":{"command":"git status"},
+///  "hook_event_name":"PreToolUse","tool_use_id":"exec-…","cwd":"…"}
+/// ```
+pub fn run_codex() -> Result<()> {
+    let input = read_stdin_limited()?;
+    if let Some(output) = run_codex_inner(&input) {
+        let _ = writeln!(io::stdout(), "{output}");
+    }
+    Ok(())
+}
+
+fn run_codex_inner(input: &str) -> Option<String> {
+    run_codex_inner_impl(input, |cmd| {
+        decide_hook_action(cmd, permissions::Host::Codex)
+    })
+}
+
+#[cfg(test)]
+fn run_codex_inner_with_rules(
+    input: &str,
+    deny: &[String],
+    ask: &[String],
+    allow: &[String],
+) -> Option<String> {
+    run_codex_inner_impl(input, |cmd| {
+        decide_from_verdict(
+            cmd,
+            permissions::check_command_with_rules(cmd, deny, ask, allow),
+        )
+    })
+}
+
+fn run_codex_inner_impl(input: &str, decide: impl Fn(&str) -> HookDecision) -> Option<String> {
+    let input = strip_leading_bom(input);
+    let json: Value = match serde_json::from_str(input) {
+        Ok(v) => v,
+        Err(e) => {
+            let _ = writeln!(io::stderr(), "[rtk hook] Failed to parse JSON input: {e}");
+            return None;
+        }
+    };
+
+    if json.get("tool_name").and_then(|v| v.as_str())? != CODEX_SHELL_TOOL {
+        return None;
+    }
+
+    let cmd = json
+        .pointer("/tool_input/command")
+        .and_then(|v| v.as_str())
+        .filter(|c| !c.is_empty())?;
+
+    match decide(cmd) {
+        HookDecision::Deny => {
+            audit_log("deny", cmd, "");
+            Some(codex_json("deny", None))
+        }
+        // Codex only honours `updatedInput` alongside `permissionDecision:
+        // "allow"`, so an Ask verdict cannot be expressed as "rewrite, but let
+        // the host prompt". `allow` here means "RTK has no objection": Codex
+        // still applies its own `approval_policy` and sandbox to the rewritten
+        // call, so this cannot widen what the user granted.
+        HookDecision::AllowRewrite(ref rewritten) | HookDecision::AskRewrite(ref rewritten) => {
+            audit_log("rewrite", cmd, rewritten);
+            Some(codex_json("allow", Some(rewritten)))
+        }
+        // Staying silent lets Codex fall through to its native handling — the
+        // same shape `run_claude` and `run_vibe` use for a no-op.
+        HookDecision::Defer => None,
+    }
+}
+
+fn codex_json(decision: &str, rewrite: Option<&str>) -> String {
+    let mut hook_output = serde_json::json!({
+        "hookEventName": PRE_TOOL_USE_KEY,
+        "permissionDecision": decision,
+        "permissionDecisionReason": if rewrite.is_some() {
+            "RTK auto-rewrite"
+        } else {
+            "Blocked by RTK permission rule"
+        },
+    });
+    if let Some(cmd) = rewrite {
+        hook_output["updatedInput"] = serde_json::json!({ "command": cmd });
+    }
+    serde_json::json!({ "hookSpecificOutput": hook_output }).to_string()
 }
 
 // ── Vibe hook ─────────────────────────────────────────────────
@@ -2207,6 +2315,160 @@ mod tests {
         ))
         .unwrap();
         assert_eq!(v["decision"], "deny");
+    }
+
+    // --- Codex CLI hook ---
+
+    /// The `PreToolUse` payload Codex 0.153.4 sent for `git status`, captured
+    /// from a live session (trimmed to the fields the handler reads). Keeping
+    /// the real shape here is what stops a refactor from quietly breaking the
+    /// integration.
+    fn codex_input(tool: &str, cmd: &str) -> String {
+        json!({
+            "session_id": "01a08578-4678-7731-a58c-af3972b3e51f",
+            "turn_id": "01a08578-4710-7941-ab83-aec9919cc5d7",
+            "cwd": "/tmp/workspace",
+            "hook_event_name": "PreToolUse",
+            "permission_mode": "bypassPermissions",
+            "tool_name": tool,
+            "tool_input": { "command": cmd },
+            "tool_use_id": "exec-7716f8ce-28f9-4d52-aba7-e76a06b3a138"
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn test_codex_rewrite_carries_permission_decision() {
+        // Codex rejects the response outright when `updatedInput` arrives
+        // without `permissionDecision: "allow"` ("PreToolUse hook returned
+        // updatedInput without permissionDecision:allow"). That is exactly the
+        // shape `run_claude` emits on its Ask path, which is why Codex needs
+        // its own handler rather than a reused `rtk hook claude`.
+        let out = run_codex_inner_with_rules(
+            &codex_input(CODEX_SHELL_TOOL, "git status"),
+            &[],
+            &[],
+            &all_allowed(),
+        )
+        .expect("a rewritable command must produce a response");
+        let v: Value = serde_json::from_str(&out).unwrap();
+        let hook = &v["hookSpecificOutput"];
+        assert_eq!(hook["hookEventName"], "PreToolUse");
+        assert_eq!(hook["permissionDecision"], "allow");
+        assert_eq!(hook["updatedInput"]["command"], "rtk git status");
+    }
+
+    #[test]
+    fn test_codex_rewrite_without_rules_still_decides() {
+        // `Host::Codex` carries no rules, so in practice every command lands on
+        // the Ask/Defer path. A rewrite must still be emitted with `allow`.
+        let out =
+            run_codex_inner_with_rules(&codex_input(CODEX_SHELL_TOOL, "git status"), &[], &[], &[])
+                .expect("a rewritable command must produce a response");
+        let v: Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["hookSpecificOutput"]["permissionDecision"], "allow");
+        assert_eq!(
+            v["hookSpecificOutput"]["updatedInput"]["command"],
+            "rtk git status"
+        );
+    }
+
+    #[test]
+    fn test_codex_deny_carries_reason() {
+        // "PreToolUse hook returned permissionDecision:deny without a
+        // non-empty permissionDecisionReason" — Codex rejects a bare deny.
+        let out = run_codex_inner_with_rules(
+            &codex_input(CODEX_SHELL_TOOL, "rm -rf /tmp/x"),
+            &["rm -rf".to_string()],
+            &[],
+            &[],
+        )
+        .expect("a denied command must produce a response");
+        let v: Value = serde_json::from_str(&out).unwrap();
+        let hook = &v["hookSpecificOutput"];
+        assert_eq!(hook["permissionDecision"], "deny");
+        assert!(!hook["permissionDecisionReason"]
+            .as_str()
+            .unwrap_or("")
+            .is_empty());
+        assert!(hook.get("updatedInput").is_none());
+    }
+
+    #[test]
+    fn test_codex_ignores_other_tools() {
+        assert!(run_codex_inner_with_rules(
+            &json!({ "tool_name": "Read", "tool_input": { "file_path": "/x" } }).to_string(),
+            &[],
+            &[],
+            &all_allowed(),
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn test_codex_passes_through_non_rewritable() {
+        // Silence lets Codex fall through to its native handling. Emitting a
+        // decision here would put RTK in the approval path for every command.
+        assert!(run_codex_inner_with_rules(
+            &codex_input(CODEX_SHELL_TOOL, "echo hi"),
+            &[],
+            &[],
+            &all_allowed(),
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn test_codex_never_emits_unsupported_fields() {
+        // Codex rejects `continue: false`, `stopReason` and `suppressOutput`.
+        let out = run_codex_inner_with_rules(
+            &codex_input(CODEX_SHELL_TOOL, "git status"),
+            &[],
+            &[],
+            &all_allowed(),
+        )
+        .unwrap();
+        for field in ["continue", "stopReason", "suppressOutput"] {
+            assert!(!out.contains(field), "response must not carry {field}");
+        }
+    }
+
+    #[test]
+    fn test_codex_rewrite_is_idempotent() {
+        if let Some(out) = run_codex_inner_with_rules(
+            &codex_input(CODEX_SHELL_TOOL, "rtk git status"),
+            &[],
+            &[],
+            &all_allowed(),
+        ) {
+            let v: Value = serde_json::from_str(&out).unwrap();
+            let rewritten = v["hookSpecificOutput"]["updatedInput"]["command"]
+                .as_str()
+                .unwrap_or("");
+            assert!(
+                !rewritten.starts_with("rtk rtk"),
+                "double-prefixed command: {rewritten}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_codex_strips_utf8_bom() {
+        let with_bom = format!("\u{feff}{}", codex_input(CODEX_SHELL_TOOL, "git status"));
+        let out = run_codex_inner_with_rules(&with_bom, &[], &[], &all_allowed())
+            .expect("BOM-prefixed payload must parse");
+        let v: Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(
+            v["hookSpecificOutput"]["updatedInput"]["command"],
+            "rtk git status"
+        );
+    }
+
+    #[test]
+    fn test_codex_malformed_json_is_silent() {
+        // A hook that prints garbage to stdout on bad input would wedge the
+        // tool call it is supposed to be transparent to.
+        assert!(run_codex_inner("not valid json {{{").is_none());
     }
 
     // --- Factory Droid hook ---

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -15,7 +15,7 @@ use crate::hooks::constants::{
 
 use super::constants::{
     BEFORE_TOOL_KEY, CLAUDE_DIR, CLAUDE_HOOK_COMMAND, CODEX_DIR, CODEX_HOOK_COMMAND,
-    CODEX_SHELL_MATCHER, CURSOR_HOOK_COMMAND, DROID_DIR, DROID_EXECUTE_MATCHER, DROID_HOME_ENV,
+    CODEX_SHELL_TOOL, CURSOR_HOOK_COMMAND, DROID_DIR, DROID_EXECUTE_MATCHER, DROID_HOME_ENV,
     DROID_HOOKS_FILE, DROID_HOOKS_SUBDIR, DROID_HOOK_COMMAND, DROID_SETTINGS_FILE,
     GEMINI_HOOK_FILE, HERMES_DIR, HERMES_PLUGINS_SUBDIR, HERMES_PLUGIN_INIT_FILE,
     HERMES_PLUGIN_MANIFEST_FILE, HERMES_PLUGIN_NAME, HOOKS_JSON, HOOKS_SUBDIR, OMP_DIR,
@@ -1095,7 +1095,7 @@ fn uninstall_codex(global: bool, ctx: InitContext) -> Result<()> {
     let InitContext { dry_run, .. } = ctx;
     if !global {
         anyhow::bail!(
-            "Uninstall only works with --global flag. For local projects, manually remove RTK from AGENTS.md"
+            "Uninstall only works with --global flag. For local projects, manually remove RTK from AGENTS.md and the RTK entry from .codex/hooks.json"
         );
     }
 
@@ -1172,7 +1172,108 @@ fn uninstall_codex_at(codex_dir: &Path, ctx: InitContext) -> Result<Vec<String>>
         removed.push("AGENTS.md: removed @RTK.md reference".to_string());
     }
 
+    // The hook keeps rewriting commands long after the instruction files are
+    // gone, so uninstall has to reach into hooks.json too — otherwise `rtk init
+    // --codex --uninstall` reports success while the integration is still live.
+    let hooks_path = codex_dir.join(HOOKS_JSON);
+    if remove_codex_hook_entry(&hooks_path, ctx)? {
+        removed.push(format!(
+            "hooks.json: removed RTK hook ({})",
+            hooks_path.display()
+        ));
+    }
+
     Ok(removed)
+}
+
+/// Drop RTK's `PreToolUse` handler from a Codex `hooks.json`, leaving every
+/// other handler and event in place.
+///
+/// Prunes containers that RTK emptied — an orphaned `"PreToolUse": []` (or a
+/// `"hooks": {}`) would otherwise be left behind as a fossil of an integration
+/// that is no longer installed. A file that held nothing but RTK's hook is
+/// removed outright.
+///
+/// Returns `true` when something was removed.
+fn remove_codex_hook_entry(path: &Path, ctx: InitContext) -> Result<bool> {
+    let InitContext {
+        verbose, dry_run, ..
+    } = ctx;
+    if !path.exists() {
+        return Ok(false);
+    }
+
+    let content =
+        fs::read_to_string(path).with_context(|| format!("Failed to read {}", path.display()))?;
+    let content = strip_leading_bom(&content);
+    if content.trim().is_empty() {
+        return Ok(false);
+    }
+    let mut root: serde_json::Value = from_json_str(content)
+        .with_context(|| format!("Failed to parse {} as JSON", path.display()))?;
+
+    if !codex_hook_already_present(&root) {
+        return Ok(false);
+    }
+
+    let Some(hooks) = root.get_mut("hooks").and_then(|h| h.as_object_mut()) else {
+        return Ok(false);
+    };
+    if let Some(groups) = hooks
+        .get_mut(PRE_TOOL_USE_KEY)
+        .and_then(|e| e.as_array_mut())
+    {
+        // Drop RTK's handlers, then drop any group left with no handlers at all.
+        for group in groups.iter_mut() {
+            if let Some(handlers) = group.get_mut("hooks").and_then(|h| h.as_array_mut()) {
+                handlers.retain(|handler| {
+                    handler.get("command").and_then(|c| c.as_str()) != Some(CODEX_HOOK_COMMAND)
+                });
+            }
+        }
+        groups.retain(|group| {
+            group
+                .get("hooks")
+                .and_then(|h| h.as_array())
+                .is_none_or(|handlers| !handlers.is_empty())
+        });
+        if groups.is_empty() {
+            hooks.remove(PRE_TOOL_USE_KEY);
+        }
+    }
+    let hooks_now_empty = hooks.is_empty();
+    if hooks_now_empty {
+        root.as_object_mut()
+            .expect("root parsed as object above")
+            .remove("hooks");
+    }
+
+    let file_now_empty = root.as_object().is_some_and(|obj| obj.is_empty());
+
+    if dry_run {
+        if file_now_empty {
+            println!(
+                "[dry-run] would remove Codex hooks.json: {}",
+                path.display()
+            );
+        } else {
+            println!("[dry-run] would remove RTK hook from: {}", path.display());
+        }
+        return Ok(true);
+    }
+
+    if file_now_empty {
+        fs::remove_file(path).with_context(|| format!("Failed to remove {}", path.display()))?;
+    } else {
+        let serialized =
+            serde_json::to_string_pretty(&root).context("Failed to serialize hooks.json")?;
+        atomic_write(path, &serialized)?;
+    }
+    if verbose > 0 {
+        eprintln!("Removed RTK hook from {}", path.display());
+    }
+
+    Ok(true)
 }
 
 /// Orchestrator: patch settings.json with RTK hook (binary command variant)
@@ -2711,7 +2812,7 @@ fn patch_codex_hooks_json(path: &Path, ctx: InitContext) -> Result<bool> {
         .as_array_mut()
         .with_context(|| format!("{}: \"{PRE_TOOL_USE_KEY}\" is not an array", path.display()))?
         .push(serde_json::json!({
-            "matcher": CODEX_SHELL_MATCHER,
+            "matcher": CODEX_SHELL_TOOL,
             "hooks": [
                 { "type": "command", "command": CODEX_HOOK_COMMAND, "timeout": 10 }
             ]
@@ -7846,8 +7947,8 @@ mod tests {
             "./review.sh"
         );
         let entry = &root["hooks"]["PreToolUse"][0];
-        // Codex treats `matcher` as a regex and does not special-case a bare
-        // "*": a handler registered with "*" never fires (observed live).
+        // The matcher names Codex's shell tool exactly, so RTK's handler never
+        // runs for unrelated tools.
         assert_eq!(entry["matcher"], "Bash");
         assert_eq!(entry["hooks"][0]["command"], "rtk hook codex");
     }
@@ -7861,6 +7962,88 @@ mod tests {
         let first = fs::read_to_string(&path).unwrap();
         assert!(!patch_codex_hooks_json(&path, InitContext::default()).unwrap());
         assert_eq!(first, fs::read_to_string(&path).unwrap());
+    }
+
+    #[test]
+    fn test_uninstall_codex_removes_hook_and_keeps_others() {
+        // Uninstall used to strip only the instruction files, leaving the hook
+        // rewriting commands forever — a "successful" uninstall that silently
+        // left the integration running.
+        let temp = TempDir::new().unwrap();
+        let codex_dir = temp.path();
+        let hooks_path = codex_dir.join(HOOKS_JSON);
+        fs::write(
+            &hooks_path,
+            r#"{"hooks":{"PostToolUse":[{"matcher":"Edit","hooks":[{"command":"./fmt.sh"}]}]}}"#,
+        )
+        .unwrap();
+        assert!(patch_codex_hooks_json(&hooks_path, InitContext::default()).unwrap());
+
+        let removed = uninstall_codex_at(codex_dir, InitContext::default()).unwrap();
+        assert!(
+            removed.iter().any(|r| r.contains("hooks.json")),
+            "uninstall must report the hook removal: {removed:?}"
+        );
+
+        let root: serde_json::Value =
+            from_json_str(&fs::read_to_string(&hooks_path).unwrap()).unwrap();
+        assert!(
+            !codex_hook_already_present(&root),
+            "RTK hook must be gone after uninstall"
+        );
+        assert_eq!(
+            root["hooks"]["PostToolUse"][0]["hooks"][0]["command"], "./fmt.sh",
+            "unrelated handlers must survive uninstall"
+        );
+        assert!(
+            root["hooks"].get(PRE_TOOL_USE_KEY).is_none(),
+            "an emptied PreToolUse list must not be left behind"
+        );
+    }
+
+    #[test]
+    fn test_uninstall_codex_removes_hooks_file_it_created() {
+        // If RTK created hooks.json, uninstall should leave no fossil behind.
+        let temp = TempDir::new().unwrap();
+        let codex_dir = temp.path();
+        let hooks_path = codex_dir.join(HOOKS_JSON);
+        assert!(patch_codex_hooks_json(&hooks_path, InitContext::default()).unwrap());
+
+        uninstall_codex_at(codex_dir, InitContext::default()).unwrap();
+        assert!(!hooks_path.exists(), "empty hooks.json should be removed");
+    }
+
+    #[test]
+    fn test_uninstall_codex_leaves_foreign_file_untouched() {
+        let temp = TempDir::new().unwrap();
+        let hooks_path = temp.path().join(HOOKS_JSON);
+        let original = r#"{"hooks":{"Stop":[{"hooks":[{"command":"./x.sh"}]}]}}"#;
+        fs::write(&hooks_path, original).unwrap();
+
+        assert!(!remove_codex_hook_entry(&hooks_path, InitContext::default()).unwrap());
+        assert_eq!(
+            fs::read_to_string(&hooks_path).unwrap(),
+            original,
+            "a file without RTK's hook must not be rewritten at all"
+        );
+    }
+
+    #[test]
+    fn test_uninstall_codex_hook_dry_run_writes_nothing() {
+        let temp = TempDir::new().unwrap();
+        let hooks_path = temp.path().join(HOOKS_JSON);
+        patch_codex_hooks_json(&hooks_path, InitContext::default()).unwrap();
+        let before = fs::read_to_string(&hooks_path).unwrap();
+
+        assert!(remove_codex_hook_entry(
+            &hooks_path,
+            InitContext {
+                dry_run: true,
+                ..Default::default()
+            }
+        )
+        .unwrap());
+        assert_eq!(before, fs::read_to_string(&hooks_path).unwrap());
     }
 
     #[test]

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -14,13 +14,14 @@ use crate::hooks::constants::{
 };
 
 use super::constants::{
-    BEFORE_TOOL_KEY, CLAUDE_DIR, CLAUDE_HOOK_COMMAND, CODEX_DIR, CURSOR_HOOK_COMMAND, DROID_DIR,
-    DROID_EXECUTE_MATCHER, DROID_HOME_ENV, DROID_HOOKS_FILE, DROID_HOOKS_SUBDIR,
-    DROID_HOOK_COMMAND, DROID_SETTINGS_FILE, GEMINI_HOOK_FILE, HERMES_DIR, HERMES_PLUGINS_SUBDIR,
-    HERMES_PLUGIN_INIT_FILE, HERMES_PLUGIN_MANIFEST_FILE, HERMES_PLUGIN_NAME, HOOKS_JSON,
-    HOOKS_SUBDIR, OMP_DIR, OMP_LOCAL_DIR, PI_AGENT_STATE_FILE, PI_CODING_AGENT_DIR_ENV, PI_DIR,
-    PI_EXTENSIONS_SUBDIR, PI_LOCAL_DIR, PI_PLUGIN_FILE, PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE,
-    SETTINGS_JSON, VIBE_BASH_MATCH, VIBE_DIR, VIBE_HOOKS_FILE, VIBE_HOOK_COMMAND, VIBE_HOOK_NAME,
+    BEFORE_TOOL_KEY, CLAUDE_DIR, CLAUDE_HOOK_COMMAND, CODEX_DIR, CODEX_HOOK_COMMAND,
+    CODEX_SHELL_MATCHER, CURSOR_HOOK_COMMAND, DROID_DIR, DROID_EXECUTE_MATCHER, DROID_HOME_ENV,
+    DROID_HOOKS_FILE, DROID_HOOKS_SUBDIR, DROID_HOOK_COMMAND, DROID_SETTINGS_FILE,
+    GEMINI_HOOK_FILE, HERMES_DIR, HERMES_PLUGINS_SUBDIR, HERMES_PLUGIN_INIT_FILE,
+    HERMES_PLUGIN_MANIFEST_FILE, HERMES_PLUGIN_NAME, HOOKS_JSON, HOOKS_SUBDIR, OMP_DIR,
+    OMP_LOCAL_DIR, PI_AGENT_STATE_FILE, PI_CODING_AGENT_DIR_ENV, PI_DIR, PI_EXTENSIONS_SUBDIR,
+    PI_LOCAL_DIR, PI_PLUGIN_FILE, PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE, SETTINGS_JSON,
+    VIBE_BASH_MATCH, VIBE_DIR, VIBE_HOOKS_FILE, VIBE_HOOK_COMMAND, VIBE_HOOK_NAME,
     VIBE_PROMPTS_SUBDIR, VIBE_PROMPT_FILE,
 };
 use super::integrity;
@@ -2634,14 +2635,129 @@ fn normalized_yaml_scalar(value: &str) -> Option<String> {
 }
 
 fn run_codex_mode(global: bool, ctx: InitContext) -> Result<()> {
-    let (agents_md_path, rtk_md_path) = if global {
+    let (agents_md_path, rtk_md_path, hooks_path) = if global {
         let codex_dir = resolve_codex_dir()?;
-        (codex_dir.join(AGENTS_MD), codex_dir.join(RTK_MD))
+        (
+            codex_dir.join(AGENTS_MD),
+            codex_dir.join(RTK_MD),
+            codex_dir.join(HOOKS_JSON),
+        )
     } else {
-        (PathBuf::from(AGENTS_MD), PathBuf::from(RTK_MD))
+        (
+            PathBuf::from(AGENTS_MD),
+            PathBuf::from(RTK_MD),
+            PathBuf::from(CODEX_DIR).join(HOOKS_JSON),
+        )
     };
 
+    let hook_installed = patch_codex_hooks_json(&hooks_path, ctx)?;
+    if !ctx.dry_run {
+        let state = if hook_installed {
+            "installed"
+        } else {
+            "already present"
+        };
+        println!("  Hook:  {} ({state})", hooks_path.display());
+    }
+
     run_codex_mode_with_paths(agents_md_path, rtk_md_path, global, ctx)
+}
+
+/// Install RTK's `PreToolUse` handler into a Codex `hooks.json`.
+///
+/// Codex nests its events under a single top-level `hooks` key (unlike
+/// Antigravity's map of hook names), and merges every handler registered for an
+/// event. RTK appends one entry and must leave the rest of the file — a user's
+/// `PostToolUse` formatter, a `Stop` reviewer — untouched.
+///
+/// Returns `true` when the file was written, `false` on an idempotent re-run.
+fn patch_codex_hooks_json(path: &Path, ctx: InitContext) -> Result<bool> {
+    let InitContext {
+        verbose, dry_run, ..
+    } = ctx;
+
+    let mut root = if path.exists() {
+        let content = fs::read_to_string(path)
+            .with_context(|| format!("Failed to read {}", path.display()))?;
+        let content = strip_leading_bom(&content);
+        if content.trim().is_empty() {
+            serde_json::json!({})
+        } else {
+            from_json_str(content)
+                .with_context(|| format!("Failed to parse {} as JSON", path.display()))?
+        }
+    } else {
+        serde_json::json!({})
+    };
+
+    if codex_hook_already_present(&root) {
+        if verbose > 0 {
+            eprintln!("Codex hooks.json: RTK hook already present");
+        }
+        return Ok(false);
+    }
+
+    let hooks = root
+        .as_object_mut()
+        .with_context(|| format!("{} is not a JSON object", path.display()))?
+        .entry("hooks")
+        .or_insert_with(|| serde_json::json!({}));
+    let pre_tool_use = hooks
+        .as_object_mut()
+        .with_context(|| format!("{}: \"hooks\" is not a JSON object", path.display()))?
+        .entry(PRE_TOOL_USE_KEY)
+        .or_insert_with(|| serde_json::json!([]));
+    pre_tool_use
+        .as_array_mut()
+        .with_context(|| format!("{}: \"{PRE_TOOL_USE_KEY}\" is not an array", path.display()))?
+        .push(serde_json::json!({
+            "matcher": CODEX_SHELL_MATCHER,
+            "hooks": [
+                { "type": "command", "command": CODEX_HOOK_COMMAND, "timeout": 10 }
+            ]
+        }));
+
+    let serialized =
+        serde_json::to_string_pretty(&root).context("Failed to serialize hooks.json")?;
+
+    if dry_run {
+        println!("[dry-run] would patch Codex hooks.json: {}", path.display());
+        if verbose > 0 {
+            println!("[dry-run] content:\n{}", serialized);
+        }
+        return Ok(true);
+    }
+
+    if path.exists() {
+        let backup_path = path.with_extension("json.bak");
+        fs::copy(path, &backup_path)
+            .with_context(|| format!("Failed to backup to {}", backup_path.display()))?;
+        if verbose > 0 {
+            eprintln!("Backup: {}", backup_path.display());
+        }
+    } else if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create {}", parent.display()))?;
+    }
+
+    atomic_write(path, &serialized)?;
+
+    Ok(true)
+}
+
+fn codex_hook_already_present(root: &serde_json::Value) -> bool {
+    root.get("hooks")
+        .and_then(|hooks| hooks.get(PRE_TOOL_USE_KEY))
+        .and_then(|events| events.as_array())
+        .map(|events| {
+            events
+                .iter()
+                .filter_map(|group| group.get("hooks")?.as_array())
+                .flatten()
+                .filter_map(|handler| handler.get("command")?.as_str())
+                .any(|command| command == CODEX_HOOK_COMMAND)
+        })
+        .unwrap_or(false)
 }
 
 fn run_codex_mode_with_paths(
@@ -7702,6 +7818,66 @@ mod tests {
             "original",
             "dry-run must not modify file contents"
         );
+    }
+
+    #[test]
+    fn test_codex_hooks_json_preserves_other_events() {
+        // A real Codex user's hooks.json already carries PostToolUse/Stop
+        // handlers (the shipped design-detector skill installs both). Losing
+        // them silently disables their tooling.
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join(HOOKS_JSON);
+        fs::write(
+            &path,
+            r#"{"hooks":{"PostToolUse":[{"matcher":"Edit","hooks":[{"command":"./fmt.sh"}]}],
+                        "Stop":[{"hooks":[{"command":"./review.sh"}]}]}}"#,
+        )
+        .unwrap();
+
+        assert!(patch_codex_hooks_json(&path, InitContext::default()).unwrap());
+
+        let root: serde_json::Value = from_json_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(
+            root["hooks"]["PostToolUse"][0]["hooks"][0]["command"],
+            "./fmt.sh"
+        );
+        assert_eq!(
+            root["hooks"]["Stop"][0]["hooks"][0]["command"],
+            "./review.sh"
+        );
+        let entry = &root["hooks"]["PreToolUse"][0];
+        // Codex treats `matcher` as a regex and does not special-case a bare
+        // "*": a handler registered with "*" never fires (observed live).
+        assert_eq!(entry["matcher"], "Bash");
+        assert_eq!(entry["hooks"][0]["command"], "rtk hook codex");
+    }
+
+    #[test]
+    fn test_codex_hooks_json_install_is_idempotent() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join(HOOKS_JSON);
+
+        assert!(patch_codex_hooks_json(&path, InitContext::default()).unwrap());
+        let first = fs::read_to_string(&path).unwrap();
+        assert!(!patch_codex_hooks_json(&path, InitContext::default()).unwrap());
+        assert_eq!(first, fs::read_to_string(&path).unwrap());
+    }
+
+    #[test]
+    fn test_codex_hooks_json_dry_run_writes_nothing() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join(HOOKS_JSON);
+
+        patch_codex_hooks_json(
+            &path,
+            InitContext {
+                dry_run: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        assert!(!path.exists(), "dry-run must not create hooks.json");
     }
 
     #[test]

--- a/src/hooks/permissions.rs
+++ b/src/hooks/permissions.rs
@@ -38,6 +38,7 @@ pub enum Host {
     Gemini,
     Droid,
     Vibe,
+    Codex,
 }
 
 pub fn check_command_for(cmd: &str, host: Host) -> PermissionVerdict {
@@ -58,6 +59,11 @@ pub(crate) fn load_rules_for(host: Host) -> (Vec<String>, Vec<String>, Vec<Strin
         Host::Gemini => load_gemini_rules(),
         Host::Droid => load_droid_rules(),
         Host::Vibe => (Vec::new(), Vec::new(), Vec::new()),
+        // Codex gates commands through `approval_policy` and `sandbox_mode` in
+        // `config.toml`, not through a Bash allow/deny list, and it applies
+        // them itself after the hook returns. There is nothing here for RTK to
+        // mirror — defer to the host, like `Host::Vibe`.
+        Host::Codex => (Vec::new(), Vec::new(), Vec::new()),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -963,6 +963,8 @@ enum HookCommands {
     Droid,
     /// Process Mistral Vibe CLI pre_tool hook (reads JSON from stdin)
     Vibe,
+    /// Process Codex CLI PreToolUse hook (reads JSON from stdin)
+    Codex,
     /// Check how a command would be rewritten by the hook engine (dry-run)
     Check {
         /// Target agent
@@ -2786,6 +2788,10 @@ fn run_cli() -> Result<i32> {
             }
             HookCommands::Vibe => {
                 hooks::hook_cmd::run_vibe()?;
+                0
+            }
+            HookCommands::Codex => {
+                hooks::hook_cmd::run_codex()?;
                 0
             }
             HookCommands::Check { agent: _, command } => {


### PR DESCRIPTION
## Summary

- `hooks/codex/README.md` says Codex has *"Prompt-level guidance via awareness document -- no programmatic hook"*, so `rtk init --codex` only writes `AGENTS.md` + `RTK.md`. Codex ships a stable hook engine — this PR wires RTK into it.
- New `rtk hook codex`: reads the `PreToolUse` payload and answers with `permissionDecision: "allow"` + `updatedInput.command`.
- `rtk init [-g] --codex` installs the handler into `hooks.json` (`$CODEX_HOME/` or `.codex/`), and uninstall now removes it again.

Companion to #3959 (Antigravity), same shape, independent of it.

## Why I opened this

Same story as #3959: I use these CLIs daily, wanted RTK's savings in Codex, found nothing was intercepted, and traced it to an assumption in RTK's source rather than a bug.

```bash
codex features list | grep hooks     # → hooks   stable   true
```

Not experimental — stable and on by default. The engine lives in `codex-rs/hooks/`, with events `PreToolUse`, `PermissionRequest`, `PostToolUse`, `PreCompact`, `PostCompact`, `SessionStart`, `SessionEnd`, `UserPromptSubmit`, `SubagentStart`, `SubagentStop`, `Stop`, `Interrupt`, and a `/hooks` review UI.

## The good news: the parse side already works

Codex modelled its hooks on Claude Code's. A payload captured live from Codex 0.153.4 for `git status`:

```json
{
  "session_id": "01a08578-…", "turn_id": "01a08578-…",
  "cwd": "/path/to/workspace", "hook_event_name": "PreToolUse",
  "permission_mode": "bypassPermissions",
  "tool_name": "Bash", "tool_input": { "command": "git status" },
  "tool_use_id": "exec-7716f8ce-…"
}
```

`tool_name` + `tool_input.command` as a plain string — exactly what `process_claude_payload` already reads. That payload is checked into the tests verbatim.

## Why it still needs its own handler

The response side is validated strictly, and `rtk hook claude` fails it. Feeding the captured payload to the released binary gives:

```json
{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecisionReason":"RTK auto-rewrite","updatedInput":{"command":"rtk git status"}}}
```

No `permissionDecision` — because `process_claude_payload_from_decision` only sets it on the Allow branch, and `Host::Claude` returns Ask for anything not explicitly allowed. Codex rejects exactly that: *"PreToolUse hook returned updatedInput without permissionDecision:allow"*. Two more rules the handler respects: a deny needs a non-empty `permissionDecisionReason`, and `continue: false` / `stopReason` / `suppressOutput` are rejected as unsupported.

Rather than change `run_claude`'s behaviour for Claude Code users, this adds a Codex handler alongside the existing per-host ones.

## Judgment call

**A rewrite answers `allow`; no rewrite answers with silence.** `Host::Codex` carries no rules of its own (Codex gates commands through `approval_policy`/`sandbox_mode`, not a Bash allow-list), so every command lands on Ask/Defer. Since Codex only honours `updatedInput` together with `allow`, an Ask verdict cannot be expressed as "rewrite but still prompt". `allow` here means "RTK has no objection" — Codex still applies its own approval policy and sandbox to the rewritten call. Say the word if you'd rather have this behind a config toggle.

## Scope

Feature + its docs. Two things found while testing that are **not** in this diff:

- `src/hooks/hook_check.rs::status()` only inspects Claude Code, so `rtk gain` warns "No hook installed" at anyone whose agent is Codex, Antigravity, Gemini, Cursor or Droid. `other_integration_installed` already exists for this — but only under `#[cfg(test)]`, so production never calls it. Independent defect, separate PR.
- `HookCommands::Check` discards its `--agent` argument (`src/main.rs`), so `rtk hook check --agent anything` returns the generic rewrite. Also separate.

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets -- -D warnings && cargo test` — clean; 3411 tests pass, 25 of them Codex-related
- [x] `rtk hook codex` against the live captured payload → correct `permissionDecision` + `updatedInput`; non-`Bash` tools and non-rewritable commands produce no output
- [x] `rtk init --codex` appends to an existing `hooks.json` and leaves foreign `PostToolUse`/`Stop` handlers untouched; re-running does not duplicate
- [x] Uninstall removes the handler, prunes emptied containers, deletes a hooks.json that held only RTK's hook, and does not rewrite a file that never had it
- [x] End-to-end in Codex 0.153.4, interactive TUI and headless `codex exec`, with the handler installed: `git status` executed as `rtk git status`, exit 0

An earlier round of my own testing reported that Codex hangs on any hook rewrite. That did not reproduce under controlled conditions and I withdraw it — the rewrite path is fine in both TUI and headless.
