### PR TITLE
fix(gain): stop warning "No hook installed" at non-Claude agents

### DIFF
--- a/src/hooks/hook_check.rs
+++ b/src/hooks/hook_check.rs
@@ -1,7 +1,12 @@
 //! Detects whether RTK hooks are installed and warns if they are outdated.
 
-use super::constants::{HOOKS_SUBDIR, PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE, SETTINGS_JSON};
-use super::init::resolve_claude_dir;
+use super::constants::{
+    CODEX_DIR, CONFIG_DIR, CURSOR_DIR, DROID_DIR, GEMINI_DIR, GEMINI_HOOK_FILE, HERMES_DIR,
+    HERMES_PLUGINS_SUBDIR, HERMES_PLUGIN_MANIFEST_FILE, HERMES_PLUGIN_NAME, HOOKS_JSON,
+    HOOKS_SUBDIR, OPENCODE_PLUGIN_FILE, OPENCODE_SUBDIR, PLUGIN_SUBDIR, PRE_TOOL_USE_KEY,
+    REWRITE_HOOK_FILE, SETTINGS_JSON, VIBE_DIR, VIBE_HOOKS_FILE,
+};
+use super::init::{resolve_claude_dir, AGENTS_MD};
 use super::is_claude_hook_command;
 use crate::core::constants::RTK_DATA_DIR;
 use crate::core::utils::from_json_str;
@@ -46,6 +51,14 @@ pub fn status() -> HookStatus {
 
     // Fall back to legacy script file check
     let Some(hook_path) = hook_installed_path() else {
+        // No Claude hook — but a `~/.claude` directory only means Claude Code
+        // has been run on this machine, not that it is the agent in use. A user
+        // whose agent is Codex, Antigravity, Gemini, Cursor, Droid, Hermes or
+        // Vibe would otherwise be told "No hook installed" forever, with a fix
+        // (`rtk init -g`) that targets an agent they do not use.
+        if any_other_integration_installed().unwrap_or(false) {
+            return HookStatus::Ok;
+        }
         return HookStatus::Missing;
     };
     let Ok(content) = std::fs::read_to_string(&hook_path) else {
@@ -147,35 +160,57 @@ fn warn_marker_path() -> Option<PathBuf> {
     Some(data_dir.join(".hook_warn_last"))
 }
 
+/// Artifacts RTK writes when it integrates with an agent other than Claude
+/// Code, relative to the user's home directory.
+///
+/// Deliberately a list of *installed artifacts* rather than of *agents*: an
+/// agent being present on the machine says nothing about whether RTK is wired
+/// into it, and that is the only question `status` needs answered.
+fn other_integration_paths(home: &std::path::Path) -> [PathBuf; 8] {
+    [
+        // OpenCode / Pi-style TypeScript plugin
+        home.join(CONFIG_DIR)
+            .join(OPENCODE_SUBDIR)
+            .join(PLUGIN_SUBDIR)
+            .join(OPENCODE_PLUGIN_FILE),
+        // Cursor
+        home.join(CURSOR_DIR)
+            .join(HOOKS_SUBDIR)
+            .join(REWRITE_HOOK_FILE),
+        // Codex CLI
+        home.join(CODEX_DIR).join(AGENTS_MD),
+        home.join(CODEX_DIR).join(HOOKS_JSON),
+        // Gemini CLI
+        home.join(GEMINI_DIR)
+            .join(HOOKS_SUBDIR)
+            .join(GEMINI_HOOK_FILE),
+        // Hermes
+        home.join(HERMES_DIR)
+            .join(HERMES_PLUGINS_SUBDIR)
+            .join(HERMES_PLUGIN_NAME)
+            .join(HERMES_PLUGIN_MANIFEST_FILE),
+        // Factory Droid
+        home.join(DROID_DIR).join(HOOKS_JSON),
+        // Mistral Vibe
+        home.join(VIBE_DIR).join(VIBE_HOOKS_FILE),
+    ]
+}
+
+/// True when RTK is integrated with some agent other than Claude Code.
+fn other_integration_installed(home: &std::path::Path) -> bool {
+    other_integration_paths(home).iter().any(|p| p.exists())
+}
+
+/// Same question against the real home directory. `None` when the home
+/// directory cannot be resolved — the caller then has no evidence either way
+/// and must not treat that as "no other integration".
+fn any_other_integration_installed() -> Option<bool> {
+    Some(other_integration_installed(&dirs::home_dir()?))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::hooks::constants::{
-        CODEX_DIR, CONFIG_DIR, CURSOR_DIR, GEMINI_DIR, GEMINI_HOOK_FILE, HERMES_DIR,
-        HERMES_PLUGINS_SUBDIR, HERMES_PLUGIN_MANIFEST_FILE, HERMES_PLUGIN_NAME,
-        OPENCODE_PLUGIN_FILE, OPENCODE_SUBDIR, PLUGIN_SUBDIR,
-    };
-
-    fn other_integration_installed(home: &std::path::Path) -> bool {
-        let paths = [
-            home.join(CONFIG_DIR)
-                .join(OPENCODE_SUBDIR)
-                .join(PLUGIN_SUBDIR)
-                .join(OPENCODE_PLUGIN_FILE),
-            home.join(CURSOR_DIR)
-                .join(HOOKS_SUBDIR)
-                .join(REWRITE_HOOK_FILE),
-            home.join(CODEX_DIR).join("AGENTS.md"),
-            home.join(GEMINI_DIR)
-                .join(HOOKS_SUBDIR)
-                .join(GEMINI_HOOK_FILE),
-            home.join(HERMES_DIR)
-                .join(HERMES_PLUGINS_SUBDIR)
-                .join(HERMES_PLUGIN_NAME)
-                .join(HERMES_PLUGIN_MANIFEST_FILE),
-        ];
-        paths.iter().any(|p| p.exists())
-    }
 
     #[test]
     fn test_parse_hook_version_present() {
@@ -237,6 +272,64 @@ mod tests {
     #[test]
     fn test_other_integration_none() {
         let tmp = tempfile::tempdir().expect("tempdir");
+        assert!(!other_integration_installed(tmp.path()));
+    }
+
+    /// Covers every artifact `status` consults, so an integration added later
+    /// that forgets this list fails here rather than in a user's terminal.
+    #[test]
+    fn test_other_integration_detects_every_listed_artifact() {
+        for probe in other_integration_paths(std::path::Path::new("/probe")) {
+            let tmp = tempfile::tempdir().expect("tempdir");
+            let relative = probe
+                .strip_prefix("/probe")
+                .expect("paths are built from the home directory");
+            let path = tmp.path().join(relative);
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(&path, b"installed").unwrap();
+            assert!(
+                other_integration_installed(tmp.path()),
+                "{} must count as an installed integration",
+                relative.display()
+            );
+        }
+    }
+
+    #[test]
+    fn test_other_integration_droid_vibe_and_codex_hook() {
+        // Droid, Vibe and the Codex hook post-date the original list, so their
+        // users were told "No hook installed" indefinitely.
+        for relative in [
+            std::path::Path::new(DROID_DIR).join(HOOKS_JSON),
+            std::path::Path::new(VIBE_DIR).join(VIBE_HOOKS_FILE),
+            std::path::Path::new(CODEX_DIR).join(HOOKS_JSON),
+        ] {
+            let tmp = tempfile::tempdir().expect("tempdir");
+            let path = tmp.path().join(&relative);
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(&path, b"hook").unwrap();
+            assert!(
+                other_integration_installed(tmp.path()),
+                "{} must count as an installed integration",
+                relative.display()
+            );
+        }
+    }
+
+    #[test]
+    fn test_other_integration_ignores_unrelated_files() {
+        // Detection keys on RTK's own artifacts. An agent's config directory
+        // existing says nothing about whether RTK is wired into it.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        for relative in [
+            std::path::Path::new(CODEX_DIR).join("config.toml"),
+            std::path::Path::new(CURSOR_DIR).join("mcp.json"),
+            std::path::Path::new(GEMINI_DIR).join("settings.json"),
+        ] {
+            let path = tmp.path().join(relative);
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(&path, b"unrelated").unwrap();
+        }
         assert!(!other_integration_installed(tmp.path()));
     }
 

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -147,7 +147,7 @@ schema_version = 1
 
 const RTK_MD: &str = "RTK.md";
 const CLAUDE_MD: &str = "CLAUDE.md";
-const AGENTS_MD: &str = "AGENTS.md";
+pub(super) const AGENTS_MD: &str = "AGENTS.md";
 const RTK_MD_REF: &str = "@RTK.md";
 const GEMINI_MD: &str = "GEMINI.md";
 


### PR DESCRIPTION
## Summary

- `hook_check::status()` only inspects Claude Code, so `rtk gain` tells anyone on Codex, Gemini, Cursor, Droid, Hermes or Vibe that no hook is installed — forever — while their integration is working fine.
- `other_integration_installed` already existed for exactly this, but only under `#[cfg(test)]`. Production never called it.
- This promotes it, has `status()` consult it before reporting `Missing`, and adds the integrations that appeared after it was written.

## The bug, as a user sees it

```
$ rtk gain
[rtk] /!\ No hook installed — run `rtk init -g` for automatic token savings
```

The hook *is* installed — just not for Claude Code. `status()` resolves `~/.claude`, finds no RTK hook there, and reports `Missing`. But a `~/.claude` directory only means Claude Code has been run on this machine at some point; it says nothing about which agent the user actually works in. The suggested remedy (`rtk init -g`) targets an agent they may not use, so following it does not clear the warning either.

Measured on a machine with the Gemini hook installed and no Claude hook:

```
released 0.48.0 → [rtk] /!\ No hook installed — run `rtk init -g` …
this build      → (nothing)
```

## Why the tests did not catch it

`other_integration_installed` sat inside the `#[cfg(test)]` module with four green tests behind it. Those tests only ever proved that a helper nothing calls behaves correctly. Moving it into production is most of this diff.

While moving it I checked the list against the integrations RTK actually ships today: **Factory Droid** (`~/.factory/hooks.json`) and **Mistral Vibe** (`~/.vibe/hooks.toml`) were missing, so their users were in exactly the same position. Codex's `hooks.json` is listed alongside its `AGENTS.md`.

## Design notes

**Detection keys on RTK's own artifacts, not on agents being present.** A machine with Codex installed but RTK not wired into it should still get the warning — that user genuinely has no hook. `test_other_integration_ignores_unrelated_files` pins this: dropping `~/.codex/config.toml`, `~/.cursor/mcp.json` and `~/.gemini/settings.json` into a home directory does not count as an integration.

**A new test walks the artifact list itself** (`test_other_integration_detects_every_listed_artifact`), so an integration added later that forgets to register here fails in CI rather than in a user's terminal — which is how this drifted in the first place.

**`any_other_integration_installed` returns `Option<bool>`** so an unresolvable home directory stays distinguishable from a resolved one with nothing in it. The caller treats "don't know" as "keep the existing behaviour" rather than silently suppressing the warning.

`AGENTS_MD` moved from a private const in `init.rs` to `pub(super)` so `hook_check` can share it instead of re-declaring the literal.

## Scope

Only the false warning. Not touched, found while working here and happy to send separately: `HookCommands::Check` discards its `--agent` argument in `src/main.rs`, so `rtk hook check --agent anything` returns the generic rewrite regardless of the agent named.

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets -- -D warnings && cargo test` — clean; 3398 tests pass
- [x] New: every artifact in the detection list is exercised; Droid/Vibe/Codex-hook regressions pinned; unrelated agent config files confirmed not to count
- [x] Manual: `rtk gain` on a machine with a Gemini hook and no Claude hook — released binary warns, this build does not
