### PR TITLE
fix(ruff): route flag-first implicit check invocations to check (#3927)

### DIFF
--- a/src/cmds/python/ruff_cmd.rs
+++ b/src/cmds/python/ruff_cmd.rs
@@ -114,9 +114,21 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
 }
 
 fn is_check_invocation(args: &[String]) -> bool {
-    args.first().is_none_or(|arg| {
-        arg == "check" || (!arg.starts_with('-') && !RUFF_SUBCOMMANDS.contains(&arg.as_str()))
-    })
+    // The first non-flag argument names the subcommand. Leading global flags
+    // (--select, --fix, -q, ...) belong to `ruff check` rather than `ruff`, so
+    // bailing on the first `-` defeated implicit-check routing (see #3927).
+    let first_positional = args.iter().find(|arg| !arg.starts_with('-'));
+
+    match first_positional {
+        Some(arg) => arg == "check" || !RUFF_SUBCOMMANDS.contains(&arg.as_str()),
+        None => {
+            // No positional argument: `--version`/`-V`/`--help`/`-h` stay
+            // top-level; every other flag-only invocation is an implicit check.
+            !args
+                .iter()
+                .any(|arg| matches!(arg.as_str(), "--version" | "-V" | "--help" | "-h"))
+        }
+    }
 }
 
 /// Filter ruff check JSON output - group by rule and file
@@ -414,6 +426,25 @@ mod tests {
     fn top_level_flags_are_not_misclassified_as_paths() {
         assert!(!is_check_invocation(&["--version".to_string()]));
         assert!(!is_check_invocation(&["--help".to_string()]));
+        assert!(!is_check_invocation(&["-V".to_string()]));
+        assert!(!is_check_invocation(&["-h".to_string()]));
+    }
+
+    #[test]
+    fn flag_first_implicit_check_routes_to_check() {
+        assert!(is_check_invocation(&[
+            "--select".to_string(),
+            "F401".to_string(),
+            "src".to_string()
+        ]));
+        assert!(is_check_invocation(&["--fix".to_string(), "src".to_string()]));
+        assert!(is_check_invocation(&["-q".to_string(), "src".to_string()]));
+    }
+
+    #[test]
+    fn flag_only_implicit_check_routes_to_check() {
+        assert!(is_check_invocation(&["--fix".to_string()]));
+        assert!(is_check_invocation(&["--statistics".to_string()]));
     }
 
     #[test]


### PR DESCRIPTION
Closes #3927

## Problem

`rtk ruff --select F401 src` (a flag-first implicit `check`) exits 2 with no output because `is_check_invocation` bails on any leading `-`. The flag is forwarded verbatim to `ruff`, which rejects it because `--select` belongs to `ruff check`, not `ruff`. The error lands on stderr (dropped by the ruff filter), so the user sees nothing.

Repro (ruff 0.16.6, LC_ALL=C):

```
rtk ruff --select F401 src
# <empty>, exit 2
```

Same for `--fix src`, `--statistics src`, `-q src`.

## Fix

Change `is_check_invocation` to find the first non-flag argument (skipping leading global flags) and route on that:

- first positional is `check`, or is not a known subcommand → implicit `check`
- otherwise → that subcommand

When there is no positional argument at all, only the genuinely top-level flags (`--version`/`-V`/`--help`/`-h`) stay top-level; every other flag-only invocation (`rtk ruff --fix`) is treated as an implicit check.

## Tests

- extended `top_level_flags_are_not_misclassified_as_paths` with `-V`/`-h`
- `flag_first_implicit_check_routes_to_check` — `--select F401 src`, `--fix src`, `-q src`
- `flag_only_implicit_check_routes_to_check` — `--fix`, `--statistics`

Existing routing tests (`known_ruff_subcommands_do_not_route_through_check`, `paths_and_explicit_check_route_through_check`) are unchanged and still pass. `cargo fmt --check` and `cargo clippy --all-targets` clean; 19 ruff tests pass.

Verified end-to-end: `rtk ruff --select F401 <dir>` now emits the ruled/filed summary (was empty exit 2), and `rtk ruff --version` still prints the version top-level.