### PR TITLE
fix(ruff): recognize current format --check wording

### DIFF
--- a/src/cmds/python/ruff_cmd.rs
+++ b/src/cmds/python/ruff_cmd.rs
@@ -259,6 +259,7 @@ pub fn filter_ruff_check_json(output: &str) -> String {
 
 /// Filter ruff format output - show files that need formatting
 pub fn filter_ruff_format(output: &str) -> String {
+    let output = crate::core::utils::strip_ansi(output);
     let mut files_to_format: Vec<String> = Vec::new();
     let mut files_checked = 0;
 
@@ -266,51 +267,51 @@ pub fn filter_ruff_format(output: &str) -> String {
         let trimmed = line.trim();
         let lower = trimmed.to_lowercase();
 
-        // Count "would reformat" lines (check mode) - case insensitive
-        if lower.contains("would reformat:") {
-            // Extract filename from "Would reformat: path/to/file.py"
-            if let Some(filename) = trimmed.split(':').nth(1) {
-                files_to_format.push(filename.trim().to_string());
+        // Pre-0.12: "Would reformat: path/to/file.py"
+        // Current:   "unformatted: path/to/file.py" (or a diagnostic message after the colon)
+        if lower.contains("would reformat:") || lower.starts_with("unformatted:") {
+            if let Some(filename) = path_after_first_colon(trimmed) {
+                push_unique_file(&mut files_to_format, filename);
             }
         }
 
-        // Count total checked files - look for patterns like "3 files left unchanged"
-        if lower.contains("left unchanged") {
-            // Find "X file(s) left unchanged" pattern specifically
-            // Split by comma to handle "2 files would be reformatted, 3 files left unchanged"
-            let parts: Vec<&str> = trimmed.split(',').collect();
-            for part in parts {
-                let part_lower = part.to_lowercase();
-                if part_lower.contains("left unchanged") {
-                    let words: Vec<&str> = part.split_whitespace().collect();
-                    // Look for number before "file" or "files"
-                    for (i, word) in words.iter().enumerate() {
-                        if (word == &"file" || word == &"files") && i > 0 {
-                            if let Ok(count) = words[i - 1].parse::<usize>() {
-                                files_checked = count;
-                                break;
-                            }
-                        }
-                    }
-                    break;
-                }
-            }
+        // Default ruff ≥0.12 full format: " --> src/main.py:1:1"
+        if let Some(filename) = path_from_arrow_location(trimmed) {
+            push_unique_file(&mut files_to_format, filename);
+        }
+
+        // Concise format: "src/main.py:1:1: unformatted: File would be reformatted"
+        if let Some(filename) = path_from_concise_unformatted(trimmed, &lower) {
+            push_unique_file(&mut files_to_format, filename);
+        }
+
+        // Pre-0.12 / write mode: "3 files left unchanged"
+        // Current check:         "3 files already formatted"
+        if let Some(count) = parse_already_ok_count(trimmed, &lower) {
+            files_checked = count;
         }
     }
 
     let output_lower = output.to_lowercase();
+    let saw_ok_summary = output_lower.contains("left unchanged")
+        || output_lower.contains("already formatted");
+    // "would reformat" does not match "would be reformatted" — keep both.
+    let saw_check_rewrite = output_lower.contains("would reformat:")
+        || output_lower.contains("unformatted:")
+        || output_lower.contains("would be reformatted");
 
     // Check if all files are formatted
-    if files_to_format.is_empty() && output_lower.contains("left unchanged") {
+    if files_to_format.is_empty() && saw_ok_summary && !saw_check_rewrite {
         return "Ruff format: All files formatted correctly".to_string();
     }
 
     let mut result = String::new();
 
-    if output_lower.contains("would reformat") {
+    if saw_check_rewrite {
         // Check mode: show files that need formatting
         if files_to_format.is_empty() {
-            result.push_str("Ruff format: All files formatted correctly\n");
+            result.push_str("Ruff format: files need formatting\n");
+            result.push_str("\n[hint] Run `ruff format` to format these files\n");
         } else {
             result.push_str(&format!(
                 "Ruff format: {} files need formatting\n",
@@ -345,6 +346,78 @@ pub fn filter_ruff_format(output: &str) -> String {
     }
 
     result.trim().to_string()
+}
+
+/// Split after the first colon so `unformatted: C:\foo\bar.py` keeps the drive letter.
+fn path_after_first_colon(line: &str) -> Option<String> {
+    let rest = line.split_once(':')?.1.trim();
+    looks_like_source_path(rest).then(|| rest.to_string())
+}
+
+fn looks_like_source_path(s: &str) -> bool {
+    if s.is_empty() {
+        return false;
+    }
+    let has_sep = s.contains('/') || s.contains('\\');
+    if s.contains(' ') && !has_sep {
+        return false;
+    }
+    has_sep || s.contains('.')
+}
+
+/// ` --> src/main.py:1:1` from ruff's default `full` format --check output.
+fn path_from_arrow_location(line: &str) -> Option<String> {
+    let rest = line.trim().strip_prefix("-->")?.trim();
+    strip_trailing_line_col(rest).map(str::to_string)
+}
+
+/// `src/main.py:1:1: unformatted: File would be reformatted`
+fn path_from_concise_unformatted(line: &str, lower: &str) -> Option<String> {
+    let idx = lower.find(": unformatted:")?;
+    strip_trailing_line_col(line[..idx].trim()).map(str::to_string)
+}
+
+fn strip_trailing_line_col(s: &str) -> Option<&str> {
+    let mut parts = s.rsplitn(3, ':');
+    let col = parts.next()?;
+    let row = parts.next()?;
+    let path = parts.next()?;
+    if !row.is_empty()
+        && !col.is_empty()
+        && row.chars().all(|c| c.is_ascii_digit())
+        && col.chars().all(|c| c.is_ascii_digit())
+    {
+        Some(path)
+    } else {
+        None
+    }
+}
+
+fn parse_already_ok_count(trimmed: &str, lower: &str) -> Option<usize> {
+    if !lower.contains("left unchanged") && !lower.contains("already formatted") {
+        return None;
+    }
+    for part in trimmed.split(',') {
+        let part_lower = part.to_lowercase();
+        if !part_lower.contains("left unchanged") && !part_lower.contains("already formatted") {
+            continue;
+        }
+        let words: Vec<&str> = part.split_whitespace().collect();
+        for (i, word) in words.iter().enumerate() {
+            if (*word == "file" || *word == "files") && i > 0 {
+                if let Ok(count) = words[i - 1].parse::<usize>() {
+                    return Some(count);
+                }
+            }
+        }
+    }
+    None
+}
+
+fn push_unique_file(files: &mut Vec<String>, filename: String) {
+    if !files.iter().any(|existing| existing == &filename) {
+        files.push(filename);
+    }
 }
 
 /// Compact file path (remove common prefixes)
@@ -477,6 +550,82 @@ mod tests {
         let output = r#"Would reformat: src/main.py
 Would reformat: tests/test_utils.py
 2 files would be reformatted, 3 files left unchanged"#;
+        let result = filter_ruff_format(output);
+        assert!(result.contains("2 files need formatting"));
+        assert!(result.contains("main.py"));
+        assert!(result.contains("test_utils.py"));
+        assert!(result.contains("3 files already formatted"));
+    }
+
+    /// ruff ≥0.12 `format --check` when every file is already clean.
+    #[test]
+    fn test_filter_ruff_format_all_formatted_current_check() {
+        let output = "5 files already formatted";
+        let result = filter_ruff_format(output);
+        assert!(result.contains("Ruff format"));
+        assert!(result.contains("All files formatted correctly"));
+    }
+
+    /// ruff ≥0.12 per-file line is `unformatted: <path>` (split after first colon).
+    #[test]
+    fn test_filter_ruff_format_needs_formatting_current_check_paths() {
+        let output = r#"unformatted: src/main.py
+unformatted: tests/test_utils.py
+unformatted: C:\Users\foo\project\src\legacy.py
+3 files would be reformatted, 3 files already formatted"#;
+        let result = filter_ruff_format(output);
+        assert!(result.contains("3 files need formatting"));
+        assert!(result.contains("main.py"));
+        assert!(result.contains("test_utils.py"));
+        assert!(result.contains("legacy.py"), "split after first colon must keep the Windows path");
+        assert!(result.contains("3 files already formatted"));
+        assert!(result.contains("[hint] Run `ruff format`"));
+    }
+
+    /// Default ruff 0.16.x `format --check` (full diagnostic + summary).
+    /// This is the wording that currently falls through to identity (0% savings).
+    #[test]
+    fn test_filter_ruff_format_needs_formatting_current_check_full() {
+        let output = r#"unformatted: File would be reformatted
+ --> src/main.py:1:1
+  |
+1 | import   os
+1 + import os
+  |
+
+unformatted: File would be reformatted
+ --> tests/test_utils.py:3:1
+  |
+3 | def  bad( x ):
+3 + def bad(x):
+  |
+
+2 files would be reformatted, 3 files already formatted"#;
+        let result = filter_ruff_format(output);
+        assert!(
+            result.contains("2 files need formatting"),
+            "current ruff check output should compress, got:\n{result}"
+        );
+        assert!(result.contains("main.py"));
+        assert!(result.contains("test_utils.py"));
+        assert!(!result.contains("import   os"), "must drop the diagnostic diff");
+        assert!(result.contains("3 files already formatted"));
+
+        let raw_tokens = output.split_whitespace().count();
+        let out_tokens = result.split_whitespace().count();
+        let savings = 100.0 - (out_tokens as f64 / raw_tokens as f64) * 100.0;
+        assert!(
+            savings >= 20.0,
+            "current ruff check path must compress: {savings:.1}%"
+        );
+    }
+
+    /// ruff ≥0.12 `--output-format concise`.
+    #[test]
+    fn test_filter_ruff_format_needs_formatting_current_check_concise() {
+        let output = r#"src/main.py:1:1: unformatted: File would be reformatted
+tests/test_utils.py:3:1: unformatted: File would be reformatted
+2 files would be reformatted, 3 files already formatted"#;
         let result = filter_ruff_format(output);
         assert!(result.contains("2 files need formatting"));
         assert!(result.contains("main.py"));


### PR DESCRIPTION
## Summary

- `rtk ruff format --check` compressed nothing on ruff 0.12+ because `filter_ruff_format` only matched pre-0.12 wording (`Would reformat:` / `left unchanged`).
- Current ruff (verified on 0.16.6) emits `unformatted:` per file and `N files already formatted` as the summary, plus a full diagnostic. Neither old branch fired, so the filter fell through to identity (0% savings).
- Write mode still says `left unchanged` and was already fine; only the `--check` path was dead.

**Root cause:** substring checks were too specific. `"would reformat"` does not match `"would be reformatted"`, and `"left unchanged"` does not match `"already formatted"`.

**Fix:** recognize both generations of wording. Parse `unformatted: <path>` by splitting after the first colon (Windows-safe). Also collect paths from the default full diagnostic and from `--output-format concise`. Keep the pre-0.12 fixtures green.

Fixes #3930

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test --all`
- [x] Unit fixtures: pre-0.12 plus current check output (`unformatted:`, full diagnostic, concise, `already formatted`)

## Notes

- Draft PR #3912 (cosmetic rename) was not stacked; rebase if it lands first.
- Authored by Cestercian. Prepared with Cursor/AI assistance; no AI co-author trailer.

> All PRs must target `develop` (not `master`). See CONTRIBUTING.md.