### PR TITLE
feat(js): add aube/aubr/aubx package manager support

### DIFF
--- a/docs/guide/resources/what-rtk-covers.md
+++ b/docs/guide/resources/what-rtk-covers.md
@@ -61,6 +61,9 @@ Every percentage below measures **bash output bytes removed** — the only thing
 | `eslint` | 84% | Violations grouped by rule |
 | `pnpm list` | 70-90% | Compact dependency tree |
 | `pnpm outdated` | 70% | Package + current + latest only |
+| `aube install` | 70% | Progress and banners stripped |
+| `aube test` / `aubr` | 70% | Script echo lines stripped |
+| `aube list` | 70% | Compact dependency tree |
 | `next build` | 80% | Route summary + errors only |
 | `prisma migrate` | 75% | Migration status only |
 | `playwright test` | 90% | Failures + trace links only |

--- a/src/cmds/js/aube_cmd.rs
+++ b/src/cmds/js/aube_cmd.rs
@@ -1,0 +1,161 @@
+//! Filters aube output — install logs and script runners.
+//!
+//! [aube](https://github.com/jdx/aube) is a Rust pnpm-compatible package manager.
+//! `aubr` / `aubx` are multicall shims for `aube run` and `aube dlx`.
+
+use crate::core::utils::{join_or_ok, resolved_command, strip_ansi};
+use anyhow::Result;
+use std::ffi::OsString;
+
+/// Filter aube install/ci/add output — strip banners and progress noise.
+pub fn filter_aube_pkg(output: &str) -> String {
+    let cleaned = strip_ansi(output);
+    let mut result = Vec::new();
+
+    for line in cleaned.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if trimmed.starts_with("aube ") && trimmed.contains("by jdx") {
+            continue;
+        }
+        if trimmed.starts_with("Auto-installing:") {
+            continue;
+        }
+        if trimmed.starts_with("Resolving")
+            || trimmed.starts_with("Downloading")
+            || trimmed.contains("Progress")
+            || trimmed.contains('│')
+        {
+            continue;
+        }
+        result.push(line);
+    }
+
+    join_or_ok(&result)
+}
+
+/// Filter script runner output (`aube test`, `aube run`) — strip echo lines.
+pub fn filter_aube_script(output: &str) -> String {
+    let cleaned = strip_ansi(output);
+    let mut result = Vec::new();
+
+    for line in cleaned.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if trimmed.starts_with("aube ") && trimmed.contains("by jdx") {
+            continue;
+        }
+        if trimmed.starts_with("Auto-installing:") {
+            continue;
+        }
+        if trimmed.starts_with("$ ") {
+            continue;
+        }
+        result.push(line);
+    }
+
+    join_or_ok(&result)
+}
+
+fn run_pkg_subcmd(subcmd: &str, args: &[String], verbose: u8, tee: &str) -> Result<i32> {
+    let mut cmd = resolved_command("aube");
+    cmd.arg(subcmd);
+    for arg in args {
+        cmd.arg(arg);
+    }
+    if verbose > 0 {
+        eprintln!("Running: aube {} {}", subcmd, args.join(" "));
+    }
+    let display = format!("{} {}", subcmd, args.join(" "));
+    crate::core::runner::run_filtered(
+        cmd,
+        "aube",
+        display.trim_end(),
+        filter_aube_pkg,
+        crate::core::runner::RunOptions::with_tee(tee),
+    )
+}
+
+pub fn run_install(args: &[String], verbose: u8) -> Result<i32> {
+    run_pkg_subcmd("install", args, verbose, "aube_install")
+}
+
+pub fn run_ci(args: &[String], verbose: u8) -> Result<i32> {
+    run_pkg_subcmd("ci", args, verbose, "aube_ci")
+}
+
+pub fn run_test(args: &[String], verbose: u8) -> Result<i32> {
+    if crate::core::runner::is_watch_mode(args) {
+        let mut passthrough: Vec<OsString> = vec![OsString::from("test")];
+        passthrough.extend(args.iter().map(OsString::from));
+        return run_passthrough(&passthrough, verbose);
+    }
+
+    let mut cmd = resolved_command("aube");
+    cmd.arg("test").args(args);
+    let display = format!("test {}", args.join(" "));
+    crate::core::runner::run_filtered(
+        cmd,
+        "aube",
+        display.trim_end(),
+        filter_aube_script,
+        crate::core::runner::RunOptions::with_tee("aube_test"),
+    )
+}
+
+/// `aubr` is the multicall shim for `aube run <script>`.
+pub fn run_aubr(args: &[String], verbose: u8) -> Result<i32> {
+    if crate::core::runner::is_watch_mode(args) {
+        let os_args: Vec<OsString> = std::iter::once(OsString::from("run"))
+            .chain(args.iter().map(OsString::from))
+            .collect();
+        return run_passthrough(&os_args, verbose);
+    }
+
+    let mut cmd = resolved_command("aube");
+    cmd.arg("run").args(args);
+    let display = format!("run {}", args.join(" "));
+    crate::core::runner::run_filtered(
+        cmd,
+        "aube",
+        display.trim_end(),
+        filter_aube_script,
+        crate::core::runner::RunOptions::with_tee("aube_run"),
+    )
+}
+
+/// `aubx` is the multicall shim for `aube dlx <tool>`.
+pub fn run_aubx(args: &[String], verbose: u8, skip_env: bool) -> Result<i32> {
+    if crate::core::runner::is_watch_mode(args) {
+        let passthrough: Vec<OsString> = args.iter().map(OsString::from).collect();
+        return crate::core::runner::run_passthrough("aubx", &passthrough, verbose);
+    }
+    super::npm_cmd::exec_with("aubx", args, verbose, skip_env)
+}
+
+pub fn run_passthrough(args: &[OsString], verbose: u8) -> Result<i32> {
+    crate::core::runner::run_passthrough("aube", args, verbose)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_filter_aube_script_strips_banner_and_echo() {
+        let raw = "Auto-installing: install state not found\naube 2.2.0 by jdx.dev · ✓ Already up to date\n$ node -e \"console.log(1)\"\n1\n";
+        let filtered = filter_aube_script(raw);
+        assert_eq!(filtered.trim(), "1");
+    }
+
+    #[test]
+    fn test_filter_aube_pkg_keeps_errors() {
+        let raw = "aube 2.2.0 by jdx.dev\nResolving dependencies\nERR_PNPM_SOMETHING went wrong\n";
+        let filtered = filter_aube_pkg(raw);
+        assert!(filtered.contains("ERR_PNPM"));
+    }
+}

--- a/src/cmds/js/lint_cmd.rs
+++ b/src/cmds/js/lint_cmd.rs
@@ -61,7 +61,7 @@ fn is_python_linter(linter: &str) -> bool {
 /// Strip package manager prefixes (npx, bunx, pnpm, pnpm exec, yarn) from args.
 /// Returns the number of args to skip.
 fn strip_pm_prefix(args: &[String]) -> usize {
-    let pm_names = ["npx", "bunx", "pnpm", "yarn"];
+    let pm_names = ["npx", "bunx", "aubx", "pnpm", "aube", "yarn"];
     let mut skip = 0;
     for arg in args {
         if pm_names.contains(&arg.as_str()) || arg == "exec" {

--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -385,7 +385,8 @@ pub fn count_tokens(text: &str) -> usize {
 /// ```no_run
 /// use rtk::utils::detect_package_manager;
 /// let pm = detect_package_manager();
-/// // "pnpm" for pnpm-lock.yaml, "yarn" for yarn.lock, "bun" for bun.lock(b), else "npm"
+/// // "aube" for aube-lock.yaml, "pnpm" for pnpm-lock.yaml, "yarn" for yarn.lock,
+/// // "bun" for bun.lock(b), else "npm"
 /// ```
 #[allow(dead_code)]
 pub fn detect_package_manager() -> &'static str {
@@ -395,7 +396,9 @@ pub fn detect_package_manager() -> &'static str {
 /// Lockfile detection against an explicit directory, so callers (and tests) do
 /// not have to move the process's current directory to ask the question.
 pub fn detect_package_manager_in(dir: &std::path::Path) -> &'static str {
-    if dir.join("pnpm-lock.yaml").exists() {
+    if dir.join("aube-lock.yaml").exists() {
+        "aube"
+    } else if dir.join("pnpm-lock.yaml").exists() {
         "pnpm"
     } else if dir.join("yarn.lock").exists() {
         "yarn"
@@ -459,6 +462,11 @@ pub fn tool_exec(runner: Option<&str>, tool: &str, missing: MissingTool) -> Comm
         match exec_runner(runner, missing) {
             "pnpm" => {
                 let mut c = resolved_command("pnpm");
+                c.arg("exec").arg("--").arg(tool);
+                c
+            }
+            "aube" => {
+                let mut c = resolved_command("aube");
                 c.arg("exec").arg("--").arg(tool);
                 c
             }
@@ -1006,7 +1014,7 @@ mod tests {
         // In the test environment (rtk repo), there's no JS lockfile
         // so it should default to "npm"
         let pm = detect_package_manager();
-        assert!(["pnpm", "yarn", "bun", "npm"].contains(&pm));
+        assert!(["aube", "pnpm", "yarn", "bun", "npm"].contains(&pm));
     }
 
     #[test]
@@ -1645,6 +1653,30 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         std::fs::write(dir.path().join("bun.lockb"), "").expect("write lockfile");
         assert_eq!(detect_package_manager_in(dir.path()), "bun");
+    }
+
+    #[test]
+    fn test_detect_package_manager_recognizes_aube() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("aube-lock.yaml"), "").expect("write lockfile");
+        assert_eq!(detect_package_manager_in(dir.path()), "aube");
+    }
+
+    #[test]
+    fn test_detect_package_manager_aube_before_pnpm() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("aube-lock.yaml"), "").expect("write aube lockfile");
+        std::fs::write(dir.path().join("pnpm-lock.yaml"), "").expect("write pnpm lockfile");
+        assert_eq!(detect_package_manager_in(dir.path()), "aube");
+    }
+
+    #[test]
+    fn test_tool_exec_aube_uses_exec() {
+        let args: Vec<String> = tool_exec(Some("aube"), "vitest", MissingTool::Fail)
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(args, ["exec", "--", "vitest"]);
     }
 
     #[test]

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -5300,6 +5300,49 @@ mod tests {
     }
 
     #[test]
+    fn test_rewrite_aube_command() {
+        for command in [
+            "install",
+            "i",
+            "ci",
+            "test",
+            "list",
+            "ls",
+            "run",
+            "run-script",
+            "exec",
+        ] {
+            assert_eq!(
+                rewrite_command_no_prefixes(format!("aube {command}").as_str(), &[]),
+                Some(format!("rtk aube {command}")),
+                "Failed for command: aube {}",
+                command
+            );
+        }
+    }
+
+    #[test]
+    fn test_rewrite_aubr_and_aubx() {
+        assert_eq!(
+            rewrite_command_no_prefixes("aubr test", &[]),
+            Some("rtk aubr test".into())
+        );
+        // aubx/aube exec route inner tools to specialized filters (like pnpm dlx)
+        assert_eq!(
+            rewrite_command_no_prefixes("aubx vitest", &[]),
+            Some("rtk vitest".into())
+        );
+        assert_eq!(
+            rewrite_command_no_prefixes("aube exec vitest", &[]),
+            Some("rtk vitest".into())
+        );
+        assert_eq!(
+            rewrite_command_no_prefixes("aubx tsc --noEmit", &[]),
+            Some("rtk tsc --noEmit".into())
+        );
+    }
+
+    #[test]
     fn test_rewrite_npm_bare_subcommand() {
         let commands = vec!["exec", "run", "run-script", "x"];
         for command in commands {

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -107,6 +107,35 @@ pub const RULES: &[RtkRule] = &[
         ..RtkRule::DEFAULT
     },
     RtkRule {
+        pattern: r"^aube\s+(ci|exec|i|install|list|ls|outdated|run|run-script|test|add|remove)\b",
+        rtk_cmd: "rtk aube",
+        rewrite_prefixes: &["aube"],
+        category: "PackageManager",
+        savings_pct: 80.0,
+        subcmd_savings: &[("test", 70.0), ("install", 70.0), ("list", 70.0), ("ls", 70.0)],
+        subcmd_status: &[
+            ("run", RtkStatus::Passthrough),
+            ("exec", RtkStatus::Passthrough),
+        ],
+        ..RtkRule::DEFAULT
+    },
+    RtkRule {
+        pattern: r"^aubr\s+",
+        rtk_cmd: "rtk aubr",
+        rewrite_prefixes: &["aubr"],
+        category: "PackageManager",
+        savings_pct: 70.0,
+        ..RtkRule::DEFAULT
+    },
+    RtkRule {
+        pattern: r"^aubx\s+",
+        rtk_cmd: "rtk aubx",
+        rewrite_prefixes: &["aubx"],
+        category: "PackageManager",
+        savings_pct: 70.0,
+        ..RtkRule::DEFAULT
+    },
+    RtkRule {
         pattern: r"^npm\s+(exec|run|run-script|rum|urn|x)(\s|$)",
         rtk_cmd: "rtk npm",
         rewrite_prefixes: &["npm"],
@@ -166,7 +195,7 @@ pub const RULES: &[RtkRule] = &[
         ..RtkRule::DEFAULT
     },
     RtkRule {
-        pattern: r"^((p?np(m|x)|p?npm\s+(exec|run|run-script)|npm\s+(rum|urn|x)|pnpm\s+dlx)\s+)?tsc(\s|$)",
+        pattern: r"^((p?np(m|x)|p?npm\s+(exec|run|run-script)|npm\s+(rum|urn|x)|pnpm\s+dlx|aube\s+(exec|dlx)|aubx)\s+)?tsc(\s|$)",
         rtk_cmd: "rtk tsc",
         rewrite_prefixes: &[
             "npm exec tsc",
@@ -178,7 +207,10 @@ pub const RULES: &[RtkRule] = &[
             "npm x tsc",
             "npx tsc",
             "pnpm dlx tsc",
+            "aube dlx tsc",
             "pnpm exec tsc",
+            "aubx tsc",
+            "aube exec tsc",
             "pnpm run tsc",
             "pnpm run-script tsc",
             "pnpm tsc",
@@ -190,7 +222,7 @@ pub const RULES: &[RtkRule] = &[
         ..RtkRule::DEFAULT
     },
     RtkRule {
-        pattern: r"^((p?np(m|x)|p?npm\s+(exec|run|run-script)|npm\s+(rum|urn|x)|pnpm\s+dlx)\s+)?(biome|eslint|lint)(\s|$)",
+        pattern: r"^((p?np(m|x)|p?npm\s+(exec|run|run-script)|npm\s+(rum|urn|x)|pnpm\s+dlx|aube\s+(exec|dlx)|aubx)\s+)?(biome|eslint|lint)(\s|$)",
         rtk_cmd: "rtk lint",
         pipeline_safety: PipelineSafety::ProducerOnly,
         rewrite_prefixes: &[
@@ -221,10 +253,16 @@ pub const RULES: &[RtkRule] = &[
             "npx lint",
             "pnpm biome",
             "pnpm dlx biome",
+            "aube dlx biome",
             "pnpm dlx eslint",
+            "aube dlx eslint",
             "pnpm eslint",
             "pnpm exec biome",
+            "aubx biome",
+            "aube exec biome",
             "pnpm exec eslint",
+            "aubx eslint",
+            "aube exec eslint",
             "pnpm lint",
             "pnpm run biome",
             "pnpm run eslint",
@@ -241,7 +279,7 @@ pub const RULES: &[RtkRule] = &[
         ..RtkRule::DEFAULT
     },
     RtkRule {
-        pattern: r"^((p?np(m|x)|p?npm\s+(exec|run|run-script)|npm\s+(rum|urn|x)|pnpm\s+dlx)\s+)?prettier",
+        pattern: r"^((p?np(m|x)|p?npm\s+(exec|run|run-script)|npm\s+(rum|urn|x)|pnpm\s+dlx|aube\s+(exec|dlx)|aubx)\s+)?prettier",
         rtk_cmd: "rtk prettier",
         pipeline_safety: PipelineSafety::ProducerOnly,
         rewrite_prefixes: &[
@@ -254,7 +292,10 @@ pub const RULES: &[RtkRule] = &[
             "npm x prettier",
             "npx prettier",
             "pnpm dlx prettier",
+            "aube dlx prettier",
             "pnpm exec prettier",
+            "aubx prettier",
+            "aube exec prettier",
             "pnpm prettier",
             "pnpm run prettier",
             "pnpm run-script prettier",
@@ -266,7 +307,7 @@ pub const RULES: &[RtkRule] = &[
         ..RtkRule::DEFAULT
     },
     RtkRule {
-        pattern: r"^((p?np(m|x)|p?npm\s+(exec|run|run-script)|npm\s+(rum|urn|x)|pnpm\s+dlx)\s+)?next\s+build",
+        pattern: r"^((p?np(m|x)|p?npm\s+(exec|run|run-script)|npm\s+(rum|urn|x)|pnpm\s+dlx|aube\s+(exec|dlx)|aubx)\s+)?next\s+build",
         rtk_cmd: "rtk next",
         pipeline_safety: PipelineSafety::ProducerOnly,
         rewrite_prefixes: &[
@@ -280,7 +321,10 @@ pub const RULES: &[RtkRule] = &[
             "npm x next build",
             "npx next build",
             "pnpm dlx next build",
+            "aube dlx next build",
             "pnpm exec next build",
+            "aubx next build",
+            "aube exec next build",
             "pnpm next build",
             "pnpm run next build",
             "pnpm run-script next build",
@@ -291,7 +335,7 @@ pub const RULES: &[RtkRule] = &[
         ..RtkRule::DEFAULT
     },
     RtkRule {
-        pattern: r"^((p?np(m|x)|p?npm\s+(exec|run|run-script)|npm\s+(rum|urn|x)|pnpm\s+dlx)\s+)?jest(\s+run)?(\s|$)",
+        pattern: r"^((p?np(m|x)|p?npm\s+(exec|run|run-script)|npm\s+(rum|urn|x)|pnpm\s+dlx|aube\s+(exec|dlx)|aubx)\s+)?jest(\s+run)?(\s|$)",
         rtk_cmd: "rtk jest",
         rewrite_prefixes: &[
             "jest run",
@@ -313,9 +357,15 @@ pub const RULES: &[RtkRule] = &[
             "npx jest run",
             "npx jest",
             "pnpm dlx jest run",
+            "aube dlx jest run",
             "pnpm dlx jest",
+            "aube dlx jest",
             "pnpm exec jest run",
+            "aubx jest run",
+            "aube exec jest run",
             "pnpm exec jest",
+            "aubx jest",
+            "aube exec jest",
             "pnpm jest run",
             "pnpm jest",
             "pnpm run jest run",
@@ -330,7 +380,7 @@ pub const RULES: &[RtkRule] = &[
         ..RtkRule::DEFAULT
     },
     RtkRule {
-        pattern: r"^((p?np(m|x)|p?npm\s+(exec|run|run-script)|npm\s+(rum|urn|x)|pnpm\s+dlx)\s+)?vitest(\s+run)?(\s|$)",
+        pattern: r"^((p?np(m|x)|p?npm\s+(exec|run|run-script)|npm\s+(rum|urn|x)|pnpm\s+dlx|aube\s+(exec|dlx)|aubx)\s+)?vitest(\s+run)?(\s|$)",
         rtk_cmd: "rtk vitest",
         rewrite_prefixes: &[
             "npm exec vitest run",
@@ -350,9 +400,15 @@ pub const RULES: &[RtkRule] = &[
             "npx vitest run",
             "npx vitest",
             "pnpm dlx vitest run",
+            "aube dlx vitest run",
             "pnpm dlx vitest",
+            "aube dlx vitest",
             "pnpm exec vitest run",
+            "aubx vitest run",
+            "aube exec vitest run",
             "pnpm exec vitest",
+            "aubx vitest",
+            "aube exec vitest",
             "pnpm run vitest run",
             "pnpm run vitest",
             "pnpm run-script vitest run",
@@ -377,7 +433,7 @@ pub const RULES: &[RtkRule] = &[
         ..RtkRule::DEFAULT
     },
     RtkRule {
-        pattern: r"^((p?np(m|x)|p?npm\s+(exec|run|run-script)|npm\s+(rum|urn|x)|pnpm\s+dlx)\s+)?playwright",
+        pattern: r"^((p?np(m|x)|p?npm\s+(exec|run|run-script)|npm\s+(rum|urn|x)|pnpm\s+dlx|aube\s+(exec|dlx)|aubx)\s+)?playwright",
         rtk_cmd: "rtk playwright",
         rewrite_prefixes: &[
             "npm exec playwright",
@@ -390,7 +446,10 @@ pub const RULES: &[RtkRule] = &[
             "npx playwright",
             "playwright",
             "pnpm dlx playwright",
+            "aube dlx playwright",
             "pnpm exec playwright",
+            "aubx playwright",
+            "aube exec playwright",
             "pnpm playwright",
             "pnpm run playwright",
             "pnpm run-script playwright",
@@ -401,7 +460,7 @@ pub const RULES: &[RtkRule] = &[
         ..RtkRule::DEFAULT
     },
     RtkRule {
-        pattern: r"^((p?np(m|x)|p?npm\s+(exec|run|run-script)|npm\s+(rum|urn|x)|pnpm\s+dlx)\s+)?prisma",
+        pattern: r"^((p?np(m|x)|p?npm\s+(exec|run|run-script)|npm\s+(rum|urn|x)|pnpm\s+dlx|aube\s+(exec|dlx)|aubx)\s+)?prisma",
         rtk_cmd: "rtk prisma",
         rewrite_prefixes: &[
             "npm exec prisma",
@@ -413,7 +472,10 @@ pub const RULES: &[RtkRule] = &[
             "npm x prisma",
             "npx prisma",
             "pnpm dlx prisma",
+            "aube dlx prisma",
             "pnpm exec prisma",
+            "aubx prisma",
+            "aube exec prisma",
             "pnpm prisma",
             "pnpm run prisma",
             "pnpm run-script prisma",

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use cmds::dotnet::{binlog, dotnet_cmd, dotnet_format_report, dotnet_trx};
 use cmds::git::{diff_cmd, gh_cmd, git, glab_cmd, gt_cmd};
 use cmds::go::{go_cmd, golangci_cmd};
 use cmds::js::{
-    bun_cmd, deno_cmd, lint_cmd, next_cmd, npm_cmd, playwright_cmd, pnpm_cmd, prettier_cmd,
+    aube_cmd, bun_cmd, deno_cmd, lint_cmd, next_cmd, npm_cmd, playwright_cmd, pnpm_cmd, prettier_cmd,
     prisma_cmd, tsc_cmd, vitest_cmd,
 };
 use cmds::jvm::{gradlew_cmd, mvn_cmd};
@@ -609,6 +609,24 @@ enum Commands {
     /// bunx with passthrough + auto-filter
     Bunx {
         /// bunx arguments
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+
+    /// aube package manager commands with compact output
+    Aube {
+        #[command(subcommand)]
+        command: AubeCommands,
+    },
+
+    /// aubr shim (`aube run`) with passthrough
+    Aubr {
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+
+    /// aubx shim (`aube dlx`) with passthrough + auto-filter
+    Aubx {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
@@ -1446,6 +1464,28 @@ enum BunPmCommands {
 }
 
 #[derive(Debug, Subcommand)]
+enum AubeCommands {
+    /// Install dependencies (filter progress noise)
+    Install {
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+    /// Clean install with frozen lockfile
+    Ci {
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+    /// Run the test script with compact output
+    Test {
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+    /// Passthrough: runs any unsupported aube subcommand directly
+    #[command(external_subcommand)]
+    Other(Vec<OsString>),
+}
+
+#[derive(Debug, Subcommand)]
 enum DenoCommands {
     /// Run a script
     Run {
@@ -1497,6 +1537,18 @@ fn run_bunx_tool(args: &[String], verbose: u8, skip_env: bool) -> Result<i32> {
         "tsc" | "typescript" => tsc_cmd::run(Some("bunx"), &args[1..], verbose),
         "eslint" => lint_cmd::run(Some("bunx"), args, verbose),
         _ => bun_cmd::run_bunx(args, verbose, skip_env),
+    }
+}
+
+/// Route `aubx <tool>` to the matching tool filter, like bunx/npx.
+fn run_aubx_tool(args: &[String], verbose: u8, skip_env: bool) -> Result<i32> {
+    if args.is_empty() {
+        anyhow::bail!("aubx requires a command argument");
+    }
+    match args[0].as_str() {
+        "tsc" | "typescript" => tsc_cmd::run(Some("aubx"), &args[1..], verbose),
+        "eslint" => lint_cmd::run(Some("aubx"), args, verbose),
+        _ => aube_cmd::run_aubx(args, verbose, skip_env),
     }
 }
 
@@ -2562,6 +2614,17 @@ fn run_cli() -> Result<i32> {
         },
 
         Commands::Bunx { args } => run_bunx_tool(&args, cli.verbose, cli.skip_env)?,
+
+        Commands::Aube { command } => match command {
+            AubeCommands::Install { args } => aube_cmd::run_install(&args, cli.verbose)?,
+            AubeCommands::Ci { args } => aube_cmd::run_ci(&args, cli.verbose)?,
+            AubeCommands::Test { args } => aube_cmd::run_test(&args, cli.verbose)?,
+            AubeCommands::Other(args) => aube_cmd::run_passthrough(&args, cli.verbose)?,
+        },
+
+        Commands::Aubr { args } => aube_cmd::run_aubr(&args, cli.verbose)?,
+
+        Commands::Aubx { args } => run_aubx_tool(&args, cli.verbose, cli.skip_env)?,
 
         Commands::Deno { command } => match command {
             DenoCommands::Test { args } => deno_cmd::run_test(&args, cli.verbose)?,


### PR DESCRIPTION
## Summary

Adds native support for [aube](https://github.com/jdx/aube) — a Rust, pnpm-compatible package manager — and its multicall shims `aubr` (`aube run`) and `aubx` (`aube dlx`).

Mirrors the existing pnpm/bun/bunx integration pattern:

| Command | Rewrite | Filter |
|---------|---------|--------|
| `aube install` / `aube test` | `rtk aube …` | PM noise (banners, progress, `$ cmd` echo) |
| `aubr lint` / `aubr build` | `rtk aubr …` | Same script-runner filter as `aube test` |
| `aubx vitest` / `aube exec vitest` | `rtk vitest` | Specialized vitest filter |
| `aubx tsc --noEmit` | `rtk tsc --noEmit` | Specialized tsc filter |

## Changes

- **`src/cmds/js/aube_cmd.rs`** (new): filters for `install`/`ci`/`test`; `aubr` → `aube run`; `aubx` → `aube dlx`
- **`src/main.rs`**: `rtk aube`, `rtk aubr`, `rtk aubx` CLI commands; `run_aubx_tool` routes tsc/eslint to specialized filters
- **`src/discover/rules.rs`**: rewrite rules + `aube exec`/`aube dlx`/`aubx` prefixes on tsc, vitest, eslint, prettier, playwright, prisma, jest
- **`src/discover/registry.rs`**: unit tests for rewrites
- **`src/core/utils.rs`**: recognize `aube-lock.yaml` in `detect_package_manager_in`; `tool_exec` arm for `aube exec --`
- **`src/cmds/js/lint_cmd.rs`**: recognize `aube`/`aubx` as PM prefixes

## Test plan

- [x] `cargo test test_rewrite_aube_command` — 12 aube subcommand rewrites
- [x] `cargo test test_rewrite_aubr` — aubr + aubx/aube exec tool routing
- [x] `cargo test test_filter_aube` — install/test output filters
- [x] `cargo test test_detect_package_manager_recognizes_aube` — lockfile detection
- [x] `cargo test test_tool_exec_aube_uses_exec` — `aube exec --` argv
- [x] Manual: `rtk rewrite 'aube test'` → `rtk aube test`
- [x] Manual: `rtk rewrite 'aubx vitest'` → `rtk vitest`
- [x] Manual: `rtk aubr test` strips `$ node …` echo lines
- [x] Manual: `aubr lint` / `aubr fmt:check` in real repos (k8s, spec, auricle)

## Notes

- **`aube test` vs `aubx vitest`**: `aube test` runs the project's `scripts.test` via the PM filter (same tier as `pnpm run test`). For vitest-specific compression, use `aubx vitest` or `aube exec vitest` — identical to how `pnpm dlx vitest` routes to `rtk vitest`.
- **`aube-lock.yaml`**: checked before `pnpm-lock.yaml` so repos with both locks resolve to aube.
- No default `transparent_prefixes` added — users who need wrapper prefixes configure them in `config.toml`.

Fixes #3993

