### PR TITLE
fix(parser): preserve CRLF byte offsets during JSON extraction

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -150,19 +150,15 @@ pub fn extract_json_object(input: &str) -> Option<&str> {
     } else {
         // Fallback: find first `{` on its own line or after whitespace
         let mut found_start = None;
-        for (idx, line) in input.lines().enumerate() {
-            let trimmed = line.trim();
+        let mut line_start = 0;
+        // Keep line terminators so offsets remain exact for LF, CRLF, or a mix.
+        for line in input.split_inclusive('\n') {
+            let trimmed = line.trim_start();
             if trimmed.starts_with('{') {
-                // Calculate byte offset
-                found_start = Some(
-                    input[..]
-                        .lines()
-                        .take(idx)
-                        .map(|l| l.len() + 1)
-                        .sum::<usize>(),
-                );
+                found_start = Some(line_start + line.len() - trimmed.len());
                 break;
             }
+            line_start += line.len();
         }
         found_start?
     };
@@ -348,5 +344,50 @@ Scope: all 6 workspace projects
         let extracted =
             extract_json_object(input).expect("Should extract nested JSON with mixed multibyte");
         assert_eq!(extracted, input);
+    }
+
+    #[test]
+    fn test_extract_json_object_crlf_multibyte_prefix() {
+        let input = "ligne un\r\n ligne deux\r\n fin é\r\n{\"a\": 1}\r\n";
+        assert_eq!(extract_json_object(input), Some(r#"{"a": 1}"#));
+    }
+
+    #[test]
+    fn test_extract_json_object_line_endings_and_unicode() {
+        let objects = [
+            r#"{"a": 1}"#,
+            r#"{"message": "café 中文 🚀 {\"quoted\"}", "nested": {"ok": true}}"#,
+            r#"{"numTotalTests": 1, "message": "café 中文 🚀", "nested": {"ok": true}}"#,
+        ];
+        for (first_eol, second_eol) in [("\n", "\n"), ("\r\n", "\r\n"), ("\r\n", "\n")] {
+            for prefix in ["", "build output", "café 中文 🚀"] {
+                for indent in ["", " \t", "\u{2003}"] {
+                    for object in objects {
+                        for suffix in ["", "\r\ntrailing 中文 🚀 output"] {
+                            let input = format!(
+                                "{prefix}{first_eol}warning{second_eol}{indent}{object}{suffix}"
+                            );
+                            let extracted =
+                                extract_json_object(&input).expect("Should extract JSON");
+                            assert_eq!(extracted, object, "input: {input:?}");
+                            let parsed: serde_json::Value = serde_json::from_str(extracted)
+                                .expect("Extracted JSON must be valid");
+                            assert!(parsed.is_object());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_extract_json_object_incomplete_crlf_fallback() {
+        for input in [
+            "café\r\n中文\r\nno object here 🚀",
+            "café\r\n中文\r\n  {\"nested\": {\"ok\": true}",
+            "café\r\n中文\r\n  {\"message\": \"unterminated 🚀",
+        ] {
+            assert_eq!(extract_json_object(input), None, "input: {input:?}");
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Fix `extract_json_object` fallback offsets on CRLF and mixed line endings by retaining the actual line terminators; skip indentation so the returned slice begins at `{`.
- Cover the reported multibyte-prefix panic, exact JSON extraction across line endings/Unicode/indentation/marker variants, and incomplete objects.

Fixes #3903. The marker-path regression coverage in #2533 is separate from this fallback-path fix.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets`
- [x] `cargo test --all` — 3572 passed, 8 ignored.
- [x] `cargo test --all -- --ignored --test-threads=1` — all 8 additional tests passed.
- [x] Red/green check: the new CRLF/Unicode regression panics before the production fix; all 18 parser tests pass afterward.
- [x] Manual `rtk vitest` check with a failing shim emitting CRLF and an accented path: original diagnostics remain visible and exit status remains 1, with no panic.
- [x] Focused hyperfine comparison of the actual before/after extraction functions (20,000 calls with a 100-line LF prefix, 15 runs): 54.7 ms before / 21.2 ms after. This measures parser throughput, not whole-command startup.

Validated on macOS arm64 with Rust 1.98.0. The full suite required normal filesystem access for existing initialization tests that write RTK's application-support directory.
