### PR TITLE
fix(git): pass through diff diagnostic modes like --check unfiltered (#3984)

### DIFF
--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -128,6 +128,39 @@ fn run_diff(
     // Check if user wants compact diff (default RTK behavior)
     let wants_compact = !args.iter().any(|arg| arg == "--no-compact") && !emits_word_diff(args);
 
+    // Diagnostic modes whose entire signal is on stdout (--check, --exit-code,
+    // --quiet, --no-patch) must pass through unfiltered. They exit non-zero
+    // when they find problems, so dropping their stdout turns a whitespace
+    // report into a silent failure (issue #3984).
+    if wants_diagnostic_output(args) {
+        let mut cmd = git_cmd(global_args);
+        cmd.arg("diff");
+        for arg in args {
+            if arg == "--no-compact" {
+                continue; // RTK flag, not a git flag
+            }
+            cmd.arg(arg);
+        }
+
+        let result = exec_capture(&mut cmd).context("Failed to run git diff")?;
+
+        if !result.stdout.is_empty() {
+            print!("{}", result.stdout);
+        }
+        if !result.stderr.trim().is_empty() {
+            eprint!("{}", result.stderr);
+        }
+
+        timer.track(
+            &format!("git diff {}", args.join(" ")),
+            &format!("rtk git diff {} (diagnostic)", args.join(" ")),
+            &result.stdout,
+            &result.stdout,
+        );
+
+        return Ok(result.exit_code);
+    }
+
     if wants_stat || !wants_compact {
         // User wants stat or explicitly no compacting - pass through directly
         let mut cmd = git_cmd(global_args);
@@ -360,6 +393,14 @@ fn emits_word_diff(args: &[String]) -> bool {
         }
     }
     word_diff
+}
+
+/// Diagnostic diff modes that produce a whitespace/violation report on stdout
+/// and exit non-zero when problems are found. rtk must not filter these.
+fn wants_diagnostic_output(args: &[String]) -> bool {
+    args.iter().any(|arg| {
+        arg == "--check" || arg == "--exit-code" || arg == "--quiet" || arg == "--no-patch"
+    })
 }
 
 fn is_blob_show_arg(arg: &str) -> bool {
@@ -2711,6 +2752,24 @@ mod tests {
         let cmd = git_cmd(&global_args);
         let args: Vec<_> = cmd.get_args().collect();
         assert_eq!(args, vec!["--no-pager", "--bare"]);
+    }
+
+    #[test]
+    fn test_wants_diagnostic_output_detects_diff_modes() {
+        for flag in ["--check", "--exit-code", "--quiet", "--no-patch"] {
+            assert!(
+                wants_diagnostic_output(&[flag.to_string()]),
+                "{flag} should be a diagnostic passthrough mode"
+            );
+        }
+    }
+
+    #[test]
+    fn test_wants_diagnostic_output_ignores_normal_diff_args() {
+        assert!(!wants_diagnostic_output(&["--stat".to_string()]));
+        assert!(!wants_diagnostic_output(&["--numstat".to_string()]));
+        assert!(!wants_diagnostic_output(&[]));
+        assert!(!wants_diagnostic_output(&["src/main.rs".to_string()]));
     }
 
     #[test]


### PR DESCRIPTION
Closes #3984

## Problem

`rtk git diff --check` emits no output at all — it silently discards every whitespace diagnostic. `git diff --check` is a diagnostic mode whose entire value is its stdout (one line per whitespace error, exit code 2). Under rtk, stdout was empty while exit 2 was preserved, so an agent or pre-commit script sees a failure with no reason attached.

Repro:

```
git --no-pager diff --check   # 4 lines of diagnostics, exit 2
rtk git diff --check          # 0 bytes, exit 2
```

## Fix

Treat `--check` (plus the sibling diagnostic modes `--exit-code`, `--quiet`, `--no-patch`) as pass-through modes in the `git diff` filter. A `wants_diagnostic_output` helper detects these flags, and `run_diff` routes them to a raw pass-through branch that emits stdout and stderr verbatim and preserves the exit code — no `--stat` rewrite and no compaction.

## Tests

- `test_wants_diagnostic_output_detects_diff_modes` — all four flags detected
- `test_wants_diagnostic_output_ignores_normal_diff_args` — `--stat`, `--numstat`, a path, and empty args are not diagnostic

`cargo fmt --check` and `cargo clippy --all-targets` clean; 478 git tests pass. Verified end-to-end: `rtk git diff --check` now prints the trailing-whitespace diagnostics and preserves exit code 2.