### PR TITLE
fix(go): preserve explicitly requested verbose test output

### DIFF
--- a/src/cmds/go/README.md
+++ b/src/cmds/go/README.md
@@ -6,4 +6,5 @@
 
 - `go_cmd.rs` uses `GoCommands` sub-enum in main.rs (same pattern as git/cargo)
 - `go test` outputs NDJSON (`-json` flag injected by RTK) -- parsed line-by-line as streaming events
+- Explicit Go test verbosity (`-v` or `-test.v`, including `=true` forms) passes through the original output and exit code. `-v=false` keeps the default compression; flags after `-args` or `--` belong to the test binary.
 - `golangci_cmd.rs` forces `--out-format=json` for structured parsing

--- a/src/cmds/go/go_cmd.rs
+++ b/src/cmds/go/go_cmd.rs
@@ -45,11 +45,88 @@ struct PackageResult {
     package_fail_output: Vec<String>,         // output lines collected before the package fail
 }
 
+fn go_test_verbose_requested(args: &[String]) -> bool {
+    let mut verbose = false;
+    let mut args = args.iter();
+    // Go stops interpreting its own flags at -args/--. Repeated boolean flags
+    // use the last value, including aliases such as -test.v and --v.
+    while let Some(arg) = args.next() {
+        if matches!(arg.as_str(), "-args" | "--args" | "--") {
+            break;
+        }
+        let Some(flag) = arg.strip_prefix("--").or_else(|| arg.strip_prefix('-')) else {
+            continue;
+        };
+        let (name, value) = flag.split_once('=').unwrap_or((flag, "true"));
+        if matches!(name, "v" | "test.v") {
+            verbose = !matches!(value, "0" | "f" | "F" | "false" | "False" | "FALSE");
+        } else if !flag.contains('=') && go_test_flag_takes_value(name) {
+            args.next();
+        }
+    }
+    verbose
+}
+
+fn go_test_flag_takes_value(name: &str) -> bool {
+    // Test selectors, output paths and build flag values may themselves look
+    // like -v or -args. Consume them before interpreting verbosity flags.
+    matches!(
+        name.strip_prefix("test.").unwrap_or(name),
+        "C" | "o"
+            | "exec"
+            | "vet"
+            | "bench"
+            | "benchtime"
+            | "blockprofile"
+            | "blockprofilerate"
+            | "count"
+            | "cpu"
+            | "cpuprofile"
+            | "fuzz"
+            | "fuzztime"
+            | "fuzzminimizetime"
+            | "list"
+            | "memprofile"
+            | "memprofilerate"
+            | "mutexprofile"
+            | "mutexprofilefraction"
+            | "outputdir"
+            | "parallel"
+            | "run"
+            | "shuffle"
+            | "skip"
+            | "timeout"
+            | "trace"
+            | "covermode"
+            | "coverpkg"
+            | "coverprofile"
+            | "p"
+            | "asmflags"
+            | "buildmode"
+            | "compiler"
+            | "gccgoflags"
+            | "gcflags"
+            | "installsuffix"
+            | "ldflags"
+            | "mod"
+            | "modfile"
+            | "overlay"
+            | "pgo"
+            | "pkgdir"
+            | "tags"
+            | "toolexec"
+            | "debug-actiongraph"
+            | "debug-runtime-trace"
+            | "debug-trace"
+    )
+}
+
 pub fn run_test(args: &[String], verbose: u8) -> Result<i32> {
     let mut cmd = resolved_command("go");
     cmd.arg("test");
 
-    let skip_json = args.iter().any(|a| a == "-json" || a.starts_with("-bench"));
+    let passthrough = go_test_verbose_requested(args);
+    let skip_json = passthrough || args.iter().any(|a| a == "-json" || a.starts_with("-bench"));
 
     if !skip_json {
         cmd.arg("-json");
@@ -64,6 +141,16 @@ pub fn run_test(args: &[String], verbose: u8) -> Result<i32> {
             "Running: go test {}{}",
             if !skip_json { "-json " } else { "" },
             args.join(" ")
+        );
+    }
+
+    if passthrough {
+        return runner::run(
+            cmd,
+            "go test",
+            &args.join(" "),
+            runner::RunMode::Passthrough,
+            runner::RunOptions::default(),
         );
     }
 
@@ -738,6 +825,47 @@ fn compact_package_name(package: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_go_test_verbose_flag_forms() {
+        for prefix in ["-v", "--v", "-test.v", "--test.v"] {
+            for value in ["", "=1", "=t", "=T", "=true", "=True", "=TRUE", "=test2json"] {
+                let args = vec!["./...".to_string(), format!("{prefix}{value}")];
+                assert!(go_test_verbose_requested(&args), "args: {args:?}");
+            }
+            for value in ["0", "f", "F", "false", "False", "FALSE"] {
+                let args = vec!["-v".to_string(), format!("{prefix}={value}")];
+                assert!(!go_test_verbose_requested(&args), "args: {args:?}");
+            }
+        }
+    }
+
+    #[test]
+    fn test_go_test_verbose_flag_scope() {
+        let cases: &[(&[&str], bool)] = &[
+            (&[], false),
+            (&["./...", "-run", "TestPass"], false),
+            (&["-v=false", "-test.v"], true),
+            (&["--test.v", "--v=0"], false),
+            (&["-args", "-v"], false),
+            (&["--args", "-test.v"], false),
+            (&["--", "-v"], false),
+            (&["-v", "-args", "-v=false"], true),
+            (&["-v", "--", "-test.v=false"], true),
+            (&["-run=-v", "-vmodule=2", "-verbose"], false),
+            (&["-run", "-v"], false),
+            (&["-v", "-o", "-v=false"], true),
+            (&["-v", "-test.run", "-v=false"], true),
+            (&["-v", "-coverprofile", "-v=false"], true),
+            (&["-run", "-args", "-v"], true),
+            (&["-race", "-v"], true),
+            (&["-v", "-race", "-test.v=false"], false),
+        ];
+        for (args, expected) in cases {
+            let args: Vec<_> = args.iter().map(|arg| arg.to_string()).collect();
+            assert_eq!(go_test_verbose_requested(&args), *expected, "args: {args:?}");
+        }
+    }
 
     #[test]
     fn test_filter_go_test_all_pass() {

--- a/tests/go_test_verbose_test.rs
+++ b/tests/go_test_verbose_test.rs
@@ -1,0 +1,112 @@
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::process::{Command, Output};
+
+const STDOUT: &str = "=== RUN   TestPass\n    pass_test.go:4: PASS_MARKER\n--- PASS: TestPass (0.00s)\nPASS\nok\texample.com/probe\t0.001s\n";
+const STDERR: &str = "test stderr marker\n";
+
+struct GoShim {
+    dir: tempfile::TempDir,
+}
+
+impl GoShim {
+    fn new() -> Self {
+        let dir = tempfile::tempdir().expect("temporary directory");
+        let shim = dir.path().join("go");
+        fs::write(
+            &shim,
+            r#"#!/bin/sh
+printf '%s\n' "$@" > "$RTK_TEST_ARGV"
+for arg do
+    if [ "$arg" = '-json' ]; then
+        printf '%s\n' '{"Action":"output","Package":"example.com/probe","Test":"TestPass","Output":"PASS_MARKER\n"}'
+        printf '%s\n' '{"Action":"pass","Package":"example.com/probe","Test":"TestPass","Elapsed":0.001}'
+        printf '%s\n' '{"Action":"pass","Package":"example.com/probe","Elapsed":0.001}'
+        exit "${RTK_TEST_EXIT:-0}"
+    fi
+done
+printf '=== RUN   TestPass\n    pass_test.go:4: PASS_MARKER\n--- PASS: TestPass (0.00s)\nPASS\nok\texample.com/probe\t0.001s\n'
+printf 'test stderr marker\n' >&2
+exit "${RTK_TEST_EXIT:-0}"
+"#,
+        )
+        .expect("write Go shim");
+        fs::set_permissions(&shim, fs::Permissions::from_mode(0o755)).expect("executable shim");
+        Self { dir }
+    }
+
+    fn run(&self, args: &[&str], exit_code: i32) -> Output {
+        let mut paths = vec![self.dir.path().to_path_buf()];
+        paths.extend(std::env::split_paths(
+            &std::env::var_os("PATH").unwrap_or_default(),
+        ));
+        Command::new(env!("CARGO_BIN_EXE_rtk"))
+            .args(["go", "test"])
+            .args(args)
+            .current_dir(self.dir.path())
+            .env("PATH", std::env::join_paths(paths).expect("shim PATH"))
+            .env("RTK_DB_PATH", self.dir.path().join("tracking.db"))
+            .env("RTK_RECALL", "0")
+            .env("RTK_TEST_ARGV", self.dir.path().join("argv"))
+            .env("RTK_TEST_EXIT", exit_code.to_string())
+            .output()
+            .expect("run rtk go test")
+    }
+
+    fn argv(&self) -> Vec<String> {
+        fs::read_to_string(self.dir.path().join("argv"))
+            .expect("recorded argv")
+            .lines()
+            .map(str::to_string)
+            .collect()
+    }
+}
+
+#[test]
+fn explicit_go_test_verbosity_preserves_output_and_exit_status() {
+    let shim = GoShim::new();
+    for args in [
+        vec!["-v", "./..."],
+        vec!["./...", "-test.v"],
+        vec!["-v=true"],
+        vec!["--test.v=1"],
+        vec!["-v=false", "-v"],
+        vec!["-v", "-o", "-v=false"],
+        vec!["-v", "-run", "TestPass", "-args", "custom value"],
+    ] {
+        for exit_code in [0, 1] {
+            let output = shim.run(&args, exit_code);
+            assert_eq!(output.status.code(), Some(exit_code), "args: {args:?}");
+            assert_eq!(output.stdout, STDOUT.as_bytes(), "args: {args:?}");
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            assert!(stderr.contains(STDERR), "args: {args:?}, stderr: {stderr}");
+            let expected: Vec<_> = std::iter::once("test")
+                .chain(args.iter().copied())
+                .map(str::to_string)
+                .collect();
+            assert_eq!(shim.argv(), expected);
+        }
+    }
+}
+
+#[test]
+fn default_and_disabled_verbosity_keep_go_test_compression() {
+    let shim = GoShim::new();
+    for args in [
+        vec!["./..."],
+        vec!["-v=false"],
+        vec!["-v", "-test.v=0"],
+        vec!["-run", "-v"],
+        vec!["-args", "-v"],
+        vec!["./...", "--", "-v"],
+    ] {
+        let output = shim.run(&args, 0);
+        assert!(output.status.success(), "args: {args:?}");
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(stdout.contains("1 passed"), "args: {args:?}: {stdout}");
+        assert!(!stdout.contains("PASS_MARKER"), "args: {args:?}");
+        assert_eq!(&shim.argv()[..2], ["test", "-json"]);
+    }
+}


### PR DESCRIPTION
## Summary

- Preserve passing-test logs and stderr when `go test` explicitly requests verbosity (`-v`, `-test.v`, their double-dash aliases and boolean values), using the existing passthrough runner without injecting `-json`.
- Honor repeated verbosity flags, test argument boundaries and value-taking flags so a selector or output path such as `-v=false` is not mistaken for a verbosity switch. Document the behavior.
- Add portable flag-policy unit tests and Unix subprocess regressions covering original argv, stdout, stderr, exit status and default compression.

Fixes #3985.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets`
- [x] `cargo test --all` — 3573 passed, 8 ignored.
- [x] `cargo test --all -- --ignored --test-threads=1` — all 8 additional tests passed.
- [x] Red/green check: the new subprocess regression originally received only `Go test: 1 passed in 1 packages`; the final version preserves the passing-test marker and original stdout exactly, along with stderr and exit codes 0/1.
- [x] Manual testing: 18 comparisons against real `go test` covering verbose/quiet flag forms, pass/fail runs and flag-like `-o`/`-coverprofile` values. Exit codes and the required diagnostics match.
- [x] Default compression comparison with captured real Go NDJSON: before/after output is identical; 1945 raw bytes become 32 bytes (98.35% reduction against the JSON input).
- [x] Hyperfine, unchanged default mode replaying that fixture, 15 runs: 11.8 ms before / 11.4 ms after with debug binaries. This is a regression check, not a release-startup claim.

Validated locally on macOS arm64 with Rust 1.98.0. Flag-policy unit tests are platform-independent; subprocess shim tests use `cfg(unix)`. Windows and Linux coverage remains with the repository CI.
