### PR TITLE
fix(tracking): preserve negative saved token totals

### DIFF
--- a/src/analytics/cc_economics.rs
+++ b/src/analytics/cc_economics.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 
 use super::ccusage::{self, CcusagePeriod, Granularity};
 use crate::core::tracking::{DayStats, MonthStats, Tracker, WeekStats};
-use crate::core::utils::{format_cpt, format_tokens, format_usd};
+use crate::core::utils::{format_cpt, format_signed_tokens, format_tokens, format_usd};
 
 // ── Constants ──
 
@@ -36,7 +36,7 @@ pub struct PeriodEconomics {
     pub cc_cache_read_tokens: Option<u64>,
     // rtk metrics
     pub rtk_commands: Option<usize>,
-    pub rtk_saved_tokens: Option<usize>,
+    pub rtk_saved_tokens: Option<i64>,
     pub rtk_savings_pct: Option<f64>,
     // Primary metric (weighted input CPT)
     pub weighted_input_cpt: Option<f64>, // Derived input CPT using API ratios
@@ -103,7 +103,9 @@ impl PeriodEconomics {
         self.rtk_saved_tokens = Some(stats.saved_tokens);
         self.rtk_savings_pct = Some(if stats.input_tokens + stats.output_tokens > 0 {
             stats.saved_tokens as f64
-                / (stats.saved_tokens + stats.input_tokens + stats.output_tokens) as f64
+                / (stats.saved_tokens as f64
+                    + stats.input_tokens as f64
+                    + stats.output_tokens as f64)
                 * 100.0
         } else {
             0.0
@@ -167,7 +169,7 @@ struct Totals {
     cc_cache_create_tokens: u64,
     cc_cache_read_tokens: u64,
     rtk_commands: usize,
-    rtk_saved_tokens: usize,
+    rtk_saved_tokens: i64,
     rtk_avg_savings_pct: f64,
     weighted_input_cpt: Option<f64>,
     savings_weighted: Option<f64>,
@@ -469,7 +471,7 @@ fn display_summary(tracker: &Tracker, verbose: u8) -> Result<()> {
     println!("  RTK commands:                 {}", totals.rtk_commands);
     println!(
         "  Tokens saved:                 {}",
-        format_tokens(totals.rtk_saved_tokens)
+        format_signed_tokens(totals.rtk_saved_tokens)
     );
     println!();
 
@@ -599,7 +601,7 @@ fn print_period_table(periods: &[PeriodEconomics], verbose: u8) {
             let spent = p.cc_cost.map(format_usd).unwrap_or_else(|| "—".to_string());
             let saved = p
                 .rtk_saved_tokens
-                .map(format_tokens)
+                .map(format_signed_tokens)
                 .unwrap_or_else(|| "—".to_string());
             let weighted = p
                 .savings_weighted
@@ -638,7 +640,7 @@ fn print_period_table(periods: &[PeriodEconomics], verbose: u8) {
             let spent = p.cc_cost.map(format_usd).unwrap_or_else(|| "—".to_string());
             let saved = p
                 .rtk_saved_tokens
-                .map(format_tokens)
+                .map(format_signed_tokens)
                 .unwrap_or_else(|| "—".to_string());
             let weighted = p
                 .savings_weighted

--- a/src/analytics/gain.rs
+++ b/src/analytics/gain.rs
@@ -2,7 +2,7 @@
 
 use crate::core::display_helpers::{format_duration, print_period_table};
 use crate::core::tracking::{DayStats, MonthStats, Tracker, WeekStats};
-use crate::core::utils::{format_tokens, truncate};
+use crate::core::utils::{format_signed_tokens, format_tokens, truncate};
 use crate::hooks::hook_check;
 use anyhow::{Context, Result};
 use chrono::Local;
@@ -122,7 +122,7 @@ pub fn run(
             "Tokens saved",
             format!(
                 "{} ({:.1}%)",
-                format_tokens(summary.total_saved),
+                format_signed_tokens(summary.total_saved),
                 summary.avg_savings_pct
             ),
         );
@@ -192,7 +192,7 @@ pub fn run(
             let saved_width = summary
                 .by_command
                 .iter()
-                .map(|(_, _, saved, _, _)| format_tokens(*saved).len())
+                .map(|(_, _, saved, _, _)| format_signed_tokens(*saved).len())
                 .max()
                 .unwrap_or(5)
                 .max(5);
@@ -231,6 +231,7 @@ pub fn run(
                 .by_command
                 .iter()
                 .map(|(_, _, saved, _, _)| *saved)
+                .filter(|saved| *saved > 0)
                 .max()
                 .unwrap_or(1);
 
@@ -240,7 +241,7 @@ pub fn run(
                 let count_cell = format!("{:>count_width$}", count, count_width = count_width);
                 let saved_cell = format!(
                     "{:>saved_width$}",
-                    format_tokens(*saved),
+                    format_signed_tokens(*saved),
                     saved_width = saved_width
                 );
                 let pct_plain = format!("{:>6}", format!("{pct:.1}%"));
@@ -283,13 +284,18 @@ pub fn run(
                     } else {
                         "•"
                     };
+                    let savings_pct = if rec.savings_pct >= 0.0 {
+                        format!("-{:.0}%", rec.savings_pct)
+                    } else {
+                        format!("{:.0}%", rec.savings_pct)
+                    };
                     println!(
-                        "{} {} {:<25} -{:.0}% ({})",
+                        "{} {} {:<25} {} ({})",
                         time,
                         sign,
                         cmd_short,
-                        rec.savings_pct,
-                        format_tokens(rec.saved_tokens)
+                        savings_pct,
+                        format_signed_tokens(rec.saved_tokens)
                     );
                 }
                 println!();
@@ -314,7 +320,7 @@ pub fn run(
             print_kpi("Estimated monthly quota", format_tokens(quota_tokens));
             print_kpi(
                 "Tokens saved (lifetime)",
-                format_tokens(summary.total_saved),
+                format_signed_tokens(summary.total_saved),
             );
             print_kpi("Quota preserved", format!("{:.1}%", quota_pct));
             println!();
@@ -400,8 +406,8 @@ fn style_command_cell(cmd: &str) -> String {
 }
 
 /// Render a proportional bar chart segment (TTY-aware). // added
-fn mini_bar(value: usize, max: usize, width: usize) -> String {
-    if max == 0 || width == 0 {
+fn mini_bar(value: i64, max: i64, width: usize) -> String {
+    if value <= 0 || max <= 0 || width == 0 {
         return String::new();
     }
     let filled = ((value as f64 / max as f64) * width as f64).round() as usize;
@@ -575,18 +581,23 @@ fn shorten_path(path: &str) -> String {
     }
 }
 
-fn print_ascii_graph(data: &[(String, usize)]) {
+fn print_ascii_graph(data: &[(String, i64)]) {
     if data.is_empty() {
         return;
     }
 
-    let max_val = data.iter().map(|(_, v)| *v).max().unwrap_or(1);
+    let max_val = data
+        .iter()
+        .map(|(_, v)| *v)
+        .filter(|value| *value > 0)
+        .max()
+        .unwrap_or(1);
     let width = 40;
 
     for (date, value) in data {
         let date_short = if date.len() >= 10 { &date[5..10] } else { date };
 
-        let bar_len = if max_val > 0 {
+        let bar_len = if *value > 0 {
             ((*value as f64 / max_val as f64) * width as f64) as usize
         } else {
             0
@@ -600,7 +611,7 @@ fn print_ascii_graph(data: &[(String, usize)]) {
             date_short,
             bar,
             spaces,
-            format_tokens(*value)
+            format_signed_tokens(*value)
         );
     }
 }
@@ -642,7 +653,7 @@ struct ExportSummary {
     total_commands: usize,
     total_input: usize,
     total_output: usize,
-    total_saved: usize,
+    total_saved: i64,
     avg_savings_pct: f64,
     total_time_ms: u64,
     avg_time_ms: u64,

--- a/src/core/display_helpers.rs
+++ b/src/core/display_helpers.rs
@@ -4,7 +4,7 @@
 //! a unified trait-based system for displaying daily/weekly/monthly data.
 
 use crate::core::tracking::{DayStats, MonthStats, WeekStats};
-use crate::core::utils::format_tokens;
+use crate::core::utils::{format_signed_tokens, format_tokens};
 
 /// Format duration in milliseconds to human-readable string
 pub fn format_duration(ms: u64) -> String {
@@ -40,7 +40,7 @@ pub trait PeriodStats {
     fn output_tokens(&self) -> usize;
 
     /// Saved tokens in this period
-    fn saved_tokens(&self) -> usize;
+    fn saved_tokens(&self) -> i64;
 
     /// Savings percentage
     fn savings_pct(&self) -> f64;
@@ -100,7 +100,7 @@ pub fn print_period_table<T: PeriodStats>(data: &[T]) {
             period.commands(),
             format_tokens(period.input_tokens()),
             format_tokens(period.output_tokens()),
-            format_tokens(period.saved_tokens()),
+            format_signed_tokens(period.saved_tokens()),
             period.savings_pct(),
             format_duration(period.avg_time_ms()),
             width = period_width
@@ -111,7 +111,7 @@ pub fn print_period_table<T: PeriodStats>(data: &[T]) {
     let total_cmds: usize = data.iter().map(|d| d.commands()).sum();
     let total_input: usize = data.iter().map(|d| d.input_tokens()).sum();
     let total_output: usize = data.iter().map(|d| d.output_tokens()).sum();
-    let total_saved: usize = data.iter().map(|d| d.saved_tokens()).sum();
+    let total_saved: i64 = data.iter().map(|d| d.saved_tokens()).sum();
     let total_time: u64 = data.iter().map(|d| d.total_time_ms()).sum();
     let avg_pct = if total_input > 0 {
         (total_saved as f64 / total_input as f64) * 100.0
@@ -131,7 +131,7 @@ pub fn print_period_table<T: PeriodStats>(data: &[T]) {
         total_cmds,
         format_tokens(total_input),
         format_tokens(total_output),
-        format_tokens(total_saved),
+        format_signed_tokens(total_saved),
         avg_pct,
         format_duration(avg_time),
         width = period_width
@@ -166,7 +166,7 @@ impl PeriodStats for DayStats {
         self.output_tokens
     }
 
-    fn saved_tokens(&self) -> usize {
+    fn saved_tokens(&self) -> i64 {
         self.saved_tokens
     }
 
@@ -226,7 +226,7 @@ impl PeriodStats for WeekStats {
         self.output_tokens
     }
 
-    fn saved_tokens(&self) -> usize {
+    fn saved_tokens(&self) -> i64 {
         self.saved_tokens
     }
 
@@ -276,7 +276,7 @@ impl PeriodStats for MonthStats {
         self.output_tokens
     }
 
-    fn saved_tokens(&self) -> usize {
+    fn saved_tokens(&self) -> i64 {
         self.saved_tokens
     }
 

--- a/src/core/telemetry.rs
+++ b/src/core/telemetry.rs
@@ -730,13 +730,11 @@ mod tests {
             Ok(t) => t,
             Err(_) => return, // No DB — skip
         };
-        let (cmds, top, pct, saved_24h, saved_total) = get_stats(&tracker);
+        let (cmds, top, pct, _saved_24h, _saved_total) = get_stats(&tracker);
         assert!(cmds >= 0);
         assert!(top.len() <= 5);
-        assert!(saved_24h >= 0);
-        assert!(saved_total >= 0);
         if let Some(p) = pct {
-            assert!((0.0..=100.0).contains(&p));
+            assert!(p.is_finite());
         }
     }
 
@@ -750,7 +748,7 @@ mod tests {
         assert!(stats.passthrough_top.len() <= 5);
         assert!(stats.parse_failures_24h >= 0);
         assert!(stats.low_savings_commands.len() <= 5);
-        assert!((0.0..=100.0).contains(&stats.avg_savings_per_command));
+        assert!(stats.avg_savings_per_command.is_finite());
         assert!(
             ["claude", "gemini", "codex", "cursor", "copilot", "vibe", "none", "unknown"]
                 .iter()

--- a/src/core/tracking.rs
+++ b/src/core/tracking.rs
@@ -103,7 +103,7 @@ pub struct CommandRecord {
     /// RTK command that was executed (e.g., "rtk ls")
     pub rtk_cmd: String,
     /// Number of tokens saved (input - output)
-    pub saved_tokens: usize,
+    pub saved_tokens: i64,
     /// Savings percentage ((saved / input) * 100)
     pub savings_pct: f64,
 }
@@ -195,7 +195,7 @@ pub struct GainSummary {
     /// Total output tokens across all commands
     pub total_output: usize,
     /// Total tokens saved (input - output)
-    pub total_saved: usize,
+    pub total_saved: i64,
     /// Average savings percentage across all commands
     pub avg_savings_pct: f64,
     /// Total execution time across all commands (milliseconds)
@@ -203,9 +203,9 @@ pub struct GainSummary {
     /// Average execution time per command (milliseconds)
     pub avg_time_ms: u64,
     /// Top 10 commands by tokens saved: (cmd, count, saved, avg_pct, avg_time_ms)
-    pub by_command: Vec<(String, usize, usize, f64, u64)>,
+    pub by_command: Vec<(String, usize, i64, f64, u64)>,
     /// Last 30 days of activity: (date, saved_tokens)
-    pub by_day: Vec<(String, usize)>,
+    pub by_day: Vec<(String, i64)>,
 }
 
 /// Daily statistics for token savings and execution metrics.
@@ -237,7 +237,7 @@ pub struct DayStats {
     /// Total output tokens for this day
     pub output_tokens: usize,
     /// Total tokens saved this day
-    pub saved_tokens: usize,
+    pub saved_tokens: i64,
     /// Savings percentage for this day
     pub savings_pct: f64,
     /// Total execution time for this day (milliseconds)
@@ -263,7 +263,7 @@ pub struct WeekStats {
     /// Total output tokens for this week
     pub output_tokens: usize,
     /// Total tokens saved this week
-    pub saved_tokens: usize,
+    pub saved_tokens: i64,
     /// Savings percentage for this week
     pub savings_pct: f64,
     /// Total execution time for this week (milliseconds)
@@ -286,7 +286,7 @@ pub struct MonthStats {
     /// Total output tokens for this month
     pub output_tokens: usize,
     /// Total tokens saved this month
-    pub saved_tokens: usize,
+    pub saved_tokens: i64,
     /// Savings percentage for this month
     pub savings_pct: f64,
     /// Total execution time for this month (milliseconds)
@@ -296,7 +296,7 @@ pub struct MonthStats {
 }
 
 /// Type alias for command statistics tuple: (command, count, saved_tokens, avg_savings_pct, avg_time_ms)
-type CommandStats = (String, usize, usize, f64, u64);
+type CommandStats = (String, usize, i64, f64, u64);
 
 /// Current tracking-DB schema version, stored in the SQLite `user_version` pragma.
 ///
@@ -515,7 +515,13 @@ impl Tracker {
         output_tokens: usize,
         exec_time_ms: u64,
     ) -> Result<()> {
-        let saved = input_tokens.saturating_sub(output_tokens);
+        let input_tokens = i64::try_from(input_tokens)
+            .context("Input token count exceeds SQLite INTEGER range")?;
+        let output_tokens = i64::try_from(output_tokens)
+            .context("Output token count exceeds SQLite INTEGER range")?;
+        let saved = input_tokens
+            .checked_sub(output_tokens)
+            .context("Saved token difference exceeds SQLite INTEGER range")?;
         let pct = if input_tokens > 0 {
             (saved as f64 / input_tokens as f64) * 100.0
         } else {
@@ -532,9 +538,9 @@ impl Tracker {
                 original_cmd,
                 rtk_cmd,
                 project_path, // added
-                input_tokens as i64,
-                output_tokens as i64,
-                saved as i64,
+                input_tokens,
+                output_tokens,
+                saved,
                 pct,
                 exec_time_ms as i64
             ],
@@ -824,7 +830,7 @@ impl Tracker {
         let mut total_commands = 0usize;
         let mut total_input = 0usize;
         let mut total_output = 0usize;
-        let mut total_saved = 0usize;
+        let mut total_saved = 0i64;
         let mut total_time_ms = 0u64;
 
         let mut stmt = self.conn.prepare(
@@ -838,7 +844,7 @@ impl Tracker {
             Ok((
                 row.get::<_, i64>(0)? as usize,
                 row.get::<_, i64>(1)? as usize,
-                row.get::<_, i64>(2)? as usize,
+                row.get::<_, i64>(2)?,
                 row.get::<_, i64>(3)? as u64,
             ))
         })?;
@@ -848,7 +854,9 @@ impl Tracker {
             total_commands += 1;
             total_input += input;
             total_output += output;
-            total_saved += saved;
+            total_saved = total_saved
+                .checked_add(saved)
+                .context("Total saved tokens exceeds SQLite INTEGER range")?;
             total_time_ms += time_ms;
         }
 
@@ -899,7 +907,7 @@ impl Tracker {
             Ok((
                 row.get::<_, String>(0)?,
                 row.get::<_, i64>(1)? as usize,
-                row.get::<_, i64>(2)? as usize,
+                row.get::<_, i64>(2)?,
                 row.get::<_, f64>(3)?,
                 row.get::<_, f64>(4)? as u64,
             ))
@@ -911,7 +919,7 @@ impl Tracker {
     fn get_by_day(
         &self,
         project_path: Option<&str>, // added
-    ) -> Result<Vec<(String, usize)>> {
+    ) -> Result<Vec<(String, i64)>> {
         let (project_exact, project_glob) = project_filter_params(project_path); // added
         let mut stmt = self.conn.prepare(
             "SELECT DATE(timestamp), SUM(saved_tokens)
@@ -924,7 +932,7 @@ impl Tracker {
 
         let rows = stmt.query_map(params![project_exact, project_glob], |row| {
             // added: params
-            Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)? as usize))
+            Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
         })?;
 
         let mut result: Vec<_> = rows.collect::<Result<Vec<_>, _>>()?;
@@ -974,7 +982,7 @@ impl Tracker {
         let rows = stmt.query_map(params![project_exact, project_glob], |row| {
             // added: params
             let input = row.get::<_, i64>(2)? as usize;
-            let saved = row.get::<_, i64>(4)? as usize;
+            let saved = row.get::<_, i64>(4)?;
             let commands = row.get::<_, i64>(1)? as usize;
             let total_time = row.get::<_, i64>(5)? as u64;
             let savings_pct = if input > 0 {
@@ -1048,7 +1056,7 @@ impl Tracker {
         let rows = stmt.query_map(params![project_exact, project_glob], |row| {
             // added: params
             let input = row.get::<_, i64>(3)? as usize;
-            let saved = row.get::<_, i64>(5)? as usize;
+            let saved = row.get::<_, i64>(5)?;
             let commands = row.get::<_, i64>(2)? as usize;
             let total_time = row.get::<_, i64>(6)? as u64;
             let savings_pct = if input > 0 {
@@ -1122,7 +1130,7 @@ impl Tracker {
         let rows = stmt.query_map(params![project_exact, project_glob], |row| {
             // added: params
             let input = row.get::<_, i64>(2)? as usize;
-            let saved = row.get::<_, i64>(4)? as usize;
+            let saved = row.get::<_, i64>(4)?;
             let commands = row.get::<_, i64>(1)? as usize;
             let total_time = row.get::<_, i64>(5)? as u64;
             let savings_pct = if input > 0 {
@@ -1202,7 +1210,7 @@ impl Tracker {
                         .map(|dt| dt.with_timezone(&Utc))
                         .unwrap_or_else(|_| Utc::now()),
                     rtk_cmd: row.get(1)?,
-                    saved_tokens: row.get::<_, i64>(2)? as usize,
+                    saved_tokens: row.get(2)?,
                     savings_pct: row.get(3)?,
                 })
             },
@@ -1849,6 +1857,81 @@ mod tests {
 
         assert_eq!(test_record.saved_tokens, 80);
         assert_eq!(test_record.savings_pct, 80.0);
+    }
+
+    #[test]
+    fn test_legacy_negative_saved_tokens_are_preserved() {
+        let tracker = Tracker::new_in_memory().expect("Failed to create tracker");
+
+        tracker
+            .conn
+            .execute(
+                "INSERT INTO commands (timestamp, original_cmd, rtk_cmd, input_tokens, output_tokens, saved_tokens, savings_pct)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                params![
+                    Utc::now().to_rfc3339(),
+                    "legacy command",
+                    "rtk legacy command",
+                    100i64,
+                    151i64,
+                    -51i64,
+                    -51.0f64,
+                ],
+            )
+            .expect("Failed to insert legacy row");
+
+        let summary = tracker.get_summary().expect("Failed to get summary");
+        assert_eq!(summary.total_saved, -51);
+        assert_eq!(summary.avg_savings_pct, -51.0);
+        assert_eq!(summary.by_command[0].2, -51);
+        assert_eq!(summary.by_day[0].1, -51);
+
+        let days = tracker.get_all_days().expect("Failed to get days");
+        assert_eq!(days[0].saved_tokens, -51);
+        assert_eq!(days[0].savings_pct, -51.0);
+        assert!(serde_json::to_string(&days)
+            .expect("Failed to serialize days")
+            .contains("\"saved_tokens\":-51"));
+
+        let weeks = tracker.get_by_week().expect("Failed to get weeks");
+        assert_eq!(weeks[0].saved_tokens, -51);
+        assert_eq!(weeks[0].savings_pct, -51.0);
+
+        let months = tracker.get_by_month().expect("Failed to get months");
+        assert_eq!(months[0].saved_tokens, -51);
+        assert_eq!(months[0].savings_pct, -51.0);
+
+        let recent = tracker
+            .get_recent(1)
+            .expect("Failed to get recent commands");
+        assert_eq!(recent[0].saved_tokens, -51);
+        assert_eq!(recent[0].savings_pct, -51.0);
+    }
+
+    #[test]
+    fn test_record_preserves_negative_saved_tokens() {
+        let tracker = Tracker::new_in_memory().expect("Failed to create tracker");
+
+        tracker
+            .record("empty", "rtk empty", 0, 51, 10)
+            .expect("Failed to record command");
+
+        let saved: i64 = tracker
+            .conn
+            .query_row("SELECT saved_tokens FROM commands", [], |row| row.get(0))
+            .expect("Failed to read saved tokens");
+        assert_eq!(saved, -51);
+        assert_eq!(
+            tracker.get_recent(1).expect("Failed to get recent")[0].saved_tokens,
+            -51
+        );
+        assert_eq!(
+            tracker
+                .get_summary()
+                .expect("Failed to get summary")
+                .total_saved,
+            -51
+        );
     }
 
     // 4. track_passthrough doesn't dilute stats (input=0, output=0)

--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -128,6 +128,17 @@ pub fn format_tokens(n: usize) -> String {
     }
 }
 
+/// Formats a signed token delta with K/M suffixes while preserving its sign.
+pub fn format_signed_tokens(n: i64) -> String {
+    if n >= 1_000_000 || n <= -1_000_000 {
+        format!("{:.1}M", n as f64 / 1_000_000.0)
+    } else if n >= 1_000 || n <= -1_000 {
+        format!("{:.1}K", n as f64 / 1_000.0)
+    } else {
+        n.to_string()
+    }
+}
+
 /// Formats a USD amount with adaptive precision.
 ///
 /// # Arguments
@@ -946,6 +957,13 @@ mod tests {
     fn test_format_tokens_small() {
         assert_eq!(format_tokens(694), "694");
         assert_eq!(format_tokens(0), "0");
+    }
+
+    #[test]
+    fn test_format_signed_tokens() {
+        assert_eq!(format_signed_tokens(-51), "-51");
+        assert_eq!(format_signed_tokens(-59_234), "-59.2K");
+        assert_eq!(format_signed_tokens(i64::MIN), "-9223372036854.8M");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- preserve signed `saved_tokens` values from SQLite through tracking summaries, period stats, history, analytics, JSON/CSV, and terminal output
- record output-larger-than-input commands as negative savings rather than saturating to zero
- add safe signed token formatting and keep input/output token counts unsigned

## Regression coverage
- legacy SQLite row with `saved_tokens = -51` retains its value and percentage in summary, command/day/week/month, history, and JSON-facing stats
- a newly recorded `(input_tokens: 0, output_tokens: 51)` command persists `-51`
- verified equivalent regression assertions fail on the pre-fix revision

Resolves #3958